### PR TITLE
Support new merges serialization

### DIFF
--- a/Sources/Tokenizers/BPETokenizer.swift
+++ b/Sources/Tokenizers/BPETokenizer.swift
@@ -50,8 +50,9 @@ class BPETokenizer: PreTrainedTokenizerModel {
     static func mergesFromConfig(_ config: Config?) -> [[String]]? {
         guard let config = config else { return nil }
 
-        // New format (pushed with tokenizers >= 0.20): each merge is a list of 2 items
+        // New format (pushed with tokenizers >= 0.20.0): each merge is a list of 2 items
         if let merges = config.value as? [[String]] { return merges }
+
         // Legacy: each merge is a string
         guard let merges = config.value as? [String] else { return nil }
         return merges.map { mergeString in


### PR DESCRIPTION
Introduced in tokenizers 0.20.0. Tokenizers saved with it will create a `merges` property where each merge is an array of two items, instead of a string with a separator.