### PR TITLE
Fix crashes in PreTrainedTokenizer and PreTokenizer with Gemma 2 2B

### DIFF
--- a/Sources/Tokenizers/BPETokenizer.swift
+++ b/Sources/Tokenizers/BPETokenizer.swift
@@ -93,7 +93,7 @@ class BPETokenizer: PreTrainedTokenizerModel {
         let RE = #"'s|'t|'re|'ve|'m|'ll|'d| ?\p{L}+| ?\p{N}+| ?[^\s\p{L}\p{N}]+|\s+(?!\S)|\s+"#
         let tokens = text.ranges(of: RE).map { String(text[$0]) }
         return tokens.map { (token) -> String in
-            return Array(token.utf8).map { byteEncoder[$0]! }.joined()
+            return Array(token.utf8).compactMap { byteEncoder[$0] }.joined()
         }
     }
     

--- a/Sources/Tokenizers/BertTokenizer.swift
+++ b/Sources/Tokenizers/BertTokenizer.swift
@@ -77,7 +77,7 @@ public class BertTokenizer {
                 """
             )
         }
-        return tokens.map { vocab[$0]! }
+        return tokens.compactMap { vocab[$0] }
     }
     
     /// Main entry point
@@ -91,7 +91,7 @@ public class BertTokenizer {
     
     /// Un-tokenization: get tokens from tokenIds
     func unTokenize(tokens: [Int]) -> [String] {
-        return tokens.map { ids_to_tokens[$0]! }
+        return tokens.compactMap { ids_to_tokens[$0] }
     }
     
     /// Un-tokenization:

--- a/Sources/Tokenizers/Tokenizer.swift
+++ b/Sources/Tokenizers/Tokenizer.swift
@@ -272,7 +272,7 @@ public class PreTrainedTokenizer: Tokenizer {
     /// Decode
     public func decode(tokens: [Int]) -> String {
         // IDs to tokens
-        let tokenStrings = tokens.map { model.convertIdToToken($0)! }
+        let tokenStrings = tokens.compactMap { model.convertIdToToken($0) }
         let decoded = decodeTokens(tokenStrings)
         // At this point we should have a single String
         return cleanUp(text: decoded.joined(separator: ""))


### PR DESCRIPTION
When running Gemma 2 2B, while the model is generating a longer output, swift-transformers crashes at this point in `PreTrainedTokenizer`:

```swift
let tokenStrings = tokens.map { model.convertIdToToken($0)! }
```

with this error:

```
Thread 1: Fatal error: Unexpectedly found nil while unwrapping an Optional value
```

This library uses a lot of force unwrapping, which in general is not a best practice and can cause crashes. I've only changed a few instances of force unwrapping here in the tokenizers. Please check if these changes would have any adverse consequences.