### PR TITLE
Update .spi.yml

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -1,4 +1,4 @@
 version: 1
 builder:
   configs:
-    - documentation_targets: [Transformers]
+    - documentation_targets: [Hub, Tokenizers, TensorUtils, Generation, Models]


### PR DESCRIPTION
Fixes https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/issues/2978

Doc generation fails, because there is no target `Transformers`!

```
error: no target named 'Transformers'
compatible targets: 'Tokenizers', 'Generation', 'Models', 'TransformersCLI', 'HubCLI', 'TensorUtils', 'Hub', 'ArgumentParser'
```