### PR TITLE
Propagate HubApi configuration

### DIFF
--- a/Sources/Hub/Hub.swift
+++ b/Sources/Hub/Hub.swift
@@ -112,9 +112,15 @@ public class LanguageModelConfigurationFromHub {
 
     private var configPromise: Task<Configurations, Error>? = nil
 
-    public init(modelName: String) {
+    public init(
+        modelName: String,
+        hubApi: HubApi = HubApi()
+    ) {
         self.configPromise = Task.init {
-            return try await self.loadConfig(modelName: modelName)
+            return try await self.loadConfig(
+                modelName: modelName,
+                hubApi: hubApi
+            )
         }
     }
 
@@ -161,8 +167,10 @@ public class LanguageModelConfigurationFromHub {
         }
     }
 
-    func loadConfig(modelName: String, hfToken: String? = nil) async throws -> Configurations {
-        let hubApi = HubApi(hfToken: hfToken)
+    func loadConfig(
+        modelName: String,
+        hubApi: HubApi = HubApi()
+    ) async throws -> Configurations {
         let filesToDownload = ["config.json", "tokenizer_config.json", "tokenizer.json"]
         let repo = Hub.Repo(id: modelName)
         try await hubApi.snapshot(from: repo, matching: filesToDownload)
@@ -172,7 +180,11 @@ public class LanguageModelConfigurationFromHub {
         let tokenizerConfig = try? hubApi.configuration(from: "tokenizer_config.json", in: repo)
         let tokenizerVocab = try hubApi.configuration(from: "tokenizer.json", in: repo)
         
-        let configs = Configurations(modelConfig: modelConfig, tokenizerConfig: tokenizerConfig, tokenizerData: tokenizerVocab)
+        let configs = Configurations(
+            modelConfig: modelConfig,
+            tokenizerConfig: tokenizerConfig,
+            tokenizerData: tokenizerVocab
+        )
         return configs
     }
 

--- a/Sources/Hub/Hub.swift
+++ b/Sources/Hub/Hub.swift
@@ -114,13 +114,10 @@ public class LanguageModelConfigurationFromHub {
 
     public init(
         modelName: String,
-        hubApi: HubApi = HubApi()
+        hubApi: HubApi = .shared
     ) {
         self.configPromise = Task.init {
-            return try await self.loadConfig(
-                modelName: modelName,
-                hubApi: hubApi
-            )
+            return try await self.loadConfig(modelName: modelName, hubApi: hubApi)
         }
     }
 
@@ -169,7 +166,7 @@ public class LanguageModelConfigurationFromHub {
 
     func loadConfig(
         modelName: String,
-        hubApi: HubApi = HubApi()
+        hubApi: HubApi = .shared
     ) async throws -> Configurations {
         let filesToDownload = ["config.json", "tokenizer_config.json", "tokenizer.json"]
         let repo = Hub.Repo(id: modelName)

--- a/Sources/Hub/HubApi.swift
+++ b/Sources/Hub/HubApi.swift
@@ -8,25 +8,29 @@
 import Foundation
 
 public struct HubApi {
-    var downloadBase: URL
-    var hfToken: String?
-    var endpoint: String
+    public var downloadBase: URL
+    public var hfToken: String?
+    public var endpoint: String
     
     public typealias RepoType = Hub.RepoType
     public typealias Repo = Hub.Repo
     
-    public init(downloadBase: URL? = nil, hfToken: String? = nil, endpoint: String = "https://huggingface.co") {
-        if downloadBase == nil {
+    public init(
+        downloadBase: URL? = nil,
+        hfToken: String? = nil,
+        endpoint: String = "https://huggingface.co"
+    ) {
+        self.hfToken = hfToken
+        if let downloadBase {
+            self.downloadBase = downloadBase
+        } else {
             let documents = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!
             self.downloadBase = documents.appending(component: "huggingface")
-        } else {
-            self.downloadBase = downloadBase!
         }
-        self.hfToken = hfToken
         self.endpoint = endpoint
     }
     
-    static let shared = HubApi()
+    public static let shared = HubApi()
 }
 
 /// File retrieval
@@ -179,7 +183,13 @@ public extension HubApi {
         let repoDestination = localRepoLocation(repo)
         for filename in filenames {
             let fileProgress = Progress(totalUnitCount: 100, parent: progress, pendingUnitCount: 1)
-            let downloader = HubFileDownloader(repo: repo, repoDestination: repoDestination, relativeFilename: filename, hfToken: hfToken, endpoint: endpoint)
+            let downloader = HubFileDownloader(
+                repo: repo,
+                repoDestination: repoDestination,
+                relativeFilename: filename,
+                hfToken: hfToken,
+                endpoint: endpoint
+            )
             try await downloader.download { fractionDownloaded in
                 fileProgress.completedUnitCount = Int64(100 * fractionDownloaded)
                 progressHandler(progress)

--- a/Sources/Hub/HubApi.swift
+++ b/Sources/Hub/HubApi.swift
@@ -8,9 +8,9 @@
 import Foundation
 
 public struct HubApi {
-    public var downloadBase: URL
-    public var hfToken: String?
-    public var endpoint: String
+    public let downloadBase: URL
+    public let hfToken: String?
+    public let endpoint: String
     
     public typealias RepoType = Hub.RepoType
     public typealias Repo = Hub.Repo

--- a/Sources/Tokenizers/Tokenizer.swift
+++ b/Sources/Tokenizers/Tokenizer.swift
@@ -236,7 +236,7 @@ extension AutoTokenizer {
 
     public static func from(
         pretrained model: String,
-        hubApi: HubApi = HubApi()
+        hubApi: HubApi = .shared
     ) async throws -> Tokenizer {
         let config = LanguageModelConfigurationFromHub(modelName: model, hubApi: hubApi)
         guard let tokenizerConfig = try await config.tokenizerConfig else { throw TokenizerError.missingConfig }

--- a/Sources/Tokenizers/Tokenizer.swift
+++ b/Sources/Tokenizers/Tokenizer.swift
@@ -234,8 +234,11 @@ extension AutoTokenizer {
         return try PreTrainedTokenizer(tokenizerConfig: tokenizerConfig, tokenizerData: tokenizerData)
     }
 
-    public static func from(pretrained model: String) async throws -> Tokenizer {
-        let config = LanguageModelConfigurationFromHub(modelName: model)
+    public static func from(
+        pretrained model: String,
+        hubApi: HubApi = HubApi()
+    ) async throws -> Tokenizer {
+        let config = LanguageModelConfigurationFromHub(modelName: model, hubApi: hubApi)
         guard let tokenizerConfig = try await config.tokenizerConfig else { throw TokenizerError.missingConfig }
         let tokenizerData = try await config.tokenizerData
 


### PR DESCRIPTION
Propagating the `HubApi` configuration will allow the user to specify the download folder when using e.g. `AutoTokenizer.from` method.

Detailed description of the issue:

I'm trying to create a homebrew formula for [WhisperKit CLI](https://github.com/argmaxinc/WhisperKit) (PR is here: https://github.com/Homebrew/homebrew-core/pull/165912). As a part of the acceptance criteria, homebrew CI runs the tests on the formula in the sandbox environment. The tests are failing because the whisperkit cli is trying to download the tokenizer configuration to the destination to which it doesn't have access and this results in error:

```
Error: You don’t have permission to save the file “whisper-tiny” in the folder “openai”.
```

cc @ZachNagengast 