### PR TITLE
Fixed LogitsProcessor

### DIFF
--- a/Sources/TensorUtils/LogitsWarper/LogitsProcessor.swift
+++ b/Sources/TensorUtils/LogitsWarper/LogitsProcessor.swift
@@ -11,7 +11,7 @@ public struct LogitsProcessor {
         var indexes = Array(arr.indices)
         var logits = arr
         for warper in logitsWarpers {
-            (indexes, logits) = warper(logits)
+            (indexes, logits) = warper(indexes, logits)
         }
         return (indexes: indexes, logits: logits)
     }

--- a/Sources/TensorUtils/LogitsWarper/LogitsWarper.swift
+++ b/Sources/TensorUtils/LogitsWarper/LogitsWarper.swift
@@ -2,12 +2,12 @@ import Foundation
 
 /// Protocol for all logit warpers that can be applied during generation
 public protocol LogitsWarper {
-    func warp(_ arr: [Float]) -> (indexes: [Int], logits: [Float])
-    func callAsFunction(_ arr: [Float]) -> (indexes: [Int], logits: [Float])
+    func warp(indexes: [Int], logits: [Float]) -> (indexes: [Int], logits: [Float])
+    func callAsFunction(_ indexes: [Int], _ logits: [Float]) -> (indexes: [Int], logits: [Float])
 }
 
 extension LogitsWarper {
-    public func callAsFunction(_ arr: [Float]) -> (indexes: [Int], logits: [Float]) {
-        warp(arr)
+    public func callAsFunction(_ indexes: [Int], _ logits: [Float]) -> (indexes: [Int], logits: [Float]) {
+        warp(indexes: indexes, logits: logits)
     }
 }

--- a/Sources/TensorUtils/LogitsWarper/TemperatureLogitsWarper.swift
+++ b/Sources/TensorUtils/LogitsWarper/TemperatureLogitsWarper.swift
@@ -7,8 +7,7 @@ public struct TemperatureLogitsWarper: LogitsWarper {
         self.temperature = temperature
     }
 
-    public func warp(_ arr: [Float]) -> (indexes: [Int], logits: [Float]) {
-        let logits = arr.map { $0 / temperature }
-        return (indexes: Array(logits.indices), logits: logits)
+    public func warp(indexes: [Int], logits: [Float]) -> (indexes: [Int], logits: [Float]) {
+        return (indexes: indexes, logits: logits.map { $0 / temperature })
     }
 }

--- a/Sources/TensorUtils/LogitsWarper/TopPLogitsWarper.swift
+++ b/Sources/TensorUtils/LogitsWarper/TopPLogitsWarper.swift
@@ -10,15 +10,15 @@ public struct TopPLogitsWarper: LogitsWarper {
         self.p = p
     }
 
-    public func warp(_ arr: [Float]) -> (indexes: [Int], logits: [Float]) {
-        guard !arr.isEmpty else {
+    public func warp(indexes: [Int], logits: [Float]) -> (indexes: [Int], logits: [Float]) {
+        guard !logits.isEmpty else {
             return (indexes: [], logits: [])
         }
 
-        let arrSoftmax = Math.softmax(arr)
+        let arrSoftmax = Math.softmax(logits)
         var indexLogitProb = [(index: Int, logit: Float, prob: Float)]()
-        indexLogitProb.reserveCapacity(arr.count)
-        for (index, data) in zip(arr, arrSoftmax).enumerated() {
+        indexLogitProb.reserveCapacity(logits.count)
+        for (index, data) in zip(logits, arrSoftmax).enumerated() {
             indexLogitProb.append((index: index, logit: data.0, prob: data.1))
         }
         indexLogitProb.sort { $0.prob > $1.prob }
@@ -30,8 +30,8 @@ public struct TopPLogitsWarper: LogitsWarper {
             break
         }
 
-        let indexes = indexLogitProb[0 ... sliceIndex].map(\.index)
-        let logits = indexLogitProb[0 ... sliceIndex].map(\.logit)
-        return (indexes: indexes, logits: logits)
+        let toppIndexes = indexLogitProb[0 ... sliceIndex].map { indexes[$0.index] }
+        let toppLogits = indexLogitProb[0 ... sliceIndex].map(\.logit)
+        return (indexes: toppIndexes, logits: toppLogits)
     }
 }

--- a/Tests/TensorUtilsTests/LogitsWarperTests.swift
+++ b/Tests/TensorUtilsTests/LogitsWarperTests.swift
@@ -12,65 +12,79 @@ final class LogitsWarperTests: XCTestCase {
     private let accuracy: Float = 0.00001
 
     func testTemperatureLogitsWarper() {
-        let result1 = TemperatureLogitsWarper(temperature: 0.0)([])
+        let result1 = TemperatureLogitsWarper(temperature: 0.0)([], [])
         XCTAssertTrue(result1.indexes.isEmpty)
         XCTAssertTrue(result1.logits.isEmpty)
 
-        let result2 = TemperatureLogitsWarper(temperature: 1.0)([])
+        let result2 = TemperatureLogitsWarper(temperature: 1.0)([], [])
         XCTAssertTrue(result2.indexes.isEmpty)
         XCTAssertTrue(result2.logits.isEmpty)
 
-        let result3 = TemperatureLogitsWarper(temperature: 1.0)([2.0, 1.0])
+        let result3 = TemperatureLogitsWarper(temperature: 1.0)([0, 1], [2.0, 1.0])
         XCTAssertEqual(result3.indexes, [0, 1])
         XCTAssertEqual(result3.logits, [2.0, 1.0], accuracy: accuracy)
 
-        let result4 = TemperatureLogitsWarper(temperature: 2.0)([2.0, 1.0])
+        let result4 = TemperatureLogitsWarper(temperature: 2.0)([0, 1], [2.0, 1.0])
         XCTAssertEqual(result4.indexes, [0, 1])
         XCTAssertEqual(result4.logits, [1.0, 0.5], accuracy: accuracy)
 
-        let result5 = TemperatureLogitsWarper(temperature: 0.5)([2.0, 1.0])
+        let result5 = TemperatureLogitsWarper(temperature: 0.5)([0, 1], [2.0, 1.0])
         XCTAssertEqual(result5.indexes, [0, 1])
         XCTAssertEqual(result5.logits, [4.0, 2.0], accuracy: accuracy)
+
+        let result6 = TemperatureLogitsWarper(temperature: 0.5)([200, 100], [2.0, 1.0])
+        XCTAssertEqual(result6.indexes, [200, 100])
+        XCTAssertEqual(result6.logits, [4.0, 2.0], accuracy: accuracy)
     }
 
     func testTopKLogitsWarper() {
-        let result1 = TopKLogitsWarper(k: 0)([])
+        let result1 = TopKLogitsWarper(k: 0)([], [])
         XCTAssertTrue(result1.indexes.isEmpty)
         XCTAssertTrue(result1.logits.isEmpty)
 
-        let result2 = TopKLogitsWarper(k: 3)([])
+        let result2 = TopKLogitsWarper(k: 3)([], [])
         XCTAssertTrue(result2.indexes.isEmpty)
         XCTAssertTrue(result2.logits.isEmpty)
 
-        let result3 = TopKLogitsWarper(k: 3)([2.0, 1.0])
+        let result3 = TopKLogitsWarper(k: 3)([0, 1], [2.0, 1.0])
         XCTAssertEqual(result3.indexes, [0, 1])
         XCTAssertEqual(result3.logits, [2.0, 1.0], accuracy: accuracy)
 
-        let result4 = TopKLogitsWarper(k: 3)([2.0, 1.0, 3.0])
+        let result4 = TopKLogitsWarper(k: 3)([0, 1, 2], [2.0, 1.0, 3.0])
         XCTAssertEqual(result4.indexes, [2, 0, 1])
         XCTAssertEqual(result4.logits, [3.0, 2.0, 1.0], accuracy: accuracy)
 
-        let result5 = TopKLogitsWarper(k: 4)([2.0, 1.0, 3.0, -1.0, 123.0, 0.0])
+        let result5 = TopKLogitsWarper(k: 4)([0, 1, 2, 3, 4, 5], [2.0, 1.0, 3.0, -1.0, 123.0, 0.0])
         XCTAssertEqual(result5.indexes, [4, 2, 0, 1])
         XCTAssertEqual(result5.logits, [123.0, 3.0, 2.0, 1.0], accuracy: accuracy)
+
+        let result6 = TopKLogitsWarper(k: 3)([10, 1, 52], [2.0, 1.0, 3.0])
+        XCTAssertEqual(result6.indexes, [52, 10, 1])
+        XCTAssertEqual(result6.logits, [3.0, 2.0, 1.0], accuracy: accuracy)
     }
 
     func testTopPLogitsWarper() {
-        let result1 = TopPLogitsWarper(p: 0.99)([])
+        let result1 = TopPLogitsWarper(p: 0.99)([], [])
         XCTAssertTrue(result1.indexes.isEmpty)
         XCTAssertTrue(result1.logits.isEmpty)
 
-        let result2 = TopPLogitsWarper(p: 0.99)((0 ..< 10).map { Float($0) })
+        let logits = (0 ..< 10).map { Float($0) }
+        let indexes = Array(logits.indices)
+        let result2 = TopPLogitsWarper(p: 0.99)(indexes, logits)
         XCTAssertEqual(result2.indexes, [9, 8, 7, 6, 5])
         XCTAssertEqual(result2.logits, [9.0, 8.0, 7.0, 6.0, 5.0], accuracy: accuracy)
 
-        let result3 = TopPLogitsWarper(p: 0.95)((0 ..< 10).map { Float($0) })
+        let result3 = TopPLogitsWarper(p: 0.95)(indexes, logits)
         XCTAssertEqual(result3.indexes, [9, 8, 7])
         XCTAssertEqual(result3.logits, [9.0, 8.0, 7.0], accuracy: accuracy)
 
-        let result4 = TopPLogitsWarper(p: 0.6321493)((0 ..< 10).map { Float($0) })
+        let result4 = TopPLogitsWarper(p: 0.6321493)(indexes, logits)
         XCTAssertEqual(result4.indexes, [9, 8])
         XCTAssertEqual(result4.logits, [9.0, 8.0], accuracy: accuracy)
+
+        let result5 = TopPLogitsWarper(p: 0.95)([3, 1, 8], [0, 1, 2])
+        XCTAssertEqual(result5.indexes, [8, 1, 3])
+        XCTAssertEqual(result5.logits, [2, 1, 0], accuracy: accuracy)
     }
 
     func testLogitsProcessor() {
@@ -95,7 +109,14 @@ final class LogitsWarperTests: XCTestCase {
             logitsWarpers: [TopKLogitsWarper(k: 3), TopPLogitsWarper(p: 0.99)]
         )
         let result4 = processor4([2.0, 1.0, 3.0, -5.0, -23.0, 12.5])
-        XCTAssertEqual(result4.indexes, [0])
+        XCTAssertEqual(result4.indexes, [5])
         XCTAssertEqual(result4.logits, [12.5], accuracy: accuracy)
+
+        let processor5 = LogitsProcessor(
+            logitsWarpers: [TopKLogitsWarper(k: 4), TopPLogitsWarper(p: 0.99)]
+        )
+        let result5 = processor5([2.0, 1.0, 3.0, -5.0, -3.0, 4.5])
+        XCTAssertEqual(result5.indexes, [5, 2, 0, 1])
+        XCTAssertEqual(result5.logits, [4.5, 3.0, 2.0, 1.0], accuracy: accuracy)
     }
 }


### PR DESCRIPTION
Issue is described [here](https://github.com/huggingface/swift-transformers/issues/44)

When `LogitsProcessor` contains more than one instance of `LogitsWarper` wrong indexes are returned -- we're returning indexes of the processed array but we should return these indexes mapped to the result of the previous call of `LogitsProcessor`.

Fixed by changing the interface of `LogitsWarper` allowing to pass indexes along with logits and mapping the result indexes to the passed indexes.