### PR TITLE
Support loading tokenizer from local folder #76

### DIFF
--- a/Sources/Hub/Hub.swift
+++ b/Sources/Hub/Hub.swift
@@ -179,19 +179,9 @@ public class LanguageModelConfigurationFromHub {
     ) async throws -> Configurations {
         let filesToDownload = ["config.json", "tokenizer_config.json", "tokenizer.json"]
         let repo = Hub.Repo(id: modelName)
-        try await hubApi.snapshot(from: repo, matching: filesToDownload)
+        let downloadedModelFolder = try await hubApi.snapshot(from: repo, matching: filesToDownload)
 
-        // Note tokenizerConfig may be nil (does not exist in all models)
-        let modelConfig = try hubApi.configuration(from: "config.json", in: repo)
-        let tokenizerConfig = try? hubApi.configuration(from: "tokenizer_config.json", in: repo)
-        let tokenizerVocab = try hubApi.configuration(from: "tokenizer.json", in: repo)
-        
-        let configs = Configurations(
-            modelConfig: modelConfig,
-            tokenizerConfig: tokenizerConfig,
-            tokenizerData: tokenizerVocab
-        )
-        return configs
+        return try await loadConfig(modelFolder: downloadedModelFolder, hubApi: hubApi)
     }
     
     func loadConfig(
@@ -199,9 +189,9 @@ public class LanguageModelConfigurationFromHub {
         hubApi: HubApi = .shared
     ) async throws -> Configurations {
         // Note tokenizerConfig may be nil (does not exist in all models)
-        let modelConfig = try hubApi.configuration(url: modelFolder.appending(path: "config.json"))
-        let tokenizerConfig = try? hubApi.configuration(url: modelFolder.appending(path: "tokenizer_config.json"))
-        let tokenizerVocab = try hubApi.configuration(url: modelFolder.appending(path: "tokenizer.json"))
+        let modelConfig = try hubApi.configuration(fileURL: modelFolder.appending(path: "config.json"))
+        let tokenizerConfig = try? hubApi.configuration(fileURL: modelFolder.appending(path: "tokenizer_config.json"))
+        let tokenizerVocab = try hubApi.configuration(fileURL: modelFolder.appending(path: "tokenizer.json"))
         
         let configs = Configurations(
             modelConfig: modelConfig,

--- a/Sources/Hub/Hub.swift
+++ b/Sources/Hub/Hub.swift
@@ -120,6 +120,15 @@ public class LanguageModelConfigurationFromHub {
             return try await self.loadConfig(modelName: modelName, hubApi: hubApi)
         }
     }
+    
+    public init(
+        modelFolder: URL,
+        hubApi: HubApi = .shared
+    ) {
+        self.configPromise = Task {
+            return try await self.loadConfig(modelFolder: modelFolder, hubApi: hubApi)
+        }
+    }
 
     public var modelConfig: Config {
         get async throws {
@@ -176,6 +185,23 @@ public class LanguageModelConfigurationFromHub {
         let modelConfig = try hubApi.configuration(from: "config.json", in: repo)
         let tokenizerConfig = try? hubApi.configuration(from: "tokenizer_config.json", in: repo)
         let tokenizerVocab = try hubApi.configuration(from: "tokenizer.json", in: repo)
+        
+        let configs = Configurations(
+            modelConfig: modelConfig,
+            tokenizerConfig: tokenizerConfig,
+            tokenizerData: tokenizerVocab
+        )
+        return configs
+    }
+    
+    func loadConfig(
+        modelFolder: URL,
+        hubApi: HubApi = .shared
+    ) async throws -> Configurations {
+        // Note tokenizerConfig may be nil (does not exist in all models)
+        let modelConfig = try hubApi.configuration(url: modelFolder.appending(path: "config.json"))
+        let tokenizerConfig = try? hubApi.configuration(url: modelFolder.appending(path: "tokenizer_config.json"))
+        let tokenizerVocab = try hubApi.configuration(url: modelFolder.appending(path: "tokenizer.json"))
         
         let configs = Configurations(
             modelConfig: modelConfig,

--- a/Sources/Hub/HubApi.swift
+++ b/Sources/Hub/HubApi.swift
@@ -93,14 +93,14 @@ public extension HubApi {
     /// Assumes the file has already been downloaded.
     /// `filename` is relative to the download base.
     func configuration(from filename: String, in repo: Repo) throws -> Config {
-        let url = localRepoLocation(repo).appending(path: filename)
-        return try configuration(url: url)
+        let fileURL = localRepoLocation(repo).appending(path: filename)
+        return try configuration(fileURL: fileURL)
     }
     
-    /// Assumes the file has already present at local url.
-    /// `url` is complete local file path for given model
-    func configuration(url: URL) throws -> Config {
-        let data = try Data(contentsOf: url)
+    /// Assumes the file is already present at local url.
+    /// `fileURL` is a complete local file path for the given model
+    func configuration(fileURL: URL) throws -> Config {
+        let data = try Data(contentsOf: fileURL)
         let parsed = try JSONSerialization.jsonObject(with: data, options: [])
         guard let dictionary = parsed as? [String: Any] else { throw Hub.HubClientError.parse }
         return Config(dictionary)

--- a/Sources/Hub/HubApi.swift
+++ b/Sources/Hub/HubApi.swift
@@ -94,6 +94,12 @@ public extension HubApi {
     /// `filename` is relative to the download base.
     func configuration(from filename: String, in repo: Repo) throws -> Config {
         let url = localRepoLocation(repo).appending(path: filename)
+        return try configuration(url: url)
+    }
+    
+    /// Assumes the file has already present at local url.
+    /// `url` is complete local file path for given model
+    func configuration(url: URL) throws -> Config {
         let data = try Data(contentsOf: url)
         let parsed = try JSONSerialization.jsonObject(with: data, options: [])
         guard let dictionary = parsed as? [String: Any] else { throw Hub.HubClientError.parse }

--- a/Sources/Tokenizers/Tokenizer.swift
+++ b/Sources/Tokenizers/Tokenizer.swift
@@ -256,6 +256,17 @@ extension AutoTokenizer {
 
         return try PreTrainedTokenizer(tokenizerConfig: tokenizerConfig, tokenizerData: tokenizerData)
     }
+    
+    public static func from(
+        modelFolder: URL,
+        hubApi: HubApi = .shared
+    ) async throws -> Tokenizer {
+        let config = LanguageModelConfigurationFromHub(modelFolder: modelFolder, hubApi: hubApi)
+        guard let tokenizerConfig = try await config.tokenizerConfig else { throw TokenizerError.missingConfig }
+        let tokenizerData = try await config.tokenizerData
+        
+        return try PreTrainedTokenizer(tokenizerConfig: tokenizerConfig, tokenizerData: tokenizerData)
+    }
 }
 
 // MARK: - Tokenizer model classes

--- a/Tests/TokenizersTests/FactoryTests.swift
+++ b/Tests/TokenizersTests/FactoryTests.swift
@@ -42,4 +42,24 @@ class FactoryTests: TestWithCustomHubDownloadLocation {
         let inputIds = tokenizer("Today she took a train to the West")
         XCTAssertEqual(inputIds, [50258, 50363, 27676, 750, 1890, 257, 3847, 281, 264, 4055, 50257])
     }
+    
+    func testFromModelFolder() async throws {
+        let filesToDownload = ["config.json", "tokenizer_config.json", "tokenizer.json"]
+        let repo = Hub.Repo(id: "coreml-projects/Llama-2-7b-chat-coreml")
+        let localModelFolder = try await hubApi.snapshot(from: repo, matching: filesToDownload)
+        
+        let tokenizer = try await AutoTokenizer.from(modelFolder: localModelFolder, hubApi: hubApi)
+        let inputIds = tokenizer("Today she took a train to the West")
+        XCTAssertEqual(inputIds, [1, 20628, 1183, 3614, 263, 7945, 304, 278, 3122])
+    }
+    
+    func testWhisperFromModelFolder() async throws {
+        let filesToDownload = ["config.json", "tokenizer_config.json", "tokenizer.json"]
+        let repo = Hub.Repo(id: "openai/whisper-large-v2")
+        let localModelFolder = try await hubApi.snapshot(from: repo, matching: filesToDownload)
+        
+        let tokenizer = try await AutoTokenizer.from(modelFolder: localModelFolder, hubApi: hubApi)
+        let inputIds = tokenizer("Today she took a train to the West")
+        XCTAssertEqual(inputIds, [50258, 50363, 27676, 750, 1890, 257, 3847, 281, 264, 4055, 50257])
+    }
 }


### PR DESCRIPTION
Resolves #76 


- Added new method in `AutoTokenizer` to load from local model folder. 

- Also added supporting unit tests at `Tests/TokenizersTests/FactoryTests.swift`

- Although we could have simply loaded `tokenizer_config.json` and `tokenizer.json` files directly into configurations, I chose to go via `LanguageModelConfigurationFromHub` because it has it's own magic for choosing appropriate tokenizer class and it also selects fallback tokenizer if needed [refer getter var tokenizerConfig: Config?](https://github.com/huggingface/swift-transformers/blob/4f915610451d29a05948802a140880ff37494dad/Sources/Hub/Hub.swift#L132)