### PR TITLE
Fix tokenizer for Phi 4

### DIFF
--- a/Sources/Tokenizers/Tokenizer.swift
+++ b/Sources/Tokenizers/Tokenizer.swift
@@ -313,7 +313,9 @@ public class PreTrainedTokenizer: Tokenizer {
 
     /// Main entry point
     public func encode(text: String, addSpecialTokens: Bool = true) -> [Int] {
-        return postProcess(tokenize(text: text), addSpecialTokens: addSpecialTokens).map { model.convertTokenToId($0)! }
+      let tokenizedText = tokenize(text: text)
+      print("::: Tokenized text: \(tokenizedText)")
+        return postProcess(tokenizedText, addSpecialTokens: addSpecialTokens).map { model.convertTokenToId($0)! }
     }
 
     public func encode(text: String) -> [Int] {
@@ -345,7 +347,7 @@ public class PreTrainedTokenizer: Tokenizer {
     }
 
     public func applyChatTemplate(messages: [[String: String]]) throws -> [Int] {
-        try applyChatTemplate(messages: messages, addGenerationPrompt: true)
+        return try applyChatTemplate(messages: messages, addGenerationPrompt: true)
     }
 
     public func applyChatTemplate(messages: [[String: String]], chatTemplate: ChatTemplateArgument) throws -> [Int] {
@@ -407,6 +409,9 @@ public class PreTrainedTokenizer: Tokenizer {
             throw TokenizerError.chatTemplate("No chat template was specified")
         }
 
+      print("::: Chat template:")
+      print(selectedChatTemplate)
+
         let template = try Template(selectedChatTemplate)
         var context: [String: Any] = [
             "messages": messages,
@@ -423,6 +428,10 @@ public class PreTrainedTokenizer: Tokenizer {
         }
 
         let rendered = try template.render(context)
+
+      print("::: Prompt rendered with template:")
+      print(rendered)
+
         var encodedTokens = encode(text: rendered, addSpecialTokens: false)
         var maxLength = maxLength ?? encodedTokens.count
         maxLength = min(maxLength, tokenizerConfig.modelMaxLength?.intValue ?? maxLength)


### PR DESCRIPTION
Phi 4 is not behaving correctly, as you can see from this debug output:

```
::: Prompt rendered with template:
<|im_start|>user<|im_sep|>What is the difference between a fruit and a vegetable?<|im_end|><|im_start|>assistant<|im_sep|>

::: Tokenized text: ["<|im_start|>", "<|im_sep|>", "<|im_end|>", "<|im_start|>", "<|im_sep|>"]

::: Prompt tokens decoded:
<|im_start|><|im_sep|><|im_end|><|im_start|><|im_sep|>
```

Demo with LLMEval here: https://github.com/DePasqualeOrg/mlx-swift-examples/tree/test-phi-4

@pcuenca, it looks like the tokenizer is only processing the special tokens and ignoring the content between them. Do you have any idea why this might be happening? 