### PR TITLE
Expose repo id/type

### DIFF
--- a/Sources/Hub/Hub.swift
+++ b/Sources/Hub/Hub.swift
@@ -24,8 +24,8 @@ public extension Hub {
     }
     
     struct Repo {
-        let id: String
-        let type: RepoType
+        public let id: String
+        public let type: RepoType
         
         public init(id: String, type: RepoType = .models) {
             self.id = id


### PR DESCRIPTION
Wanted to store a `Repo` and later read the `id`.

* [`Sources/Hub/Hub.swift`](diffhunk://#diff-0179f97592f62773ec1ea33daebd55a99c24df11817be7cd0b57db10be7e2b0fL27-R28): Changed the access level of `id` and `type` properties from internal to public.