### PR TITLE
Make downloads resumable across app sessions

### DIFF
--- a/Sources/Hub/Hub.swift
+++ b/Sources/Hub/Hub.swift
@@ -51,13 +51,13 @@ public extension Hub {
         }
     }
 
-    enum RepoType: String {
+    enum RepoType: String, Codable {
         case models
         case datasets
         case spaces
     }
-
-    struct Repo {
+    
+    struct Repo: Codable {
         public let id: String
         public let type: RepoType
 

--- a/Sources/Hub/HubApi.swift
+++ b/Sources/Hub/HubApi.swift
@@ -433,10 +433,7 @@ public extension HubApi {
             if FileManager.default.fileExists(atPath: incompleteFile.path) {
                 if let fileAttributes = try? FileManager.default.attributesOfItem(atPath: incompleteFile.path) {
                     resumeSize = (fileAttributes[FileAttributeKey.size] as? Int) ?? 0
-                    print("[HubApi] Found existing incomplete file for \(destination.lastPathComponent): \(resumeSize) bytes at \(incompleteFile.path)")
                 }
-            } else {
-                print("[HubApi] No existing incomplete file found for \(destination.lastPathComponent)")
             }
             
             let downloader = Downloader(
@@ -466,7 +463,6 @@ public extension HubApi {
                 return destination
             } catch {
                 // If download fails, leave the incomplete file in place for future resume
-                print("[HubApi] Download failed but incomplete file is preserved for future resume: \(error.localizedDescription)")
                 throw error
             }
             

--- a/Sources/Hub/HubApi.swift
+++ b/Sources/Hub/HubApi.swift
@@ -426,14 +426,48 @@ public extension HubApi {
             try prepareDestination()
             try prepareMetadataDestination()
 
-            let downloader = Downloader(from: source, to: destination, using: hfToken, inBackground: backgroundSession, expectedSize: remoteSize)
+            // Check for an existing incomplete file
+            let incompleteFile = Downloader.incompletePath(for: destination)
+            var resumeSize = 0
+            
+            if FileManager.default.fileExists(atPath: incompleteFile.path) {
+                if let fileAttributes = try? FileManager.default.attributesOfItem(atPath: incompleteFile.path) {
+                    resumeSize = (fileAttributes[FileAttributeKey.size] as? Int) ?? 0
+                    print("[HubApi] Found existing incomplete file for \(destination.lastPathComponent): \(resumeSize) bytes at \(incompleteFile.path)")
+                }
+            } else {
+                print("[HubApi] No existing incomplete file found for \(destination.lastPathComponent)")
+            }
+            
+            let downloader = Downloader(
+                from: source,
+                to: destination,
+                using: hfToken,
+                inBackground: backgroundSession,
+                resumeSize: resumeSize,
+                expectedSize: remoteSize
+            )
+            
             let downloadSubscriber = downloader.downloadState.sink { state in
-                if case let .downloading(progress) = state {
+                switch state {
+                case let .downloading(progress):
                     progressHandler(progress)
+                case .completed, .failed, .notStarted:
+                    break
                 }
             }
-            _ = try withExtendedLifetime(downloadSubscriber) {
-                try downloader.waitUntilDone()
+            do {
+                _ = try withExtendedLifetime(downloadSubscriber) {
+                    try downloader.waitUntilDone()
+                }
+                
+                try HubApi.shared.writeDownloadMetadata(commitHash: remoteCommitHash, etag: remoteEtag, metadataPath: metadataDestination)
+                
+                return destination
+            } catch {
+                // If download fails, leave the incomplete file in place for future resume
+                print("[HubApi] Download failed but incomplete file is preserved for future resume: \(error.localizedDescription)")
+                throw error
             }
             
             try hub.writeDownloadMetadata(commitHash: remoteCommitHash, etag: remoteEtag, metadataPath: metadataDestination)


### PR DESCRIPTION
This PR adds support for resumable downloads that persist across app sessions. When a download is interrupted, it will resume from where it left off when the app is restarted and the download is initiated. The implementation uses stable file hashing, UserDefaults for state persistence, and HTTP Range requests to efficiently download only the missing portions of files.