### PR TITLE
Make `tools` and `additionalContext` optional

### DIFF
--- a/Sources/Tokenizers/Tokenizer.swift
+++ b/Sources/Tokenizers/Tokenizer.swift
@@ -148,7 +148,10 @@ public protocol Tokenizer {
     func applyChatTemplate(messages: [Message]) throws -> [Int]
 
     /// The appropriate chat template is selected from the tokenizer config
-    func applyChatTemplate(messages: [Message], tools: [ToolSpec]) throws -> [Int]
+    func applyChatTemplate(messages: [Message], tools: [ToolSpec]?) throws -> [Int]
+
+    /// The appropriate chat template is selected from the tokenizer config
+    func applyChatTemplate(messages: [Message], tools: [ToolSpec]?, additionalContext: [String: Any]?) throws -> [Int]
 
     /// The chat template is provided as a string literal or specified by name
     func applyChatTemplate(messages: [Message], chatTemplate: ChatTemplateArgument) throws -> [Int]
@@ -400,11 +403,11 @@ public class PreTrainedTokenizer: Tokenizer {
         try applyChatTemplate(messages: messages, addGenerationPrompt: true)
     }
 
-    public func applyChatTemplate(messages: [Message], tools: [ToolSpec]) throws -> [Int] {
+    public func applyChatTemplate(messages: [Message], tools: [ToolSpec]? = nil) throws -> [Int] {
         try applyChatTemplate(messages: messages, addGenerationPrompt: true, tools: tools)
     }
 
-    public func applyChatTemplate(messages: [Message], tools: [ToolSpec], additionalContext: [String: Any]) throws
+    public func applyChatTemplate(messages: [Message], tools: [ToolSpec]? = nil, additionalContext: [String: Any]? = nil) throws
         -> [Int]
     {
         try applyChatTemplate(


### PR DESCRIPTION
I'm finishing up the [tools example](https://github.com/ml-explore/mlx-swift-examples/pull/174) in mlx-swift-examples, and it occurred to me that `tools` and `additionalContext` should probably be optional. Otherwise you might want to pass in an empty array, and that could affect how the template renders the prompt if it only checks if `tools` is defined, and not if `tools` is empty. What do you think, @pcuenca?