### PR TITLE
Supporting more BERT-like models

### DIFF
--- a/Sources/Hub/Hub.swift
+++ b/Sources/Hub/Hub.swift
@@ -100,7 +100,14 @@ public struct Config {
     }
     
     /// Tuple of token identifier and string value
-    public var tokenValue: (UInt, String)? { value as? (UInt, String) }
+    public var tokenValue: (UInt, String)? {
+        if let tuple = value as? (UInt, String) {
+            return tuple
+        } else if let reversedTuple = value as? (String, UInt) {
+            return (reversedTuple.1, reversedTuple.0)
+        }
+        return nil
+    }
 }
 
 public class LanguageModelConfigurationFromHub {

--- a/Sources/Hub/Hub.swift
+++ b/Sources/Hub/Hub.swift
@@ -101,11 +101,16 @@ public struct Config {
     
     /// Tuple of token identifier and string value
     public var tokenValue: (UInt, String)? {
-        if let tuple = value as? (UInt, String) {
-            return tuple
-        } else if let reversedTuple = value as? (String, UInt) {
-            return (reversedTuple.1, reversedTuple.0)
+        guard let array = value as? [Any], array.count == 2 else {
+            return nil
         }
+
+        if let first = array[0] as? String, let second = array[1] as? Int64 {
+            return (UInt(second), first)
+        } else if let first = array[0] as? Int64, let second = array[1] as? String {
+            return (UInt(first), second)
+        }
+
         return nil
     }
 }

--- a/Sources/Tokenizers/Normalizer.swift
+++ b/Sources/Tokenizers/Normalizer.swift
@@ -39,7 +39,11 @@ enum NormalizerType: String {
 struct NormalizerFactory {
     static func fromConfig(config: Config?) -> Normalizer? {
         guard let config = config else { return nil }
-        guard let typeName = config.type?.stringValue else { return nil }
+        guard var typeName = config.type?.stringValue else { return nil }
+        if typeName.hasSuffix("Normalizer") {
+            typeName = String(typeName.dropLast("Normalizer".count))
+        }
+        
         let type = NormalizerType(rawValue: typeName)
         switch type {
         case .Sequence: return NormalizerSequence(config: config)

--- a/Sources/Tokenizers/PreTokenizer.swift
+++ b/Sources/Tokenizers/PreTokenizer.swift
@@ -49,7 +49,11 @@ enum PreTokenizerType: String {
 struct PreTokenizerFactory {
     static func fromConfig(config: Config?) -> PreTokenizer? {
         guard let config = config else { return nil }
-        guard let typeName = config.type?.stringValue else { return nil }
+        guard var typeName = config.type?.stringValue else { return nil }
+        if typeName.hasSuffix("PreTokenizer") {
+            typeName = String(typeName.dropLast("PreTokenizer".count))
+        }
+
         let type = PreTokenizerType(rawValue: typeName)
         switch type {
         case .Sequence : return PreTokenizerSequence(config: config)

--- a/Sources/Tokenizers/PreTokenizer.swift
+++ b/Sources/Tokenizers/PreTokenizer.swift
@@ -36,6 +36,7 @@ enum PreTokenizerType: String {
     case Sequence
     case ByteLevel
     case Punctuation
+    case Bert
     case Digits
     case Split
     case Whitespace
@@ -54,6 +55,7 @@ struct PreTokenizerFactory {
         case .Sequence : return PreTokenizerSequence(config: config)
         case .ByteLevel: return ByteLevelPreTokenizer(config: config)
         case .Punctuation: return PunctuationPreTokenizer(config: config)
+        case .Bert: return BertPreTokenizer(config: config)
         case .Digits: return DigitsPreTokenizer(config: config)
         case .Split: return SplitPreTokenizer(config: config)
         case .Whitespace, .WhitespaceSplit: return WhitespacePreTokenizer(config: config)
@@ -188,6 +190,20 @@ class PunctuationPreTokenizer: PreTokenizer {
 
     func preTokenize(text: String) -> [String] {
         // Ref: https://github.com/xenova/transformers.js/blob/27920d84831e323275b38f0b5186644b7936e1a2/src/tokenizers.js#L1138
+        return text.ranges(of: re).map { String(text[$0]) }
+    }
+}
+
+class BertPreTokenizer: PreTokenizer {
+    // Identical to PunctuationPreTokenizer, but with a different regex
+    let PUNCTUATION_REGEX = #"\p{P}\u0021-\u002F\u003A-\u0040\u005B-\u0060\u007B-\u007E"#
+    let re: String
+
+    required init(config: Config) {
+        re = "[^\\s\(PUNCTUATION_REGEX)]+|[\(PUNCTUATION_REGEX)]"
+    }
+
+    func preTokenize(text: String) -> [String] {
         return text.ranges(of: re).map { String(text[$0]) }
     }
 }

--- a/Sources/Tokenizers/Tokenizer.swift
+++ b/Sources/Tokenizers/Tokenizer.swift
@@ -86,11 +86,20 @@ struct TokenizerModel {
         if tokenizerName.hasSuffix("Tokenizer") {
             tokenizerName = String(tokenizerName.dropLast("Tokenizer".count))
         }
-        guard let tokenizerClass = TokenizerModel.knownTokenizers[tokenizerName] else {
-            throw TokenizerError.unsupportedTokenizer(tokenizerName)
+
+        // Try to perform a direct case-sensitive lookup first
+        if let tokenizerClass = TokenizerModel.knownTokenizers[tokenizerName] {
+            return try tokenizerClass.init(tokenizerConfig: tokenizerConfig, tokenizerData: tokenizerData, addedTokens: addedTokens)
+        } else {
+            // If the direct lookup fails, perform a case-insensitive scan over the keys
+            if let key = TokenizerModel.knownTokenizers.keys.first(where: { $0.lowercased() == tokenizerName.lowercased() }) {
+                if let tokenizerClass = TokenizerModel.knownTokenizers[key] {
+                    return try tokenizerClass.init(tokenizerConfig: tokenizerConfig, tokenizerData: tokenizerData, addedTokens: addedTokens)
+                }
+            }
         }
         
-        return try tokenizerClass.init(tokenizerConfig: tokenizerConfig, tokenizerData: tokenizerData, addedTokens: addedTokens)
+        throw TokenizerError.unsupportedTokenizer(tokenizerName)
     }
 }
 

--- a/Sources/Tokenizers/Tokenizer.swift
+++ b/Sources/Tokenizers/Tokenizer.swift
@@ -59,34 +59,37 @@ public protocol PreTrainedTokenizerModel: TokenizingModel {
 
 struct TokenizerModel {
     static let knownTokenizers: [String : PreTrainedTokenizerModel.Type] = [
-        "BertTokenizer"      : BertTokenizer.self,
-        "CodeGenTokenizer"   : CodeGenTokenizer.self,
-        "CodeLlamaTokenizer" : CodeLlamaTokenizer.self,
-        "FalconTokenizer"    : FalconTokenizer.self,
-        "GemmaTokenizer"     : GemmaTokenizer.self,
-        "GPT2Tokenizer"      : GPT2Tokenizer.self,
-        "LlamaTokenizer"     : LlamaTokenizer.self,
-        "T5Tokenizer"        : T5Tokenizer.self,
-        "WhisperTokenizer"   : WhisperTokenizer.self,
-        "CohereTokenizer"    : CohereTokenizer.self,
-        "PreTrainedTokenizer": BPETokenizer.self
+        "Bert"      : BertTokenizer.self,
+        "CodeGen"   : CodeGenTokenizer.self,
+        "CodeLlama" : CodeLlamaTokenizer.self,
+        "Falcon"    : FalconTokenizer.self,
+        "Gemma"     : GemmaTokenizer.self,
+        "GPT2"      : GPT2Tokenizer.self,
+        "Llama"     : LlamaTokenizer.self,
+        "T5"        : T5Tokenizer.self,
+        "Whisper"   : WhisperTokenizer.self,
+        "Cohere"    : CohereTokenizer.self,
+        "PreTrained": BPETokenizer.self
     ]
-
+    
     static func unknownToken(from tokenizerConfig: Config) -> String? {
         return tokenizerConfig.unkToken?.content?.stringValue ?? tokenizerConfig.unkToken?.stringValue
     }
-
+    
     public static func from(tokenizerConfig: Config, tokenizerData: Config, addedTokens: [String : Int]) throws -> TokenizingModel {
         guard let tokenizerClassName = tokenizerConfig.tokenizerClass?.stringValue else {
             throw TokenizerError.missingTokenizerClassInConfig
         }
-
+        
         // Some tokenizer_class entries use a Fast suffix
-        let tokenizerName = tokenizerClassName.replacingOccurrences(of: "Fast", with: "")
+        var tokenizerName = tokenizerClassName.replacingOccurrences(of: "Fast", with: "")
+        if tokenizerName.hasSuffix("Tokenizer") {
+            tokenizerName = String(tokenizerName.dropLast("Tokenizer".count))
+        }
         guard let tokenizerClass = TokenizerModel.knownTokenizers[tokenizerName] else {
             throw TokenizerError.unsupportedTokenizer(tokenizerName)
         }
-
+        
         return try tokenizerClass.init(tokenizerConfig: tokenizerConfig, tokenizerData: tokenizerData, addedTokens: addedTokens)
     }
 }

--- a/Sources/Tokenizers/Tokenizer.swift
+++ b/Sources/Tokenizers/Tokenizer.swift
@@ -66,6 +66,7 @@ struct TokenizerModel {
         "Gemma"     : GemmaTokenizer.self,
         "GPT2"      : GPT2Tokenizer.self,
         "Llama"     : LlamaTokenizer.self,
+        "Unigram"   : UnigramTokenizer.self,
         "T5"        : T5Tokenizer.self,
         "Whisper"   : WhisperTokenizer.self,
         "Cohere"    : CohereTokenizer.self,


### PR DESCRIPTION
Hi HF team!

I am extending our UForm repository of multimodal models to support Swift and mobile deployments, and along that way I've noticed that several classes for a broad range of BERT-like models are not yet supported by `swift-transformers`. So I've added a `WordPieceDecoder` class and aliases for `BertPreTokenizer` and `BertProcessing`.

Moreover, are you are well aware `config.json` and `tokenizer.json` come in all shapes and sizes. So I've added fallback mechanisms to handle different tuple order in vocabulary listings.

The [current `main-dev` branch of UForm](https://github.com/unum-cloud/uform/commit/00bd84c59995c7b3daa0b4fa1597f77608806fdb) is already using this functionality from my fork. I am looking into integrating more `Hub` functionality next. Please let me know what you think about this PR 🤗 