### PR TITLE
remove jinja dependency and chat templates

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,6 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.4.0"),
-        .package(url: "https://github.com/maiqingqiang/Jinja", from: "1.0.6")
     ],
     targets: [
         .executableTarget(
@@ -23,7 +22,7 @@ let package = Package(
                 .product(name: "ArgumentParser", package: "swift-argument-parser")]),
         .executableTarget(name: "HubCLI", dependencies: ["Hub", .product(name: "ArgumentParser", package: "swift-argument-parser")]),
         .target(name: "Hub", resources: [.process("FallbackConfigs")]),
-        .target(name: "Tokenizers", dependencies: ["Hub", .product(name: "Jinja", package: "Jinja")]),
+        .target(name: "Tokenizers", dependencies: ["Hub"]),
         .target(name: "TensorUtils"),
         .target(name: "Generation", dependencies: ["Tokenizers", "TensorUtils"]),
         .target(name: "Models", dependencies: ["Tokenizers", "Generation", "TensorUtils"]),

--- a/Sources/Tokenizers/Tokenizer.swift
+++ b/Sources/Tokenizers/Tokenizer.swift
@@ -7,7 +7,6 @@
 
 import Hub
 import Foundation
-import Jinja
 
 enum TokenizerError: Error {
     case missingConfig
@@ -124,25 +123,6 @@ public protocol Tokenizer {
     var eosTokenId: Int? { get }
     var unknownToken: String? { get }
     var unknownTokenId: Int? { get }
-
-    /// The appropriate chat template is selected from the tokenizer config
-    func applyChatTemplate(messages: [[String: String]]) throws -> [Int]
-
-    /// The chat template is provided as a string literal or specified by name
-    func applyChatTemplate(messages: [[String: String]], chatTemplate: ChatTemplateArgument) throws -> [Int]
-
-    /// The chat template is provided as a string literal
-    func applyChatTemplate(messages: [[String: String]], chatTemplate: String) throws -> [Int]
-
-    func applyChatTemplate(
-        messages: [[String: String]],
-        /// A chat template can optionally be provided or specified by name when several templates are included in the tokenizer config. Normally this is not necessary.
-        chatTemplate: ChatTemplateArgument?,
-        addGenerationPrompt: Bool,
-        truncation: Bool,
-        maxLength: Int?,
-        tools: [[String: Any]]?
-    ) throws -> [Int]
 }
 
 public extension Tokenizer {
@@ -329,97 +309,6 @@ public class PreTrainedTokenizer: Tokenizer {
 
     public func convertIdToToken(_ id: Int) -> String? {
         model.convertIdToToken(id)
-    }
-
-    public func applyChatTemplate(messages: [[String: String]]) throws -> [Int] {
-        try applyChatTemplate(messages: messages, addGenerationPrompt: true)
-    }
-
-    public func applyChatTemplate(messages: [[String: String]], chatTemplate: ChatTemplateArgument) throws -> [Int] {
-        try applyChatTemplate(messages: messages, chatTemplate: chatTemplate, addGenerationPrompt: true)
-    }
-
-    public func applyChatTemplate(messages: [[String: String]], chatTemplate: String) throws -> [Int] {
-        try applyChatTemplate(messages: messages, chatTemplate: .literal(chatTemplate), addGenerationPrompt: true)
-    }
-
-    public func applyChatTemplate(
-        messages: [[String: String]],
-        chatTemplate: ChatTemplateArgument? = nil,
-        addGenerationPrompt: Bool = false,
-        truncation: Bool = false,
-        maxLength: Int? = nil,
-        /// A list of tools (callable functions) that will be accessible to the model. If the template does not
-        /// support function calling, this argument will have no effect. Each tool should be passed as a JSON Schema,
-        /// giving the name, description and argument types for the tool. See the
-        /// [chat templating guide](https://huggingface.co/docs/transformers/main/en/chat_templating#automated-function-conversion-for-tool-use)
-        /// for more information.
-        /// Note: tool calling is not supported yet, it will be available in a future update.
-        tools: [[String: Any]]? = nil
-    ) throws -> [Int] {
-        var selectedChatTemplate: String?
-        if let chatTemplate, case .literal(let template) = chatTemplate {
-            // Use chat template from argument
-            selectedChatTemplate = template
-        } else if let valueFromConfig = tokenizerConfig.chatTemplate {
-            if let arrayValue = valueFromConfig.arrayValue {
-                // If the config specifies a list of chat templates, convert them to a dictionary
-                let templateDict = Dictionary<String, String>(uniqueKeysWithValues: arrayValue.compactMap { item in
-                    guard let name = item.name?.stringValue, let template = item.template?.stringValue else {
-                        return nil
-                    }
-                    return (name, template)
-                })
-                if let chatTemplate, case .name(let name) = chatTemplate {
-                    // Select chat template from config by name
-                    if let matchingDictEntry = templateDict[name] {
-                        selectedChatTemplate = matchingDictEntry
-                    } else {
-                        throw TokenizerError.chatTemplate("No chat template named \"\(name)\" was found in the tokenizer config")
-                    }
-                } else if let tools, !tools.isEmpty, let toolUseTemplate = templateDict["tool_use"] {
-                    // Use tool use chat template from config
-                    selectedChatTemplate = toolUseTemplate
-                } else if let defaultChatTemplate = templateDict["default"] {
-                    // Use default chat template from config
-                    selectedChatTemplate = defaultChatTemplate
-                }
-            } else if let stringValue = valueFromConfig.stringValue {
-                // Use chat template from config
-                selectedChatTemplate = stringValue
-            }
-        }
-
-        guard let selectedChatTemplate else {
-            throw TokenizerError.chatTemplate("No chat template was specified")
-        }
-
-        let template = try Template(selectedChatTemplate)
-        var context: [String: Any] = [
-            "messages": messages,
-            "add_generation_prompt": addGenerationPrompt
-            // TODO: Add `tools` entry when support is added in Jinja
-            // "tools": tools
-        ]
-
-        // TODO: maybe keep NSString here
-        for (key, value) in tokenizerConfig.dictionary as [String : Any] {
-            if specialTokenAttributes.contains(key), !(value is NSNull) {
-                context[key] = value
-            }
-        }
-
-        let rendered = try template.render(context)
-        var encodedTokens = encode(text: rendered, addSpecialTokens: false)
-        var maxLength = maxLength ?? encodedTokens.count
-        maxLength = min(maxLength, tokenizerConfig.modelMaxLength?.intValue ?? maxLength)
-        if encodedTokens.count > maxLength {
-            if truncation {
-                encodedTokens = Array(encodedTokens.prefix(maxLength))
-            }
-        }
-
-        return encodedTokens
     }
 }
 


### PR DESCRIPTION
This PR removes Jinja and the related chat template functions so that WhisperKit does not depend on them. 

I ran the debug regression tests on WhisperKit-internal to verify functionality locally after these changes. Once this PR is merged, I will update WhisperKit-internal to use this repository as a dependency instead of pointing to local package files. This change will address the issue causing the Development Tests for the WhisperKit-internal Checksum [PR](https://github.com/argmaxinc/WhisperKit-internal/pull/17) to fail, which is due to "swift-transformers" not being found during the build process.