### PR TITLE
Added Hub and Tokenizers libraries.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -9,7 +9,7 @@ let package = Package(
     products: [
         .library(name: "Transformers", targets: ["Tokenizers", "Generation", "Models"]),
         .library(name: "Hub", targets: ["Hub"]),
-        .library(name: "Tokenizers", targets: ["Tokenizers", "Models"]),
+        .library(name: "Tokenizers", targets: ["Tokenizers"]),
         .executable(name: "transformers", targets: ["TransformersCLI"]),
         .executable(name: "hub-cli", targets: ["HubCLI"]),
     ],

--- a/Package.swift
+++ b/Package.swift
@@ -9,7 +9,7 @@ let package = Package(
     products: [
         .library(name: "Transformers", targets: ["Tokenizers", "Generation", "Models"]),
         .library(name: "Hub", targets: ["Hub"]),
-        .library(name: "Tokenizers", targets: ["Tokenizers"]),
+        .library(name: "Tokenizers", targets: ["Tokenizers", "Models"]),
         .executable(name: "transformers", targets: ["TransformersCLI"]),
         .executable(name: "hub-cli", targets: ["HubCLI"]),
     ],

--- a/Package.swift
+++ b/Package.swift
@@ -9,6 +9,7 @@ let package = Package(
     products: [
         .library(name: "Transformers", targets: ["Tokenizers", "Generation", "Models"]),
         .library(name: "Hub", targets: ["Hub"]),
+        .library(name: "Tokenizers", targets: ["Tokenizers"]),
         .executable(name: "transformers", targets: ["TransformersCLI"]),
         .executable(name: "hub-cli", targets: ["HubCLI"]),
     ],

--- a/Package.swift
+++ b/Package.swift
@@ -8,6 +8,7 @@ let package = Package(
     platforms: [.iOS(.v16), .macOS(.v13)],
     products: [
         .library(name: "Transformers", targets: ["Tokenizers", "Generation", "Models"]),
+        .library(name: "Hub", targets: ["Hub"]),
         .executable(name: "transformers", targets: ["TransformersCLI"]),
         .executable(name: "hub-cli", targets: ["HubCLI"]),
     ],

--- a/Tests/TokenizersTests/TokenizerTests.swift
+++ b/Tests/TokenizersTests/TokenizerTests.swift
@@ -9,7 +9,6 @@
 import XCTest
 import Hub
 @testable import Tokenizers
-@testable import Models
 
 class GPT2TokenizerTests: TokenizerTests {
     override class var hubModelName: String? { "distilgpt2" }
@@ -277,7 +276,8 @@ class TokenizerTester {
             guard _tokenizer == nil else { return _tokenizer! }
             do {
                 guard let tokenizerConfig = try await configuration!.tokenizerConfig else {
-                    throw TokenizerError.tokenizerConfigNotFound
+                    XCTFail("Cannot retrieve Tokenizer configuration")
+                    return nil 
                 }
                 let tokenizerData = try await configuration!.tokenizerData
                 _tokenizer = try AutoTokenizer.from(tokenizerConfig: tokenizerConfig, tokenizerData: tokenizerData)


### PR DESCRIPTION
Added `Hub` and `Tokenizers` as separate library products in `Package.swift`. This change should enable selective compilation of specific components while maintaining a single project structure.

### Usage Example

Usage is pretty simple, I created an external project and all that was needed was to edit `Package.swift`. 

Specifically, Add the package dependency:
```
dependencies: [
        .package(url: "https://github.com/huggingface/swift-transformers", branch: "main")
    ],
```

Then import specific products as dependencies of the desired target:
```
targets: [
        .target(
            ...
            dependencies: [
                .product(name: "Hub", package: "swift-transformers")
            ]
        ),
```

### Testing

In the external project I copied and ran all the Tokenizer, and Hub tests from swift-transformers.

- Successfully imported both products
- All tests passed:
    - Hub: 14 tests passed in 9.822s
    - Tokenizers: 96 tests passed in 26.948s
