### PR TITLE
Fix  "Apple's coremltools"  in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Encoder-decoder models such as T5 and Flan are currently _not supported_. They a
 ## Other Tools
 
 - [`swift-chat`](https://github.com/huggingface/swift-chat), a simple app demonstrating how to use this package.
-- [`exporters`](https://github.com/huggingface/exporters), a Core ML conversion package for transformers models, based on Apple`s [`coremltools`](https://github.com/apple/coremltools).
+- [`exporters`](https://github.com/huggingface/exporters), a Core ML conversion package for transformers models, based on Apple's [`coremltools`](https://github.com/apple/coremltools).
 - [`transformers-to-coreml`](https://huggingface.co/spaces/coreml-projects/transformers-to-coreml), a no-code Core ML conversion tool built on `exporters`.
 
 ## <a name="roadmap"></a> Roadmap / To Do


### PR DESCRIPTION
Before:

![image](https://github.com/huggingface/swift-transformers/assets/17675462/3a2669cf-e5c9-4c3a-b75c-0af680b3a245)

After:

![image](https://github.com/huggingface/swift-transformers/assets/17675462/e5a06852-6b03-4bb9-8d12-d21986bf218d)

@pcuenca Thanks!