### PR TITLE
Update Jinja version to fix build on Xcode >= 16.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.4.0"),
-        .package(url: "https://github.com/maiqingqiang/Jinja", from: "1.0.0")
+        .package(url: "https://github.com/maiqingqiang/Jinja", from: "1.0.6")
     ],
     targets: [
         .executableTarget(


### PR DESCRIPTION
Jinja version was updated to 1.0.6 after this PR was merged https://github.com/maiqingqiang/Jinja/pull/5

This should fix build on Xcode >= 16.0. Example of failing builds:
https://swiftpackageindex.com/builds/F6095453-30D2-4175-8FBF-E28D9AD440FE
https://swiftpackageindex.com/builds/EF6D0DF9-542C-47AE-9D1A-D16C8790BF71

