### PR TITLE
CI Tests and SPI Docs

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build-and-test:
-    runs-on: macos-latest
+    runs-on: macos-13
     steps:
     - uses: actions/checkout@v4
     - name: Build

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,0 +1,20 @@
+name: Unit Tests
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+  workflow_dispatch:
+
+jobs:
+  build-and-test:
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Build
+      run: swift build
+    - name: Run tests
+      run: 
+        set -o pipefail &&
+        swift test | xcpretty

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -13,8 +13,6 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Build
-      run: swift build
+      run: swift build --vv --build-tests
     - name: Run tests
-      run: 
-        set -o pipefail &&
-        swift test | xcpretty
+      run: swift test --vv --skip-build

--- a/.spi.yml
+++ b/.spi.yml
@@ -1,0 +1,4 @@
+version: 1
+builder:
+  configs:
+    - documentation_targets: [Transformers]

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # `swift-transformers`
+[![Unit Tests](https://github.com/huggingface/swift-transformers/actions/workflows/unit-tests.yml/badge.svg)](https://github.com/huggingface/swift-transformers/actions/workflows/unit-tests.yml)
+[![](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2Fhuggingface%2Fswift-transformers%2Fbadge%3Ftype%3Dswift-versions)](https://swiftpackageindex.com/huggingface/swift-transformers)
+[![](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2Fhuggingface%2Fswift-transformers%2Fbadge%3Ftype%3Dplatforms)](https://swiftpackageindex.com/huggingface/swift-transformers)
 
 This is a collection of utilities to help adopt language models in Swift apps. It tries to follow the Python `transformers` API and abstractions whenever possible, but it also aims to provide an idiomatic Swift interface and does not assume prior familiarity with [`transformers`](https://github.com/huggingface/transformers) or [`tokenizers`](https://github.com/huggingface/tokenizers).
 

--- a/Sources/TransformersCLI/main.swift
+++ b/Sources/TransformersCLI/main.swift
@@ -53,13 +53,17 @@ struct TransformersCLI: ParsableCommand {
         }
         semaphore.wait()
     }
-    
+
     func compile(at url: URL) throws -> URL {
+        #if os(watchOS)
+        fatalError("Model compilation is not supported on watchOS")
+        #else
         if url.pathExtension == "mlmodelc" { return url }
         print("Compiling model \(url)")
         return try MLModel.compileModel(at: url)
+        #endif
     }
-    
+
     func run() throws {
         let url = URL(filePath: modelPath)
         let compiledURL = try compile(at: url)


### PR DESCRIPTION
This will run all the tests on PRs. Future work will be to run all the tests on each supported platform. This would be similar to the checks that [swift package index](https://swiftpackageindex.com/huggingface/swift-transformers/builds) is doing, which are now displayed in the readme.

<img width="591" alt="image" src="https://github.com/huggingface/swift-transformers/assets/1981179/96936689-1600-41c7-bdf2-6e7a3f8a88af">


Additionally, added the `.spi.yml` needed for swift package index to auto generate docs on their website. 