### PR TITLE
Upgrade Jinja 1.0.1 - Fix Qwen2.5 Chat Template error

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.4.0"),
-        .package(url: "https://github.com/maiqingqiang/Jinja", from: "1.0.1")
+        .package(url: "https://github.com/maiqingqiang/Jinja", "1.0.1"..<"1.1.0")
     ],
     targets: [
         .executableTarget(

--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.4.0"),
-        .package(url: "https://github.com/maiqingqiang/Jinja", from: "1.0.0")
+        .package(url: "https://github.com/maiqingqiang/Jinja", from: "1.0.1")
     ],
     targets: [
         .executableTarget(


### PR DESCRIPTION
Fix Qwen2.5 Chat Template error: evaluateUnaryExpression Unknown argument type: UndefinedValue https://github.com/maiqingqiang/Jinja/commit/4a6eb1a94ef54cf6a57c6325a13d73295626dd8c