### PR TITLE
Fix Jinja Version

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.4.0"),
-        .package(url: "https://github.com/maiqingqiang/Jinja", branch: "main")
+        .package(url: "https://github.com/maiqingqiang/Jinja", from: "1.0.0")
     ],
     targets: [
         .executableTarget(


### PR DESCRIPTION
I'm very sorry, I didn't tag Jinja, which caused the inability to properly depend on swift-transformers 0.1.10.

```
Failed to resolve dependencies Dependencies could not be resolved because root depends on 'swift-transformers' 0.1.10..<1.0.0.
'swift-transformers' >= 0.1.10 cannot be used because package 'swift-transformers' is required using a stable-version but 'swift-transformers' depends on an unstable-version package 'jinja' and no versions of 'swift-transformers' match the requirement 0.1.11..<1.0.0.
```
