### PR TITLE
Replace usage of Bundle.module to build outside SPM context

### DIFF
--- a/Sources/Hub/Hub.swift
+++ b/Sources/Hub/Hub.swift
@@ -202,7 +202,8 @@ public class LanguageModelConfigurationFromHub {
     }
 
     static func fallbackTokenizerConfig(for modelType: String) -> Config? {
-        guard let url = Bundle.module.url(forResource: "\(modelType)_tokenizer_config", withExtension: "json") else { return nil }
+        let bundle = Bundle(for: self)
+        guard let url = bundle.url(forResource: "\(modelType)_tokenizer_config", withExtension: "json") else { return nil }
         do {
             let data = try Data(contentsOf: url)
             let parsed = try JSONSerialization.jsonObject(with: data, options: [])


### PR DESCRIPTION
Replacing `Bundle.module` with `Bundle(for: self)` to accommodate building transformers outside SPM context.