### PR TITLE
Simulator flag for background urlsessions 

### DIFF
--- a/Sources/Hub/Downloader.swift
+++ b/Sources/Hub/Downloader.swift
@@ -34,7 +34,11 @@ class Downloader: NSObject, ObservableObject {
         super.init()
         
         let config = URLSessionConfiguration.background(withIdentifier: url.path)
+#if targetEnvironment(simulator)
+        urlSession = URLSession(configuration: .default, delegate: self, delegateQueue: OperationQueue())
+#else
         urlSession = URLSession(configuration: config, delegate: self, delegateQueue: OperationQueue())
+#endif
         downloadState.value = .downloading(0)
         urlSession?.getAllTasks { tasks in
             // If there's an existing pending background task with the same URL, let it proceed.


### PR DESCRIPTION
Background url sessions require entitlements to run properly, this allows simulators and in particular CI machines to run the code without entitlements by using default configs instead of background.