### PR TITLE
Add get_hf_file_metadata Functionality

### DIFF
--- a/Sources/Hub/HubApi.swift
+++ b/Sources/Hub/HubApi.swift
@@ -237,9 +237,13 @@ public extension HubApi {
     }
     
     func getHfFileMetadata(
-        url: URL,
+        fileURL: URL,
         timeout: TimeInterval? = 10
     ) async throws -> HfFileMetadata {
+        guard let url = URL(string: self.endpoint.appending(fileURL.path)) else {
+            throw Hub.HubClientError.unexpectedError
+        }
+        
         var request = URLRequest(url: url)
         request.httpMethod = "HEAD"
         
@@ -313,8 +317,8 @@ public extension Hub {
         return try await HubApi(hfToken: token).whoami()
     }
     
-    static func getHfFileMetadata(url: URL, timeout: TimeInterval?) async throws -> HubApi.HfFileMetadata {
-        return try await HubApi.shared.getHfFileMetadata(url: url, timeout: timeout)
+    static func getHfFileMetadata(fileURL: URL, timeout: TimeInterval?) async throws -> HubApi.HfFileMetadata {
+        return try await HubApi.shared.getHfFileMetadata(fileURL: fileURL, timeout: timeout)
     }
 }
 

--- a/Sources/Hub/HubApi.swift
+++ b/Sources/Hub/HubApi.swift
@@ -237,13 +237,9 @@ public extension HubApi {
     }
     
     func getHfFileMetadata(
-        fileURL: URL,
+        url: URL,
         timeout: TimeInterval? = 10
     ) async throws -> HfFileMetadata {
-        guard let url = URL(string: self.endpoint.appending(fileURL.path)) else {
-            throw Hub.HubClientError.unexpectedError
-        }
-        
         var request = URLRequest(url: url)
         request.httpMethod = "HEAD"
         
@@ -269,12 +265,12 @@ public extension HubApi {
         let headers = httpResponse.allHeaderFields
         
         return HfFileMetadata(
-            commitHash: headers["x-repo-commit"] as? String,
+            commitHash: headers["X-Repo-Commit"] as? String,
             etag: normalizeEtag(
-                (headers["x-linked-etag"] as? String) ?? (headers["Etag"] as? String)
+                (headers["X-Linked-Etag"] as? String) ?? (headers["Etag"] as? String)
             ),
             location: (headers["Location"] as? String) ?? url.absoluteString,
-            size: Int(headers["x-linked-size"] as? String ?? headers["Content-Length"] as? String ?? "")
+            size: Int(headers["X-Linked-Size"] as? String ?? headers["Content-Length"] as? String ?? "")
         )
     }
 }
@@ -317,8 +313,8 @@ public extension Hub {
         return try await HubApi(hfToken: token).whoami()
     }
     
-    static func getHfFileMetadata(fileURL: URL, timeout: TimeInterval?) async throws -> HubApi.HfFileMetadata {
-        return try await HubApi.shared.getHfFileMetadata(fileURL: fileURL, timeout: timeout)
+    static func getHfFileMetadata(fileURL: URL, timeout: TimeInterval? = 10) async throws -> HubApi.HfFileMetadata {
+        return try await HubApi.shared.getHfFileMetadata(url: fileURL, timeout: timeout)
     }
 }
 

--- a/Tests/HubTests/HubApiTests.swift
+++ b/Tests/HubTests/HubApiTests.swift
@@ -95,7 +95,7 @@ class HubApiTests: XCTestCase {
             
             XCTAssertEqual(metadata.commitHash, nil)
             XCTAssertEqual(metadata.etag, "1081d-mpal1Yulao9aaX7RagptBneDspU")
-            XCTAssertEqual(metadata.location, "https://huggingface.co/coreml-projects/Llama-2-7b-chat-coreml/blob/main/config.json")
+            XCTAssertEqual(metadata.location, url?.absoluteString)
             XCTAssertEqual(metadata.size, 67613)
         } catch {
             XCTFail("\(error)")

--- a/Tests/HubTests/HubApiTests.swift
+++ b/Tests/HubTests/HubApiTests.swift
@@ -88,13 +88,13 @@ class HubApiTests: XCTestCase {
         }
     }
     
-    func testGetHfFileMetadata() async throws {
+    func testGetFileMetadata() async throws {
         do {
             let url = URL(string: "https://huggingface.co/coreml-projects/Llama-2-7b-chat-coreml/blob/main/config.json")
-            let metadata = try await Hub.getHfFileMetadata(fileURL: url!)
+            let metadata = try await Hub.getFileMetadata(fileURL: url!)
             
             XCTAssertEqual(metadata.commitHash, nil)
-            XCTAssertEqual(metadata.etag, "1081d-mpal1Yulao9aaX7RagptBneDspU")
+            XCTAssertTrue(metadata.etag != nil && metadata.etag!.hasPrefix("1081d-"))
             XCTAssertEqual(metadata.location, url?.absoluteString)
             XCTAssertEqual(metadata.size, 67613)
         } catch {

--- a/Tests/HubTests/HubApiTests.swift
+++ b/Tests/HubTests/HubApiTests.swift
@@ -87,6 +87,20 @@ class HubApiTests: XCTestCase {
             XCTFail("\(error)")
         }
     }
+    
+    func testGetHfFileMetadata() async throws {
+        do {
+            let url = URL(string: "https://huggingface.co/coreml-projects/Llama-2-7b-chat-coreml/blob/main/config.json")
+            let metadata = try await Hub.getHfFileMetadata(fileURL: url!)
+            
+            XCTAssertEqual(metadata.commitHash, nil)
+            XCTAssertEqual(metadata.etag, "1081d-mpal1Yulao9aaX7RagptBneDspU")
+            XCTAssertEqual(metadata.location, "https://huggingface.co/coreml-projects/Llama-2-7b-chat-coreml/blob/main/config.json")
+            XCTAssertEqual(metadata.size, 67613)
+        } catch {
+            XCTFail("\(error)")
+        }
+    }
 }
 
 class SnapshotDownloadTests: XCTestCase {

--- a/Tests/HubTests/HubApiTests.swift
+++ b/Tests/HubTests/HubApiTests.swift
@@ -108,9 +108,9 @@ class HubApiTests: XCTestCase {
             let metadata = try await Hub.getFileMetadata(fileURL: url!)
             
             XCTAssertEqual(metadata.commitHash, nil)
-            XCTAssertTrue(metadata.etag != nil && metadata.etag!.hasPrefix("1081d-"))
+            XCTAssertTrue(metadata.etag != nil && metadata.etag!.hasPrefix("10841-"))
             XCTAssertEqual(metadata.location, url?.absoluteString)
-            XCTAssertEqual(metadata.size, 67613)
+            XCTAssertEqual(metadata.size, 67649)
         } catch {
             XCTFail("\(error)")
         }

--- a/Tests/HubTests/HubApiTests.swift
+++ b/Tests/HubTests/HubApiTests.swift
@@ -90,6 +90,20 @@ class HubApiTests: XCTestCase {
     
     func testGetFileMetadata() async throws {
         do {
+            let url = URL(string: "https://huggingface.co/coreml-projects/Llama-2-7b-chat-coreml/resolve/main/config.json")
+            let metadata = try await Hub.getFileMetadata(fileURL: url!)
+            
+            XCTAssertNotNil(metadata.commitHash)
+            XCTAssertNotNil(metadata.etag)
+            XCTAssertEqual(metadata.location, url?.absoluteString)
+            XCTAssertEqual(metadata.size, 163)
+        } catch {
+            XCTFail("\(error)")
+        }
+    }
+    
+    func testGetFileMetadataBlobPath() async throws {
+        do {
             let url = URL(string: "https://huggingface.co/coreml-projects/Llama-2-7b-chat-coreml/blob/main/config.json")
             let metadata = try await Hub.getFileMetadata(fileURL: url!)
             
@@ -99,6 +113,35 @@ class HubApiTests: XCTestCase {
             XCTAssertEqual(metadata.size, 67613)
         } catch {
             XCTFail("\(error)")
+        }
+    }
+    
+    func testGetFileMetadataWithRevision() async throws {
+        do {
+            let revision = "f2c752cfc5c0ab6f4bdec59acea69eefbee381c2"
+            let url = URL(string: "https://huggingface.co/julien-c/dummy-unknown/resolve/\(revision)/config.json")
+            let metadata = try await Hub.getFileMetadata(fileURL: url!)
+            
+            XCTAssertEqual(metadata.commitHash, revision)
+            XCTAssertNotNil(metadata.etag)
+            XCTAssertGreaterThan(metadata.etag!.count, 0)
+            XCTAssertEqual(metadata.location, url?.absoluteString)
+            XCTAssertEqual(metadata.size, 851)
+        } catch {
+            XCTFail("\(error)")
+        }
+    }
+
+    func testGetFileMetadataWithBlobSearch() async throws {
+        let repo = "coreml-projects/Llama-2-7b-chat-coreml"
+        let metadataFromBlob = try await Hub.getFileMetadata(from: repo, matching: "*.json").sorted { $0.location < $1.location }
+        let files = try await Hub.getFilenames(from: repo, matching: "*.json").sorted()
+        for (metadata, file) in zip(metadataFromBlob, files) {
+            XCTAssertNotNil(metadata.commitHash)
+            XCTAssertNotNil(metadata.etag)
+            XCTAssertGreaterThan(metadata.etag!.count, 0)
+            XCTAssertTrue(metadata.location.contains(file))
+            XCTAssertGreaterThan(metadata.size!, 0)
         }
     }
 }


### PR DESCRIPTION
This PR brings over the [get_hf_file_metadata](https://github.com/huggingface/huggingface_hub/blob/fcecbb8598cae573b0a557492b6d7e1b1701ffa9/src/huggingface_hub/file_download.py#L1246) function from huggingface_hub Python library.

This is useful for a couple reasons:

- Check if local file's content size matches the remote file's to verify integrity of download
- To let us know if the remote file changed based on commit hash