### PR TITLE
Added RobertaTokenizer

### DIFF
--- a/Sources/Hub/Hub.swift
+++ b/Sources/Hub/Hub.swift
@@ -100,7 +100,23 @@ public struct Config {
     }
     
     /// Tuple of token identifier and string value
-    public var tokenValue: (UInt, String)? { value as? (UInt, String) }
+    public var tokenValue: (UInt, String)? {
+        if let value = value as? (UInt, String) {
+            return value
+        }
+        if let value = value as? (String, UInt) {
+            return (value.1, value.0)
+        }
+        if let value = value as? [Any] {
+            if let stringValue = value.first as? String, let intValue = value.dropFirst().first as? UInt {
+                return (intValue, stringValue)
+            }
+            if let intValue = value.first as? UInt, let stringValue = value.dropFirst().first as? String {
+                return (intValue, stringValue)
+            }
+        }
+        return nil
+    }
 }
 
 public class LanguageModelConfigurationFromHub {

--- a/Sources/Tokenizers/Tokenizer.swift
+++ b/Sources/Tokenizers/Tokenizer.swift
@@ -90,7 +90,8 @@ struct TokenizerModel {
         "WhisperTokenizer"   : WhisperTokenizer.self,
         "CohereTokenizer"    : CohereTokenizer.self,
         "Qwen2Tokenizer"     : Qwen2Tokenizer.self,
-        "PreTrainedTokenizer": BPETokenizer.self
+        "PreTrainedTokenizer": BPETokenizer.self,
+        "RobertaTokenizer"   : BPETokenizer.self,
     ]
 
     static func unknownToken(from tokenizerConfig: Config) -> String? {

--- a/Tests/HubTests/HubTests.swift
+++ b/Tests/HubTests/HubTests.swift
@@ -118,4 +118,40 @@ class HubTests: XCTestCase {
         let vocab_dict = config.dictionary["vocab"] as! [String: Int]
         XCTAssertNotEqual(vocab_dict.count, 2)
     }
+
+    func testConfigTokenValue() throws {
+        let config1 = Config(["cls": (100, "str") as (UInt, String)])
+        let tokenValue1 = config1.cls?.tokenValue
+        XCTAssertEqual(tokenValue1?.0, 100)
+        XCTAssertEqual(tokenValue1?.1, "str")
+
+        let config2 = Config(["cls": ("str", 100) as (String, UInt)])
+        let tokenValue2 = config2.cls?.tokenValue
+        XCTAssertEqual(tokenValue2?.0, 100)
+        XCTAssertEqual(tokenValue2?.1, "str")
+
+        let config3 = Config(["cls": [100 as UInt, "str" as String] as [Any]])
+        let tokenValue3 = config3.cls?.tokenValue
+        XCTAssertEqual(tokenValue3?.0, 100)
+        XCTAssertEqual(tokenValue3?.1, "str")
+
+        let config4 = Config(["cls": ["str" as String, 100 as UInt] as [Any]])
+        let tokenValue4 = config4.cls?.tokenValue
+        XCTAssertEqual(tokenValue4?.0, 100)
+        XCTAssertEqual(tokenValue4?.1, "str")
+
+        let data5 = #"{"cls": [100, "str"]}"#.data(using: .utf8)!
+        let dict5 = try JSONSerialization.jsonObject(with: data5, options: []) as! [NSString: Any]
+        let config5 = Config(dict5)
+        let tokenValue5 = config5.cls?.tokenValue
+        XCTAssertEqual(tokenValue5?.0, 100)
+        XCTAssertEqual(tokenValue5?.1, "str")
+
+        let data6 = #"{"cls": ["str", 100]}"#.data(using: .utf8)!
+        let dict6 = try JSONSerialization.jsonObject(with: data6, options: []) as! [NSString: Any]
+        let config6 = Config(dict6)
+        let tokenValue6 = config6.cls?.tokenValue
+        XCTAssertEqual(tokenValue6?.0, 100)
+        XCTAssertEqual(tokenValue6?.1, "str")
+    }
 }

--- a/Tests/TokenizersTests/TokenizerTests.swift
+++ b/Tests/TokenizersTests/TokenizerTests.swift
@@ -212,6 +212,34 @@ class BertSpacesTests: XCTestCase {
     }
 }
 
+class RobertaTests: XCTestCase {
+    func testEncodeDecode() async throws {
+        guard let tokenizer = try await AutoTokenizer.from(pretrained: "ibm-granite/granite-embedding-30m-english") as? PreTrainedTokenizer else {
+            XCTFail()
+            return
+        }
+
+        XCTAssertEqual(tokenizer.tokenize(text: "l'eure"), ["l", "'", "e", "ure"])
+        XCTAssertEqual(tokenizer.encode(text: "l'eure"), [0, 462, 108, 242, 2407, 2])
+        XCTAssertEqual(tokenizer.decode(tokens: tokenizer.encode(text: "l'eure"), skipSpecialTokens: true), "l'eure")
+
+        XCTAssertEqual(tokenizer.tokenize(text: "mąka"), ["m", "Ä", "ħ", "ka"])
+        XCTAssertEqual(tokenizer.encode(text: "mąka"), [0, 119, 649, 5782, 2348, 2])
+
+        XCTAssertEqual(tokenizer.tokenize(text: "département"), ["d", "Ã©", "part", "ement"])
+        XCTAssertEqual(tokenizer.encode(text: "département"), [0, 417, 1140, 7755, 6285, 2])
+
+        XCTAssertEqual(tokenizer.tokenize(text: "Who are you?"), ["Who", "Ġare", "Ġyou", "?"])
+        XCTAssertEqual(tokenizer.encode(text: "Who are you?"), [0, 12375, 32, 47, 116, 2])
+
+        XCTAssertEqual(tokenizer.tokenize(text: " Who are you? "), ["ĠWho", "Ġare", "Ġyou", "?", "Ġ"])
+        XCTAssertEqual(tokenizer.encode(text: " Who are you? "), [0, 3394, 32, 47, 116, 1437, 2])
+
+        XCTAssertEqual(tokenizer.tokenize(text: "<s>Who are you?</s>"), ["<s>", "Who", "Ġare", "Ġyou", "?", "</s>"])
+        XCTAssertEqual(tokenizer.encode(text: "<s>Who are you?</s>"), [0, 0, 12375, 32, 47, 116, 2, 2])
+    }
+}
+
 
 struct EncodedTokenizerSamplesDataset: Decodable {
     let text: String


### PR DESCRIPTION
This PR adds `RobertaTokenizer`.

It was tested against the python `transformers` implementation with the following code:

```python
from transformers import AutoTokenizer

model_path = "ibm-granite/granite-embedding-30m-english"
# tested as well with FacebookAI/roberta-base

tokenizer = AutoTokenizer.from_pretrained(model_path)
assert tokenizer.tokenize("l'eure") == ["l", "'", "e", "ure"]
result = tokenizer(["l'eure"])
assert result['input_ids'][0] == [0, 462, 108, 242, 2407, 2]

assert tokenizer.tokenize("mąka") == ["m", "Ä", "ħ", "ka"]
result = tokenizer(["mąka"])
assert result['input_ids'][0] == [0, 119, 649, 5782, 2348, 2]

assert tokenizer.tokenize("département") == ["d", "Ã©", "part", "ement"]
result = tokenizer(["département"])
assert result['input_ids'][0] == [0, 417, 1140, 7755, 6285, 2]

assert tokenizer.tokenize("Who are you?") == ["Who", "Ġare", "Ġyou", "?"]
result = tokenizer(["Who are you?"])
assert result['input_ids'][0] == [0, 12375, 32, 47, 116, 2]

assert tokenizer.tokenize(" Who are you? ") == ["ĠWho", "Ġare", "Ġyou", "?", "Ġ"]
result = tokenizer([" Who are you? "])
assert result['input_ids'][0] == [0, 3394, 32, 47, 116, 1437, 2]

assert tokenizer.tokenize("<s>Who are you?</s>") == ["<s>", "Who", "Ġare", "Ġyou", "?", "</s>"]
result = tokenizer(["<s>Who are you?</s>"])
assert result['input_ids'][0] == [0, 0, 12375, 32, 47, 116, 2, 2]
```