### PR TITLE
Allow unigram tokenizer to handle NSNumber score values 

### DIFF
--- a/Sources/Tokenizers/UnigramTokenizer.swift
+++ b/Sources/Tokenizers/UnigramTokenizer.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2024 Hugging Face. All rights reserved.
 //
 
+import Foundation
 import Hub
 
 class UnigramTokenizer: PreTrainedTokenizerModel {
@@ -37,8 +38,20 @@ class UnigramTokenizer: PreTrainedTokenizerModel {
         }
         
         vocab = try configVocab.map { piece in
-            guard let token = piece.first as? String else { throw TokenizerError.malformedVocab }
-            guard let score = piece.last as? Float else { throw TokenizerError.malformedVocab }
+            guard let token = piece.first as? String,
+                  let scoreValue = piece.last else {
+                throw TokenizerError.malformedVocab
+            }
+
+            let score: Float
+            if let floatScore = scoreValue as? Float {
+                score = floatScore
+            } else if let numberScore = scoreValue as? NSNumber {
+                score = numberScore.floatValue
+            } else {
+                throw TokenizerError.malformedVocab
+            }
+            
             return SentencePieceToken(token: token, score: score)
         }
         


### PR DESCRIPTION
For whatever reason, certain config files for unigram tokenizers end up reading scores as NSNumber instead of float, and throw malformedVocab errors.

`Expected a Float but found __NSCFNumber`

This doesn't convert directly to Float, so I'm adding one fallback here to attempt to convert it to float before throwing.
