### PR TITLE
[preview] Fix archive

### DIFF
--- a/Sources/Models/LanguageModel.swift
+++ b/Sources/Models/LanguageModel.swift
@@ -383,14 +383,22 @@ public class LanguageModelWithStatefulKVCache: LanguageModel {
             Keys.inputIds: inputIds,
         ]
         if isRequiringAttentionMask {
+            #if !((os(macOS) || (macCatalyst)) && arch(x86_64))
             // TODO: Infer scalar type from cache or model I/O descriptors
             let attentionMask = MLTensor(zeros: [1, 1, 1, tokenCount + 1], scalarType: Float16.self)
             inputDictionary[Keys.attentionMask] = attentionMask
+            #else
+            fatalError()
+            #endif
         }
         if isRequiringCausalMask {
+            #if !((os(macOS) || targetEnvironment(macCatalyst)) && arch(x86_64))
             // TODO: Infer scalar type from cache or model I/O descriptors
             let causalMask = MLTensor(zeros: [1, 1, 1, tokenCount + 1], scalarType: Float16.self)
             inputDictionary[Keys.causalMask] = causalMask
+            #else
+            fatalError()
+            #endif
         }
         let outputs = try! await model.prediction(from: inputDictionary, using: state)
 


### PR DESCRIPTION
SPM dependencies are always compiled for the standard architectures, but Float16 is not available for `x86_64`.

Thanks @joshnewnham for the workaround 🙌

cc @cyrilzakka, feel free to review.