### PR TITLE
Fix progress

### DIFF
--- a/Sources/Hub/Downloader.swift
+++ b/Sources/Hub/Downloader.swift
@@ -105,8 +105,8 @@ class Downloader: NSObject, ObservableObject {
 }
 
 extension Downloader: URLSessionDownloadDelegate {
-    func urlSession(_: URLSession, downloadTask: URLSessionDownloadTask, didWriteData _: Int64, totalBytesWritten _: Int64, totalBytesExpectedToWrite _: Int64) {
-        downloadState.value = .downloading(downloadTask.progress.fractionCompleted)
+    func urlSession(_: URLSession, downloadTask: URLSessionDownloadTask, didWriteData _: Int64, totalBytesWritten: Int64, totalBytesExpectedToWrite: Int64) {
+        downloadState.value = .downloading(Double(totalBytesWritten) / Double(totalBytesExpectedToWrite))
     }
 
     func urlSession(_: URLSession, downloadTask _: URLSessionDownloadTask, didFinishDownloadingTo location: URL) {


### PR DESCRIPTION
The fractionCompleted remains at 0, and the progress seen on the progressview always stays for a long time because the file has not finished downloading, so there is no update in progress. This gives people the impression that the download is very slow or there is a network anomaly. Similar to issue #79

<img width="915" alt="image" src="https://github.com/huggingface/swift-transformers/assets/1825679/415e1adc-ae31-4652-87aa-b3a552ecaa3f">
