### PR TITLE
Support `.mlmodelc` in CLI

### DIFF
--- a/Sources/TransformersCLI/main.swift
+++ b/Sources/TransformersCLI/main.swift
@@ -54,10 +54,15 @@ struct TransformersCLI: ParsableCommand {
         semaphore.wait()
     }
     
+    func compile(at url: URL) throws -> URL {
+        if url.pathExtension == "mlmodelc" { return url }
+        print("Compiling model \(url)")
+        return try MLModel.compileModel(at: url)
+    }
+    
     func run() throws {
         let url = URL(filePath: modelPath)
-        print("Compiling model \(url)")
-        let compiledURL = try MLModel.compileModel(at: url)
+        let compiledURL = try compile(at: url)
         print("Loading model \(compiledURL)")
         let model = try LanguageModel.loadCompiled(url: compiledURL, computeUnits: computeUnits.asMLComputeUnits)
         


### PR DESCRIPTION
This allows caching of models specialized for the current hardware. When using `.mlpackage`, the model is first compiled to `.mlmodelc` (fast), and then the `.mlmodelc` is specialized for the current hardware. In the first case, the specialized version is cached; in the second it is discarded.

See https://apple.github.io/coremltools/docs-guides/source/model-prediction.html#why-use-a-compiled-model