### PR TITLE
add CohereTokenizer support

### DIFF
--- a/Sources/Tokenizers/Tokenizer.swift
+++ b/Sources/Tokenizers/Tokenizer.swift
@@ -68,7 +68,7 @@ struct TokenizerModel {
         "LlamaTokenizer"     : LlamaTokenizer.self,
         "T5Tokenizer"        : T5Tokenizer.self,
         "WhisperTokenizer"   : WhisperTokenizer.self,
-
+        "CohereTokenizer"    : CohereTokenizer.self,
         "PreTrainedTokenizer": BPETokenizer.self
     ]
 
@@ -267,5 +267,6 @@ class CodeGenTokenizer  : BPETokenizer {}
 class WhisperTokenizer  : BPETokenizer {}
 class GemmaTokenizer    : BPETokenizer {}
 class CodeLlamaTokenizer: BPETokenizer {}
+class CohereTokenizer   : BPETokenizer {}
 
 class T5Tokenizer       : UnigramTokenizer {}


### PR DESCRIPTION
The CoHere tokenizer is using BPETokenizer. I did some quick tests locally and it seems to work fine with the BPETokenizer.