### PR TITLE
Add skipSpecialTokens option to Tokenizer.decode

### DIFF
--- a/Tests/TokenizersTests/TokenizerTests.swift
+++ b/Tests/TokenizersTests/TokenizerTests.swift
@@ -218,6 +218,10 @@ class TokenizerTester {
                 tokenizer.decode(tokens: edgeCase.encoded.input_ids),
                 edgeCase.decoded_with_special
             )
+            XCTAssertEqual(
+                tokenizer.decode(tokens: edgeCase.encoded.input_ids, skipSpecialTokens: true),
+                edgeCase.decoded_without_special
+            )
         }
     }
     


### PR DESCRIPTION
Merry Christmas! 🎅

This PR adds a `skipSpecialTokens` option to `Tokenizer.decode`. Default arguments can't be used since Tokenizer is a protocol, so I added another function, leaving `func decode(tokens:)` as a convenience / maintain source compatibility.