### PR TITLE
Swift 6 compatible Hub package 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ DerivedData/
 .swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
 .netrc
 .idea
+.index-build
+*.out

--- a/Package.swift
+++ b/Package.swift
@@ -13,22 +13,24 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-argument-parser.git", .upToNextMinor(from: "1.4.0")),
-        .package(url: "https://github.com/johnmai-dev/Jinja", .upToNextMinor(from: "1.1.0"))
+        .package(url: "https://github.com/apple/swift-collections.git", .upToNextMinor(from: "1.1.4")),
+        .package(url: "https://github.com/johnmai-dev/Jinja", .upToNextMinor(from: "1.1.0")),
     ],
     targets: [
         .executableTarget(
             name: "TransformersCLI",
             dependencies: [
                 "Models", "Generation", "Tokenizers",
-                .product(name: "ArgumentParser", package: "swift-argument-parser")]),
+                .product(name: "ArgumentParser", package: "swift-argument-parser"),
+            ]),
         .executableTarget(name: "HubCLI", dependencies: ["Hub", .product(name: "ArgumentParser", package: "swift-argument-parser")]),
-        .target(name: "Hub", resources: [.process("FallbackConfigs")]),
+        .target(name: "Hub", dependencies: [.product(name: "OrderedCollections", package: "swift-collections")], resources: [.process("FallbackConfigs")]),
         .target(name: "Tokenizers", dependencies: ["Hub", .product(name: "Jinja", package: "Jinja")]),
         .target(name: "TensorUtils"),
         .target(name: "Generation", dependencies: ["Tokenizers", "TensorUtils"]),
         .target(name: "Models", dependencies: ["Tokenizers", "Generation", "TensorUtils"]),
         .testTarget(name: "TokenizersTests", dependencies: ["Tokenizers", "Models", "Hub"], resources: [.process("Resources"), .process("Vocabs")]),
-        .testTarget(name: "HubTests", dependencies: ["Hub"]),
+        .testTarget(name: "HubTests", dependencies: ["Hub", .product(name: "Jinja", package: "Jinja")]),
         .testTarget(name: "PreTokenizerTests", dependencies: ["Tokenizers", "Hub"]),
         .testTarget(name: "TensorUtilsTests", dependencies: ["TensorUtils", "Models", "Hub"], resources: [.process("Resources")]),
         .testTarget(name: "NormalizerTests", dependencies: ["Tokenizers", "Hub"]),

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.8
+// swift-tools-version: 6.0
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -22,18 +22,89 @@ let package = Package(
             dependencies: [
                 "Models", "Generation", "Tokenizers",
                 .product(name: "ArgumentParser", package: "swift-argument-parser"),
+            ],
+            swiftSettings: [
+                .swiftLanguageMode(.v5)
+            ]
+        ),
+        .executableTarget(
+            name: "HubCLI",
+            dependencies: ["Hub", .product(name: "ArgumentParser", package: "swift-argument-parser")],
+            swiftSettings: [
+                .swiftLanguageMode(.v5)
             ]),
-        .executableTarget(name: "HubCLI", dependencies: ["Hub", .product(name: "ArgumentParser", package: "swift-argument-parser")]),
-        .target(name: "Hub", dependencies: [.product(name: "OrderedCollections", package: "swift-collections")], resources: [.process("FallbackConfigs")]),
-        .target(name: "Tokenizers", dependencies: ["Hub", .product(name: "Jinja", package: "Jinja")]),
-        .target(name: "TensorUtils"),
-        .target(name: "Generation", dependencies: ["Tokenizers", "TensorUtils"]),
-        .target(name: "Models", dependencies: ["Tokenizers", "Generation", "TensorUtils"]),
-        .testTarget(name: "TokenizersTests", dependencies: ["Tokenizers", "Models", "Hub"], resources: [.process("Resources"), .process("Vocabs")]),
-        .testTarget(name: "HubTests", dependencies: ["Hub", .product(name: "Jinja", package: "Jinja")]),
-        .testTarget(name: "PreTokenizerTests", dependencies: ["Tokenizers", "Hub"]),
-        .testTarget(name: "TensorUtilsTests", dependencies: ["TensorUtils", "Models", "Hub"], resources: [.process("Resources")]),
-        .testTarget(name: "NormalizerTests", dependencies: ["Tokenizers", "Hub"]),
-        .testTarget(name: "PostProcessorTests", dependencies: ["Tokenizers", "Hub"]),
+        .target(
+            name: "Hub",
+            dependencies: [.product(name: "OrderedCollections", package: "swift-collections")],
+            resources: [.process("FallbackConfigs")],
+            swiftSettings: [
+                .swiftLanguageMode(.v6),
+                .unsafeFlags(["-strict-concurrency=complete"]),
+            ]
+        ),
+        .target(
+            name: "Tokenizers",
+            dependencies: ["Hub", .product(name: "Jinja", package: "Jinja")],
+            swiftSettings: [
+                .swiftLanguageMode(.v5)
+            ]),
+        .target(
+            name: "TensorUtils",
+            swiftSettings: [
+                .swiftLanguageMode(.v5)
+            ]),
+        .target(
+            name: "Generation",
+            dependencies: ["Tokenizers", "TensorUtils"],
+            swiftSettings: [
+                .swiftLanguageMode(.v5)
+            ]),
+        .target(
+            name: "Models",
+            dependencies: ["Tokenizers", "Generation", "TensorUtils"],
+            swiftSettings: [
+                .swiftLanguageMode(.v5)
+            ]),
+        .testTarget(
+            name: "TokenizersTests",
+            dependencies: ["Tokenizers", "Models", "Hub"],
+            resources: [.process("Resources"), .process("Vocabs")],
+            swiftSettings: [
+                .swiftLanguageMode(.v5)
+            ]
+        ),
+        .testTarget(
+            name: "HubTests",
+            dependencies: ["Hub", .product(name: "Jinja", package: "Jinja")],
+            swiftSettings: [
+                .swiftLanguageMode(.v6),
+                .unsafeFlags(["-strict-concurrency=complete"]),
+            ]
+        ),
+        .testTarget(
+            name: "PreTokenizerTests",
+            dependencies: ["Tokenizers", "Hub"],
+            swiftSettings: [
+                .swiftLanguageMode(.v5)
+            ]),
+        .testTarget(
+            name: "TensorUtilsTests",
+            dependencies: ["TensorUtils", "Models", "Hub"],
+            resources: [.process("Resources")],
+            swiftSettings: [
+                .swiftLanguageMode(.v5)
+            ]),
+        .testTarget(
+            name: "NormalizerTests",
+            dependencies: ["Tokenizers", "Hub"],
+            swiftSettings: [
+                .swiftLanguageMode(.v5)
+            ]),
+        .testTarget(
+            name: "PostProcessorTests",
+            dependencies: ["Tokenizers", "Hub"],
+            swiftSettings: [
+                .swiftLanguageMode(.v5)
+            ]),
     ]
 )

--- a/Sources/Hub/BinaryDistinct.swift
+++ b/Sources/Hub/BinaryDistinct.swift
@@ -1,0 +1,348 @@
+//
+//  BinaryDistinctString.swift
+//  swift-transformers
+//
+//  Created by Piotr Kowalczuk on 06.03.25.
+//
+
+import Foundation
+
+/// BinaryDistinctString helps to overcome limitations of both String and NSString types. Where the prior is performing unicode normalization and the following is not Sendable. For more reference [Modifying-and-Comparing-Strings](https://developer.apple.com/documentation/swift/string#Modifying-and-Comparing-Strings).
+public struct BinaryDistinctString: Equatable, Hashable, Sendable, Comparable, CustomStringConvertible, ExpressibleByStringLiteral {
+    public let value: [UInt16]
+
+    public var nsString: NSString {
+        return String(utf16CodeUnits: self.value, count: self.value.count) as NSString
+    }
+
+    public var string: String {
+        return String(self.nsString)
+    }
+
+    public var count: Int {
+        self.string.count
+    }
+
+    /// Satisfies ``CustomStringConvertible`` protocol.
+    public var description: String {
+        return self.string
+    }
+
+    public init(_ bytes: [UInt16]) {
+        self.value = bytes
+    }
+
+    public init(_ str: NSString) {
+        self.value = Array(str as String).flatMap { $0.utf16 }
+    }
+
+    public init(_ str: String) {
+        self.init(str as NSString)
+    }
+    
+    public init(_ character: BinaryDistinctCharacter) {
+        self.value = character.bytes
+    }
+    
+    public init(_ characters: [BinaryDistinctCharacter]) {
+        var data: [UInt16] = []
+        for character in characters {
+            data.append(contentsOf: character.bytes)
+        }
+        self.value = data
+    }
+
+    /// Satisfies ``ExpressibleByStringLiteral`` protocol.
+    public init(stringLiteral value: String) {
+        self.init(value)
+    }
+
+    public static func == (lhs: BinaryDistinctString, rhs: BinaryDistinctString) -> Bool {
+        return lhs.value == rhs.value
+    }
+
+    public static func < (lhs: BinaryDistinctString, rhs: BinaryDistinctString) -> Bool {
+        return lhs.value.lexicographicallyPrecedes(rhs.value)
+    }
+    
+    public static func + (lhs: BinaryDistinctString, rhs: BinaryDistinctString) -> BinaryDistinctString {
+        return BinaryDistinctString(lhs.value + rhs.value)
+    }
+    
+    public func hasPrefix(_ prefix: BinaryDistinctString) -> Bool {
+        guard prefix.value.count <= self.value.count else { return false }
+        return self.value.starts(with: prefix.value)
+    }
+
+    public func hasSuffix(_ suffix: BinaryDistinctString) -> Bool {
+        guard suffix.value.count <= self.value.count else { return false }
+        return self.value.suffix(suffix.value.count) == suffix.value
+    }
+    
+    public func lowercased() -> BinaryDistinctString {
+        .init(self.string.lowercased())
+    }
+    
+    public func replacingOccurrences(of: Self, with: Self) -> BinaryDistinctString {
+        return BinaryDistinctString(self.string.replacingOccurrences(of: of.string, with: with.string))
+    }
+}
+
+extension BinaryDistinctString {
+    public typealias Index = Int  // Treat indices as integers
+
+    public var startIndex: Index { return 0 }
+    public var endIndex: Index { return self.count }
+
+    public func index(_ i: Index, offsetBy distance: Int) -> Index {
+        let newIndex = i + distance
+        guard newIndex >= 0, newIndex <= self.count else {
+            fatalError("Index out of bounds")
+        }
+        return newIndex
+    }
+    
+    public func index(_ i: Index, offsetBy distance: Int, limitedBy limit: Index) -> Index? {
+            let newIndex = i + distance
+            return newIndex <= limit ? newIndex : nil
+        }
+}
+
+extension BinaryDistinctString: Sequence {
+    public func makeIterator() -> AnyIterator<BinaryDistinctCharacter> {
+        var iterator = self.string.makeIterator()  // Use native Swift String iterator
+
+        return AnyIterator {
+            guard let char = iterator.next() else { return nil }
+            return BinaryDistinctCharacter(char)
+        }
+    }
+}
+
+extension BinaryDistinctString {
+    public subscript(bounds: PartialRangeFrom<Int>) -> BinaryDistinctString {
+        get {
+            let validRange = bounds.lowerBound..<self.value.count  // Convert to Range<Int>
+            return self[validRange]
+        }
+    }
+
+    /// Returns a slice of the `BinaryDistinctString` while ensuring correct rune (grapheme cluster) boundaries.
+    public subscript(bounds: Range<Int>) -> BinaryDistinctString {
+        get {
+            guard bounds.lowerBound >= 0, bounds.upperBound <= self.count else {
+                fatalError("Index out of bounds")
+            }
+
+            let utf8Bytes = self.value
+            var byteIndices: [Int] = []
+
+            // Decode UTF-8 manually to find rune start positions
+            var currentByteIndex = 0
+            for (index, scalar) in self.string.unicodeScalars.enumerated() {
+                if index == bounds.lowerBound {
+                    byteIndices.append(currentByteIndex)
+                }
+                currentByteIndex += scalar.utf8.count
+                if index == bounds.upperBound - 1 {
+                    byteIndices.append(currentByteIndex)
+                    break
+                }
+            }
+
+            // Extract the byte range
+            let startByteIndex = byteIndices.first ?? 0
+            let endByteIndex = byteIndices.last ?? utf8Bytes.count
+
+            let slicedBytes = Array(utf8Bytes[startByteIndex..<endByteIndex])
+            return BinaryDistinctString(slicedBytes)
+        }
+    }
+}
+
+public struct BinaryDistinctDictionary<V>: Collection, ExpressibleByDictionaryLiteral, Sendable where V: Any, V: Sendable, V: Hashable {
+    public typealias Key = BinaryDistinctString
+
+    public var storage: [Key: V] = [:]
+
+    // MARK: - Initializers
+    public init(_ dictionary: [Key: V] = [:]) {
+        self.storage = dictionary
+    }
+
+    /// Initializes from `[String: Value]`
+    public init(_ dictionary: [String: V]) {
+        self.storage = Dictionary(uniqueKeysWithValues: dictionary.map { (BinaryDistinctString($0.key), $0.value) })
+    }
+
+    /// Initializes from `[NSString: Value]`
+    public init(_ dictionary: [NSString: V]) {
+        self.storage = Dictionary(uniqueKeysWithValues: dictionary.map { (BinaryDistinctString($0.key), $0.value) })
+    }
+
+    public init(dictionaryLiteral elements: (Key, V)...) {
+        self.storage = Dictionary(uniqueKeysWithValues: elements)
+    }
+
+    // MARK: - Dictionary Operations
+    public subscript(key: Key) -> V? {
+        get { return storage[key] }
+        set { storage[key] = newValue }
+    }
+
+    public var keys: [Key] {
+        return Array(storage.keys)
+    }
+
+    public var values: [V] {
+        return Array(storage.values)
+    }
+
+    // MARK: - Collection Conformance
+    public typealias Index = Dictionary<Key, V>.Index
+    public typealias Element = (key: Key, value: V)
+
+    public var startIndex: Index { storage.startIndex }
+    public var endIndex: Index { storage.endIndex }
+
+    public func index(after i: Index) -> Index {
+        return storage.index(after: i)
+    }
+
+    public subscript(position: Index) -> Element {
+        return storage[position]
+    }
+
+    /// Returns a new dictionary with keys mapped to the requested type.
+    public func mapKeys<K: StringConvertible>(_ type: K.Type) -> [K: V] {
+        return Dictionary(
+            uniqueKeysWithValues: storage.map {
+                (K.self == String.self ? $0.key.string as! K : $0.key.nsString as! K, $0.value)
+            }
+        )
+    }
+    
+    mutating public func removeValue(forKey key: Key) -> V? {
+        return self.storage.removeValue(forKey: key)
+    }
+
+    // MARK: - Merging Methods
+
+    /// Merges another `BinaryDistinctDictionary` into this one
+    public mutating func merge(_ other: BinaryDistinctDictionary<Value>, strategy: (V, V) -> V = { _, new in new }) {
+        self.storage.merge(other.storage, uniquingKeysWith: strategy)
+    }
+
+    /// Merges a `[String: Value]` dictionary into this one
+    public mutating func merge(_ other: [BinaryDistinctString: V], strategy: (V, V) -> V = { _, new in new }) {
+        let converted = Dictionary(uniqueKeysWithValues: other.map { ($0.key, $0.value) })
+        self.storage.merge(converted, uniquingKeysWith: strategy)
+    }
+    
+    /// Merges a `[String: Value]` dictionary into this one
+    public mutating func merge(_ other: [String: V], strategy: (V, V) -> V = { _, new in new }) {
+        let converted = Dictionary(uniqueKeysWithValues: other.map { (BinaryDistinctString($0.key), $0.value) })
+        self.storage.merge(converted, uniquingKeysWith: strategy)
+    }
+
+    /// Merges a `[NSString: Value]` dictionary into this one
+    public mutating func merge(_ other: [NSString: V], strategy: (V, V) -> V = { _, new in new }) {
+        let converted = Dictionary(uniqueKeysWithValues: other.map { (BinaryDistinctString($0.key), $0.value) })
+        self.storage.merge(converted, uniquingKeysWith: strategy)
+    }
+
+    /// Returns a new dictionary by merging `other` while keeping the current dictionary unchanged.
+    public func merging(_ other: BinaryDistinctDictionary<V>, strategy: (V, V) -> V = { _, new in new }) -> BinaryDistinctDictionary {
+        var newDict = self
+        newDict.merge(other, strategy: strategy)
+        return newDict
+    }
+
+    public func merging(_ other: [String: V], strategy: (V, V) -> V = { _, new in new }) -> BinaryDistinctDictionary {
+        var newDict = self
+        newDict.merge(other, strategy: strategy)
+        return newDict
+    }
+    
+    public func merging(_ other: [BinaryDistinctString: V], strategy: (V, V) -> V = { _, new in new }) -> BinaryDistinctDictionary {
+        var newDict = self
+        newDict.merge(other, strategy: strategy)
+        return newDict
+    }
+
+    public func merging(_ other: [NSString: V], strategy: (V, V) -> V = { _, new in new }) -> BinaryDistinctDictionary {
+        var newDict = self
+        newDict.merge(other, strategy: strategy)
+        return newDict
+    }
+
+    public func invert() -> [V: BinaryDistinctString] {
+        var inverted: [V: BinaryDistinctString] = [:]
+        for (k, v) in self.storage {
+            inverted[v] = k
+        }
+        return inverted
+    }
+}
+
+extension BinaryDistinctDictionary: Hashable {
+    public func hash(into hasher: inout Hasher) {
+        // Combine the count to distinguish between dictionaries of different sizes.
+        hasher.combine(self.storage.count)
+        // Sort keys for a deterministic order.
+        for key in self.storage.keys.sorted() {
+            hasher.combine(key)
+            if let value = self.storage[key] {
+                hasher.combine(value)
+            }
+        }
+    }
+}
+
+public protocol StringConvertible: ExpressibleByStringLiteral {}
+
+extension BinaryDistinctString: StringConvertible {}
+extension String: StringConvertible {}
+extension NSString: StringConvertible {}
+
+public struct BinaryDistinctCharacter: Equatable, Hashable, CustomStringConvertible, ExpressibleByStringLiteral {
+    let bytes: [UInt16]
+
+    public init(_ character: Character) {
+        self.bytes = Array(character.utf16)
+    }
+
+    public init(_ string: String) {
+        self.bytes = Array(string.utf16)
+    }
+
+    public init(_ nsString: NSString) {
+        let swiftString = nsString as String
+        self.bytes = Array(swiftString.utf16)
+    }
+
+    public init(bytes: [UInt16]) {
+        self.bytes = bytes
+    }
+    
+    /// Satisfies ``ExpressibleByStringLiteral`` protocol.
+    public init(stringLiteral value: String) {
+        self.init(value)
+    }
+
+    var stringValue: String? {
+        String(utf16CodeUnits: self.bytes, count: self.bytes.count)
+    }
+
+    public var description: String {
+        if let str = stringValue {
+            return "BinaryDistinctCharacter('\(str)', bytes: \(bytes.map { String(format: "0x%02X", $0) }))"
+        } else {
+            return "BinaryDistinctCharacter(invalid UTF-8, bytes: \(bytes.map { String(format: "0x%02X", $0) }))"
+        }
+    }
+
+    public static func == (lhs: BinaryDistinctCharacter, rhs: BinaryDistinctCharacter) -> Bool {
+        lhs.bytes == rhs.bytes
+    }
+}

--- a/Sources/Hub/BinaryDistinct.swift
+++ b/Sources/Hub/BinaryDistinct.swift
@@ -39,11 +39,11 @@ public struct BinaryDistinctString: Equatable, Hashable, Sendable, Comparable, C
     public init(_ str: String) {
         self.init(str as NSString)
     }
-    
+
     public init(_ character: BinaryDistinctCharacter) {
         self.value = character.bytes
     }
-    
+
     public init(_ characters: [BinaryDistinctCharacter]) {
         var data: [UInt16] = []
         for character in characters {
@@ -64,11 +64,11 @@ public struct BinaryDistinctString: Equatable, Hashable, Sendable, Comparable, C
     public static func < (lhs: BinaryDistinctString, rhs: BinaryDistinctString) -> Bool {
         return lhs.value.lexicographicallyPrecedes(rhs.value)
     }
-    
+
     public static func + (lhs: BinaryDistinctString, rhs: BinaryDistinctString) -> BinaryDistinctString {
         return BinaryDistinctString(lhs.value + rhs.value)
     }
-    
+
     public func hasPrefix(_ prefix: BinaryDistinctString) -> Bool {
         guard prefix.value.count <= self.value.count else { return false }
         return self.value.starts(with: prefix.value)
@@ -78,11 +78,11 @@ public struct BinaryDistinctString: Equatable, Hashable, Sendable, Comparable, C
         guard suffix.value.count <= self.value.count else { return false }
         return self.value.suffix(suffix.value.count) == suffix.value
     }
-    
+
     public func lowercased() -> BinaryDistinctString {
         .init(self.string.lowercased())
     }
-    
+
     public func replacingOccurrences(of: Self, with: Self) -> BinaryDistinctString {
         return BinaryDistinctString(self.string.replacingOccurrences(of: of.string, with: with.string))
     }
@@ -101,11 +101,11 @@ extension BinaryDistinctString {
         }
         return newIndex
     }
-    
+
     public func index(_ i: Index, offsetBy distance: Int, limitedBy limit: Index) -> Index? {
-            let newIndex = i + distance
-            return newIndex <= limit ? newIndex : nil
-        }
+        let newIndex = i + distance
+        return newIndex <= limit ? newIndex : nil
+    }
 }
 
 extension BinaryDistinctString: Sequence {
@@ -165,7 +165,7 @@ extension Dictionary where Key == BinaryDistinctString {
     public mutating func merge(_ other: [BinaryDistinctString: Value], strategy: (Value, Value) -> Value = { _, new in new }) {
         self.merge(other, uniquingKeysWith: strategy)
     }
-    
+
     /// Merges a `[String: Value]` dictionary into this one
     public mutating func merge(_ other: [String: Value], strategy: (Value, Value) -> Value = { _, new in new }) {
         let converted = Dictionary(uniqueKeysWithValues: other.map { (BinaryDistinctString($0.key), $0.value) })
@@ -183,7 +183,7 @@ extension Dictionary where Key == BinaryDistinctString {
         newDict.merge(other, strategy: strategy)
         return newDict
     }
-    
+
     public func merging(_ other: [BinaryDistinctString: Value], strategy: (Value, Value) -> Value = { _, new in new }) -> Self {
         var newDict = self
         newDict.merge(other, strategy: strategy)
@@ -222,7 +222,7 @@ public struct BinaryDistinctCharacter: Equatable, Hashable, CustomStringConverti
     public init(bytes: [UInt16]) {
         self.bytes = bytes
     }
-    
+
     /// Satisfies ``ExpressibleByStringLiteral`` protocol.
     public init(stringLiteral value: String) {
         self.init(value)

--- a/Sources/Hub/Config.swift
+++ b/Sources/Hub/Config.swift
@@ -64,7 +64,7 @@ public struct Config: Hashable, Sendable,
             default:
                 return false
             }
-          
+
             // right hand side might be a super set of left hand side
             switch rhs {
             case .string(let rhs):
@@ -86,7 +86,7 @@ public struct Config: Hashable, Sendable,
             default:
                 return false
             }
-            
+
             return false
         }
 
@@ -110,8 +110,7 @@ public struct Config: Hashable, Sendable,
                 return "(\(val.0), \(val.1))"
             }
         }
-        
-        
+
         public func string() -> String? {
             if case .string(let val) = self {
                 return val.string
@@ -119,7 +118,6 @@ public struct Config: Hashable, Sendable,
             return nil
         }
 
-        
         public func boolean() -> Bool? {
             if case .boolean(let val) = self {
                 return val
@@ -139,14 +137,14 @@ public struct Config: Hashable, Sendable,
             }
             return nil
         }
-        
+
         public func integer() -> Int? {
             if case .integer(let val) = self {
                 return val
             }
             return nil
         }
-        
+
         public func floating() -> Float? {
             if case .floating(let val) = self {
                 return val
@@ -301,7 +299,7 @@ public struct Config: Hashable, Sendable,
     public func string() -> String? {
         return self.value.string()
     }
-    
+
     public func string(or: String) -> String {
         if let val: String = self.string() {
             return val
@@ -344,7 +342,7 @@ public struct Config: Hashable, Sendable,
     public func boolean() -> Bool? {
         return self.value.boolean()
     }
-        
+
     public func boolean(or: Bool) -> Bool {
         if let val = self.boolean() {
             return val
@@ -365,7 +363,7 @@ public struct Config: Hashable, Sendable,
     public func integer() -> Int? {
         return self.value.integer()
     }
-    
+
     public func integer(or: Int) -> Int {
         if let val = self.integer() {
             return val
@@ -386,7 +384,7 @@ public struct Config: Hashable, Sendable,
     public func floating() -> Float? {
         return self.value.floating()
     }
-    
+
     public func floating(or: Float) -> Float {
         if let val = self.value.floating() {
             return val
@@ -564,18 +562,17 @@ public struct Config: Hashable, Sendable,
             return Config()
         }
     }
-    
-    
+
     public subscript(dynamicMember member: String) -> Config? {
         get {
             if let dict = self.dictionary() {
                 return dict[BinaryDistinctString(member)] ?? dict[self.uncamelCase(BinaryDistinctString(member))] ?? Config()
             }
 
-            return nil // backward compatibility
+            return nil  // backward compatibility
         }
-    } 
-    
+    }
+
     public subscript(dynamicMember member: String) -> Config {
         get {
             if let dict = self.dictionary() {

--- a/Sources/Hub/Config.swift
+++ b/Sources/Hub/Config.swift
@@ -574,6 +574,16 @@ public struct Config: Hashable, Sendable,
 
             return nil // backward compatibility
         }
+    } 
+    
+    public subscript(dynamicMember member: String) -> Config {
+        get {
+            if let dict = self.dictionary() {
+                return dict[BinaryDistinctString(member)] ?? dict[self.uncamelCase(BinaryDistinctString(member))] ?? Config()
+            }
+
+            return Config()
+        }
     }
 
     func uncamelCase(_ string: BinaryDistinctString) -> BinaryDistinctString {

--- a/Sources/Hub/Config.swift
+++ b/Sources/Hub/Config.swift
@@ -1,0 +1,553 @@
+//
+//  Config.swift
+//  swift-transformers
+//
+//  Created by Piotr Kowalczuk on 06.03.25.
+//
+
+//
+//  Config.swift
+//  swift-transformers
+//
+//  Created by Piotr Kowalczuk on 06.03.25.
+//
+
+import Foundation
+
+// MARK: - Configuration files with dynamic lookup
+
+public struct Config: Hashable, Sendable,
+    ExpressibleByStringLiteral,
+    ExpressibleByIntegerLiteral,
+    ExpressibleByBooleanLiteral,
+    ExpressibleByFloatLiteral,
+    ExpressibleByDictionaryLiteral,
+    ExpressibleByArrayLiteral,
+    ExpressibleByExtendedGraphemeClusterLiteral
+{
+    public typealias Key = BinaryDistinctString
+    public typealias Value = Config
+
+    private let value: Data
+
+    public enum Data: Sendable {
+        case null
+        case string(BinaryDistinctString)
+        case integer(Int)
+        case boolean(Bool)
+        case floating(Float)
+        case dictionary(BinaryDistinctDictionary<Config>)
+        case array([Config])
+        case token((UInt, BinaryDistinctString))
+
+        public static func == (lhs: Data, rhs: Data) -> Bool {
+            switch (lhs, rhs) {
+            case (.string(let lhs), .string(let rhs)):
+                return lhs == rhs
+            case (.integer(let lhs), .integer(let rhs)):
+                return lhs == rhs
+            case (.boolean(let lhs), .boolean(let rhs)):
+                return lhs == rhs
+            case (.floating(let lhs), .floating(let rhs)):
+                return lhs == rhs
+            case (.dictionary(let lhs), .dictionary(let rhs)):
+                return lhs == rhs  // TODO: ensure equatable
+            case (.array(let lhs), .array(let rhs)):
+                return lhs == rhs  // TODO: ensure equatable
+            case (.token(let lhs), .token(let rhs)):
+                return lhs == rhs  // TODO: ensure equatable
+            default:
+                return false
+            }
+        }
+    }
+
+    private init() {
+        self.value = .null
+    }
+
+    public init(_ value: BinaryDistinctString) {
+        self.value = .string(value)
+    }
+
+    public init(_ value: String) {
+        self.init(stringLiteral: value)
+    }
+
+    public init(_ value: Int) {
+        self.init(integerLiteral: value)
+    }
+
+    public init(_ value: Bool) {
+        self.init(booleanLiteral: value)
+    }
+
+    public init(_ value: Float) {
+        self.init(floatLiteral: value)
+    }
+
+    public init(_ value: [Config]) {
+        self.value = .array(value)
+    }
+
+    public init(_ values: (BinaryDistinctString, Config)...) {
+        var dict = BinaryDistinctDictionary<Config>()
+        for (key, value) in values {
+            dict[key] = value
+        }
+        self.value = .dictionary(dict)
+    }
+
+    public init(_ value: BinaryDistinctDictionary<Config>) {
+        self.value = .dictionary(value)
+    }
+
+    public init(_ dictionary: [NSString: Any]) {
+        self.value = Config.convertToBinaryDistinctKeys(dictionary as Any).value
+    }
+
+    public init(_ dictionary: [String: Config]) {
+        self.value = Config.convertToBinaryDistinctKeys(dictionary as Any).value
+    }
+
+    public init(_ dictionary: [NSString: Config]) {
+        self.value = Config.convertToBinaryDistinctKeys(dictionary as Any).value
+    }
+
+    public init(_ dictionary: [BinaryDistinctString: Config]) {
+        self.value = .dictionary(BinaryDistinctDictionary<Config>(dictionary))
+    }
+
+    public init(_ token: (UInt, BinaryDistinctString)) {
+        self.value = .token(token)
+    }
+
+    private static func convertToBinaryDistinctKeys(_ object: Any) -> Config {
+        if let dict = object as? [NSString: Any] {
+            return Config(Dictionary(uniqueKeysWithValues: dict.map { (BinaryDistinctString($0.key), convertToBinaryDistinctKeys($0.value)) }))
+        } else if let array = object as? [Any] {
+            return Config(array.map { convertToBinaryDistinctKeys($0) })
+        } else {
+            switch object {
+            case let obj as String:
+                return Config(obj)
+            case let obj as Int:
+                return Config(obj)
+            case let obj as Float:
+                return Config(obj)
+            case let obj as Bool:
+                return Config(obj)
+            case let obj as NSNumber:
+                if CFNumberIsFloatType(obj) {
+                    return Config(obj.floatValue)
+                } else {
+                    return Config(obj.intValue)
+                }
+            case _ as NSNull:
+                return Config()
+            case let obj as Config:
+                return obj
+            case let obj as (UInt, String):
+                return Config((obj.0, BinaryDistinctString(obj.1)))
+            default:
+                fatalError("unknown type: \(type(of: object)) \(object)")
+            }
+        }
+    }
+
+    // MARK: constructors
+
+    // Conformance to ExpressibleByStringLiteral
+    public init(stringLiteral value: String) {
+        self.value = .string(.init(value))
+    }
+
+    // Conformance to ExpressibleByIntegerLiteral
+    public init(integerLiteral value: Int) {
+        self.value = .integer(value)
+    }
+
+    // Conformance to ExpressibleByBooleanLiteral
+    public init(booleanLiteral value: Bool) {
+        self.value = .boolean(value)
+    }
+
+    // Conformance to ExpressibleByFloatLiteral
+    public init(floatLiteral value: Float) {
+        self.value = .floating(value)
+    }
+
+    public init(dictionaryLiteral elements: (BinaryDistinctString, Config)...) {
+        let dict = elements.reduce(into: BinaryDistinctDictionary<Config>()) { result, element in
+            result[element.0] = element.1
+        }
+
+        self.value = .dictionary(dict)
+    }
+
+    public init(arrayLiteral elements: Config...) {
+        self.value = .array(elements)
+    }
+
+    public func isNull() -> Bool {
+        if case .null = self.value {
+            return true
+        }
+        return false
+    }
+
+    // MARK: getters - string
+
+    public func get() -> String? {
+        return self.string()
+    }
+
+    public func get(or: String) -> String? {
+        return self.string(or: or)
+    }
+
+    public func string() -> String? {
+        if case .string(let val) = self.value {
+            return val.string
+        }
+        return nil
+    }
+
+    public func string(or: String) -> String {
+        if let val: String = self.string() {
+            return val
+        }
+        return or
+    }
+
+    public func get() -> BinaryDistinctString? {
+        return self.binaryDistinctString()
+    }
+
+    public func get(or: BinaryDistinctString) -> BinaryDistinctString? {
+        return self.binaryDistinctString(or: or)
+    }
+
+    public func binaryDistinctString() -> BinaryDistinctString? {
+        if case .string(let val) = self.value {
+            return val
+        }
+        return nil
+    }
+
+    public func binaryDistinctString(or: BinaryDistinctString) -> BinaryDistinctString {
+        if let val: BinaryDistinctString = self.binaryDistinctString() {
+            return val
+        }
+        return or
+    }
+
+    // MARK: getters - boolean
+
+    public func get() -> Bool? {
+        return self.boolean()
+    }
+
+    public func get(or: Bool) -> Bool? {
+        return self.boolean(or: or)
+    }
+
+    public func boolean() -> Bool? {
+        if case .boolean(let val) = self.value {
+            return val
+        }
+        if case .integer(let val) = self.value {
+            return val == 1
+        }
+        if case .string(let val) = self.value {
+            switch val.string.lowercased() {
+            case "true", "t", "1":
+                return true
+            case "false", "f", "0":
+                return false
+            default:
+                return nil
+            }
+        }
+        return nil
+    }
+
+    public func boolean(or: Bool) -> Bool {
+        if let val = self.boolean() {
+            return val
+        }
+        return or
+    }
+
+    // MARK: getters - integer
+
+    public func get() -> Int? {
+        return self.integer()
+    }
+
+    public func get(or: Int) -> Int? {
+        return self.integer(or: or)
+    }
+
+    public func integer() -> Int? {
+        if case .integer(let val) = self.value {
+            return val
+        }
+        return nil
+    }
+
+    public func integer(or: Int) -> Int? {
+        if let val = self.integer() {
+            return val
+        }
+        return or
+    }
+
+    // MARK: getters - floating
+
+    public func get() -> Float? {
+        return self.floating()
+    }
+
+    public func get(or: Float) -> Float? {
+        return self.floating(or: or)
+    }
+
+    public func floating() -> Float? {
+        if case .floating(let val) = self.value {
+            return val
+        }
+        if case .integer(let val) = self.value {
+            return Float(val)
+        }
+        return nil
+    }
+
+    public func floating(or: Float) -> Float? {
+        if let val = self.floating() {
+            return val
+        }
+        return or
+    }
+
+    // MARK: getters - dictionary
+
+    public func get() -> [BinaryDistinctString: Int]? {
+        if let dict = self.dictionary() {
+            return dict.reduce(into: [:]) { result, element in
+                if let val = element.value.integer() {
+                    result[element.key] = val
+                }
+            }
+        }
+
+        return nil
+    }
+
+    public func get() -> BinaryDistinctDictionary<Config>? {
+        return self.dictionary()
+    }
+
+    public func get(or: BinaryDistinctDictionary<Config>) -> BinaryDistinctDictionary<Config> {
+        return self.dictionary(or: or)
+    }
+
+    public func dictionary() -> BinaryDistinctDictionary<Config>? {
+        if case .dictionary(let val) = self.value {
+            return val
+        }
+        return nil
+    }
+
+    public func dictionary(or: BinaryDistinctDictionary<Config>) -> BinaryDistinctDictionary<Config> {
+        if let val = self.dictionary() {
+            return val
+        }
+        return or
+    }
+
+    // MARK: getters - array
+
+    public func get() -> [String]? {
+        if let arr = self.array() {
+            return arr.reduce(into: []) { result, element in
+                if let val: String = element.string() {
+                    result.append(val)
+                }
+            }
+        }
+
+        return nil
+    }
+
+    public func get(or: [String]) -> [String] {
+        if let arr: [String] = self.get() {
+            return arr
+        }
+
+        return or
+    }
+
+    public func get() -> [BinaryDistinctString]? {
+        if let arr = self.array() {
+            return arr.reduce(into: []) { result, element in
+                if let val: BinaryDistinctString = element.binaryDistinctString() {
+                    result.append(val)
+                }
+            }
+        }
+
+        return nil
+    }
+
+    public func get(or: [BinaryDistinctString]) -> [BinaryDistinctString] {
+        if let arr: [BinaryDistinctString] = self.get() {
+            return arr
+        }
+
+        return or
+    }
+
+    public func get() -> [Config]? {
+        return self.array()
+    }
+
+    public func get(or: [Config]) -> [Config] {
+        return self.array(or: or)
+    }
+
+    public func array() -> [Config]? {
+        if case .array(let val) = self.value {
+            return val
+        }
+        return nil
+    }
+
+    public func array(or: [Config]) -> [Config] {
+        if let val = self.array() {
+            return val
+        }
+        return or
+    }
+
+    // MARK: getters - token
+
+    public func get() -> (UInt, String)? {
+        return self.token()
+    }
+
+    public func get(or: (UInt, String)) -> (UInt, String) {
+        return self.token(or: or)
+    }
+
+    public func token() -> (UInt, String)? {
+        if case .token(let val) = self.value {
+            return (val.0, val.1.string)
+        }
+        return nil
+    }
+
+    public func token(or: (UInt, String)) -> (UInt, String) {
+        if let val = self.token() {
+            return val
+        }
+        return or
+    }
+
+    // MARK: subscript
+
+    public subscript(index: BinaryDistinctString) -> Config {
+        get {
+            if let dict = self.dictionary() {
+                return dict[index] ?? dict[self.uncamelCase(index)] ?? Config()
+            }
+
+            return Config()
+        }
+    }
+
+    func uncamelCase(_ string: BinaryDistinctString) -> BinaryDistinctString {
+        let scalars = string.string.unicodeScalars
+        var result = ""
+
+        var previousCharacterIsLowercase = false
+        for scalar in scalars {
+            if CharacterSet.uppercaseLetters.contains(scalar) {
+                if previousCharacterIsLowercase {
+                    result += "_"
+                }
+                let lowercaseChar = Character(scalar).lowercased()
+                result += lowercaseChar
+                previousCharacterIsLowercase = false
+            } else {
+                result += String(scalar)
+                previousCharacterIsLowercase = true
+            }
+        }
+
+        return BinaryDistinctString(result)
+    }
+    
+    public var description: String {
+        return "\(self.value.description)"
+    }
+}
+
+extension Config.Data: Hashable {
+    public func hash(into hasher: inout Hasher) {
+        switch self {
+        case .null:
+            hasher.combine(0)  // Discriminator for null
+        case .string(let s):
+            hasher.combine(1)  // Discriminator for string
+            hasher.combine(s)
+        case .integer(let i):
+            hasher.combine(2)  // Discriminator for integer
+            hasher.combine(i)
+        case .boolean(let b):
+            hasher.combine(3)  // Discriminator for boolean
+            hasher.combine(b)
+        case .floating(let f):
+            hasher.combine(4)  // Discriminator for floating
+            hasher.combine(f)
+        case .dictionary(let d):
+            hasher.combine(5)  // Discriminator for dict
+            d.hash(into: &hasher)
+        case .array(let a):
+            hasher.combine(6)  // Discriminator for array
+            for e in a {
+                e.hash(into: &hasher)
+            }
+        case .token(let a):
+            hasher.combine(7)  // Discriminator for token
+            a.0.hash(into: &hasher)
+            a.1.hash(into: &hasher)
+        }
+    }
+    
+    var description: String {
+        switch self {
+        case .null:
+            return "null"
+        case .string(let s):
+            return "\"\(s)\""
+        case .integer(let i):
+            return "\(i)"
+        case .boolean(let b):
+            return "\(b)"
+            case .floating(let f):
+            return "\(f)"
+        case .dictionary(let d):
+            return "\(d)"
+        case .array(let a):
+            return "[\(a.map(\.description).joined(separator: ", "))]"
+        case .token(let a):
+            return "\(a.0):\(a.1)"
+        }
+    }
+}
+
+public enum ConfigError: Error {
+    case typeMismatch(expected: Config.Data, actual: Config.Data)
+    case typeConversionFailed(value: Sendable, targetType: Sendable.Type)
+}

--- a/Sources/Hub/Downloader.swift
+++ b/Sources/Hub/Downloader.swift
@@ -6,13 +6,13 @@
 //  See LICENSE at https://github.com/huggingface/swift-coreml-diffusers/LICENSE
 //
 
-import Foundation
 import Combine
+import Foundation
 
-class Downloader: NSObject, ObservableObject {
-    private(set) var destination: URL
+final class Downloader: NSObject, Sendable, ObservableObject {
+    private let destination: URL
 
-    private let chunkSize = 10 * 1024 * 1024  // 10MB
+    private let chunkSize: Int
 
     enum DownloadState {
         case notStarted
@@ -26,24 +26,22 @@ class Downloader: NSObject, ObservableObject {
         case unexpectedError
     }
 
-    private(set) lazy var downloadState: CurrentValueSubject<DownloadState, Never> = CurrentValueSubject(.notStarted)
-    private var stateSubscriber: Cancellable?
+    private let broadcaster: Broadcaster<DownloadState> = Broadcaster<DownloadState> {
+        return DownloadState.notStarted
+    }
 
-    private var urlSession: URLSession? = nil
+    private let urlSessionConfig: URLSessionConfiguration
+    private let urlSession: UrlSessionActor = UrlSessionActor()
 
     init(
-        from url: URL,
         to destination: URL,
-        using authToken: String? = nil,
         inBackground: Bool = false,
-        resumeSize: Int = 0,
-        headers: [String: String]? = nil,
-        expectedSize: Int? = nil,
-        timeout: TimeInterval = 10,
-        numRetries: Int = 5
+        chunkSize: Int = 10 * 1024 * 1024 // 10MB
     ) {
         self.destination = destination
-        super.init()
+        self.chunkSize = chunkSize
+        
+
         let sessionIdentifier = "swift-transformers.hub.downloader"
 
         var config = URLSessionConfiguration.default
@@ -52,10 +50,23 @@ class Downloader: NSObject, ObservableObject {
             config.isDiscretionary = false
             config.sessionSendsLaunchEvents = true
         }
+        self.urlSessionConfig = config
+    }
 
-        self.urlSession = URLSession(configuration: config, delegate: self, delegateQueue: nil)
-
-        setupDownload(from: url, with: authToken, resumeSize: resumeSize, headers: headers, expectedSize: expectedSize, timeout: timeout, numRetries: numRetries)
+    func download(
+        from url: URL,
+        using authToken: String? = nil,
+        resumeSize: Int = 0,
+        headers: [String: String]? = nil,
+        expectedSize: Int? = nil,
+        timeout: TimeInterval = 10,
+        numRetries: Int = 5
+    ) async -> AsyncStream<DownloadState> {
+        await self.urlSession.set(URLSession(configuration: self.urlSessionConfig, delegate: self, delegateQueue: nil))
+        await self.setupDownload(
+            from: url, with: authToken, resumeSize: resumeSize, headers: headers, expectedSize: expectedSize, timeout: timeout, numRetries: numRetries)
+        
+        return await self.broadcaster.subscribe()
     }
 
     /// Sets up and initiates a file download operation
@@ -76,9 +87,9 @@ class Downloader: NSObject, ObservableObject {
         expectedSize: Int?,
         timeout: TimeInterval,
         numRetries: Int
-    ) {
-        downloadState.value = .downloading(0)
-        urlSession?.getAllTasks { tasks in
+    ) async {
+        await self.broadcaster.broadcast(state: .downloading(0))
+        await self.urlSession.get()?.getAllTasks { tasks in
             // If there's an existing pending background task with the same URL, let it proceed.
             if let existing = tasks.filter({ $0.originalRequest?.url == url }).first {
                 switch existing.state {
@@ -101,10 +112,10 @@ class Downloader: NSObject, ObservableObject {
                 }
             }
             var request = URLRequest(url: url)
-            
+
             // Use headers from argument else create an empty header dictionary
             var requestHeaders = headers ?? [:]
-            
+
             // Populate header auth and range fields
             if let authToken = authToken {
                 requestHeaders["Authorization"] = "Bearer \(authToken)"
@@ -112,8 +123,7 @@ class Downloader: NSObject, ObservableObject {
             if resumeSize > 0 {
                 requestHeaders["Range"] = "bytes=\(resumeSize)-"
             }
-            
-            
+
             request.timeoutInterval = timeout
             request.allHTTPHeaderFields = requestHeaders
 
@@ -123,17 +133,17 @@ class Downloader: NSObject, ObservableObject {
                     let tempURL = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
                     FileManager.default.createFile(atPath: tempURL.path, contents: nil)
                     let tempFile = try FileHandle(forWritingTo: tempURL)
-                    
+
                     defer { tempFile.closeFile() }
                     try await self.httpGet(request: request, tempFile: tempFile, resumeSize: resumeSize, numRetries: numRetries, expectedSize: expectedSize)
-                    
+
                     // Clean up and move the completed download to its final destination
                     tempFile.closeFile()
                     try FileManager.default.moveDownloadedFile(from: tempURL, to: self.destination)
-                    
-                    self.downloadState.value = .completed(self.destination)
+
+                    await self.broadcaster.broadcast(state: .completed(self.destination))
                 } catch {
-                    self.downloadState.value = .failed(error)
+                    await self.broadcaster.broadcast(state: .failed(error))
                 }
             }
         }
@@ -157,32 +167,32 @@ class Downloader: NSObject, ObservableObject {
         numRetries: Int,
         expectedSize: Int?
     ) async throws {
-        guard let session = self.urlSession else {
+        guard let session = await self.urlSession.get() else {
             throw DownloadError.unexpectedError
         }
-        
+
         // Create a new request with Range header for resuming
         var newRequest = request
         if resumeSize > 0 {
             newRequest.setValue("bytes=\(resumeSize)-", forHTTPHeaderField: "Range")
         }
-        
+
         // Start the download and get the byte stream
         let (asyncBytes, response) = try await session.bytes(for: newRequest)
-        
+
         guard let response = response as? HTTPURLResponse else {
             throw DownloadError.unexpectedError
         }
-                
+
         guard (200..<300).contains(response.statusCode) else {
             throw DownloadError.unexpectedError
         }
 
         var downloadedSize = resumeSize
-        
+
         // Create a buffer to collect bytes before writing to disk
         var buffer = Data(capacity: chunkSize)
-        
+
         var newNumRetries = numRetries
         do {
             for try await byte in asyncBytes {
@@ -196,11 +206,11 @@ class Downloader: NSObject, ObservableObject {
                         newNumRetries = 5
                         guard let expectedSize = expectedSize else { continue }
                         let progress = expectedSize != 0 ? Double(downloadedSize) / Double(expectedSize) : 0
-                        downloadState.value = .downloading(progress)
+                        await self.broadcaster.broadcast(state: .downloading(progress))
                     }
                 }
             }
-            
+
             if !buffer.isEmpty {
                 try tempFile.write(contentsOf: buffer)
                 downloadedSize += buffer.count
@@ -212,10 +222,10 @@ class Downloader: NSObject, ObservableObject {
                 throw error
             }
             try await Task.sleep(nanoseconds: 1_000_000_000)
-            
+
             let config = URLSessionConfiguration.default
-            self.urlSession = URLSession(configuration: config, delegate: self, delegateQueue: nil)
-            
+            await self.urlSession.set(URLSession(configuration: self.urlSessionConfig, delegate: self, delegateQueue: nil))
+
             try await httpGet(
                 request: request,
                 tempFile: tempFile,
@@ -224,61 +234,49 @@ class Downloader: NSObject, ObservableObject {
                 expectedSize: expectedSize
             )
         }
-        
+
         // Verify the downloaded file size matches the expected size
         let actualSize = try tempFile.seekToEnd()
         if let expectedSize = expectedSize, expectedSize != actualSize {
             throw DownloadError.unexpectedError
         }
     }
-    
-    @discardableResult
-    func waitUntilDone() throws -> URL {
-        // It's either this, or stream the bytes ourselves (add to a buffer, save to disk, etc; boring and finicky)
-        let semaphore = DispatchSemaphore(value: 0)
-        stateSubscriber = downloadState.sink { state in
-            switch state {
-            case .completed: semaphore.signal()
-            case .failed:    semaphore.signal()
-            default:         break
-            }
-        }
-        semaphore.wait()
 
-        switch downloadState.value {
-        case .completed(let url): return url
-        case .failed(let error):  throw error
-        default:                  throw DownloadError.unexpectedError
-        }
-    }
-
-    func cancel() {
-        urlSession?.invalidateAndCancel()
+    func cancel() async {
+        await urlSession.get()?.invalidateAndCancel()
     }
 }
 
 extension Downloader: URLSessionDownloadDelegate {
     func urlSession(_: URLSession, downloadTask: URLSessionDownloadTask, didWriteData _: Int64, totalBytesWritten: Int64, totalBytesExpectedToWrite: Int64) {
-        downloadState.value = .downloading(Double(totalBytesWritten) / Double(totalBytesExpectedToWrite))
+        Task {
+            await self.broadcaster.broadcast(state: .downloading(Double(totalBytesWritten) / Double(totalBytesExpectedToWrite)))
+        }
     }
 
     func urlSession(_: URLSession, downloadTask _: URLSessionDownloadTask, didFinishDownloadingTo location: URL) {
         do {
             // If the downloaded file already exists on the filesystem, overwrite it
             try FileManager.default.moveDownloadedFile(from: location, to: self.destination)
-            downloadState.value = .completed(destination)
+            Task {
+                await self.broadcaster.broadcast(state: .completed(destination))
+            }
         } catch {
-            downloadState.value = .failed(error)
+            Task {
+                await self.broadcaster.broadcast(state: .failed(error))
+            }
         }
     }
 
     func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
         if let error = error {
-            downloadState.value = .failed(error)
-//        } else if let response = task.response as? HTTPURLResponse {
-//            print("HTTP response status code: \(response.statusCode)")
-//            let headers = response.allHeaderFields
-//            print("HTTP response headers: \(headers)")
+            Task {
+                await self.broadcaster.broadcast(state: .failed(error))
+            }
+            //        } else if let response = task.response as? HTTPURLResponse {
+            //            print("HTTP response status code: \(response.statusCode)")
+            //            let headers = response.allHeaderFields
+            //            print("HTTP response headers: \(headers)")
         }
     }
 }
@@ -289,5 +287,67 @@ extension FileManager {
             try removeItem(at: dstURL)
         }
         try moveItem(at: srcURL, to: dstURL)
+    }
+}
+
+actor Broadcaster<E: Sendable> {
+    private let initialState: @Sendable () async -> E?
+    private var latestState: E?
+    private var continuations: [UUID: AsyncStream<E>.Continuation] = [:]
+
+    init(initialState: @Sendable @escaping () async -> E?) {
+        self.initialState = initialState
+    }
+
+    deinit {
+        self.continuations.removeAll()
+    }
+
+    func subscribe() -> AsyncStream<E> {
+        return AsyncStream { continuation in
+            let id = UUID()
+            self.continuations[id] = continuation
+
+            continuation.onTermination = { @Sendable _ in
+                Task { await self.unsubscribe(id) }
+            }
+
+            Task {
+                if let state = self.latestState {
+                    continuation.yield(state)
+                    return
+                }
+                if let state = await self.initialState() {
+                    continuation.yield(state)
+                }
+            }
+        }
+    }
+
+    private func unsubscribe(_ id: UUID) {
+        self.continuations.removeValue(forKey: id)
+    }
+
+    func broadcast(state: E) async {
+        self.latestState = state
+        await withTaskGroup(of: Void.self) { group in
+            for continuation in continuations.values {
+                group.addTask {
+                    continuation.yield(state)
+                }
+            }
+        }
+    }
+}
+
+actor UrlSessionActor {
+    private var urlSession: URLSession? = nil
+    
+    func set(_ urlSession: URLSession?) {
+        self.urlSession = urlSession
+    }
+    
+    func get() -> URLSession? {
+        return self.urlSession
     }
 }

--- a/Sources/Hub/Hub.swift
+++ b/Sources/Hub/Hub.swift
@@ -68,75 +68,6 @@ public extension Hub {
     }
 }
 
-// MARK: - Configuration files with dynamic lookup
-
-@dynamicMemberLookup
-public struct Config {
-    public private(set) var dictionary: [NSString: Any]
-
-    public init(_ dictionary: [NSString: Any]) {
-        self.dictionary = dictionary
-    }
-
-    func camelCase(_ string: String) -> String {
-        return string
-            .split(separator: "_")
-            .enumerated()
-            .map { $0.offset == 0 ? $0.element.lowercased() : $0.element.capitalized }
-            .joined()
-    }
-
-    func uncamelCase(_ string: String) -> String {
-        let scalars = string.unicodeScalars
-        var result = ""
-
-        var previousCharacterIsLowercase = false
-        for scalar in scalars {
-            if CharacterSet.uppercaseLetters.contains(scalar) {
-                if previousCharacterIsLowercase {
-                    result += "_"
-                }
-                let lowercaseChar = Character(scalar).lowercased()
-                result += lowercaseChar
-                previousCharacterIsLowercase = false
-            } else {
-                result += String(scalar)
-                previousCharacterIsLowercase = true
-            }
-        }
-
-        return result
-    }
-
-
-    public subscript(dynamicMember member: String) -> Config? {
-        let key = (dictionary[member as NSString] != nil ? member : uncamelCase(member)) as NSString
-        if let value = dictionary[key] as? [NSString: Any] {
-            return Config(value)
-        } else if let value = dictionary[key] {
-            return Config(["value": value])
-        }
-        return nil
-    }
-
-    public var value: Any? {
-        return dictionary["value"]
-    }
-
-    public var intValue: Int? { value as? Int }
-    public var boolValue: Bool? { value as? Bool }
-    public var stringValue: String? { value as? String }
-
-    // Instead of doing this we could provide custom classes and decode to them
-    public var arrayValue: [Config]? {
-        guard let list = value as? [Any] else { return nil }
-        return list.map { Config($0 as! [NSString : Any]) }
-    }
-
-    /// Tuple of token identifier and string value
-    public var tokenValue: (UInt, String)? { value as? (UInt, String) }
-}
-
 public class LanguageModelConfigurationFromHub {
     struct Configurations {
         var modelConfig: Config
@@ -174,18 +105,18 @@ public class LanguageModelConfigurationFromHub {
         get async throws {
             if let hubConfig = try await configPromise!.value.tokenizerConfig {
                 // Try to guess the class if it's not present and the modelType is
-                if let _ = hubConfig.tokenizerClass?.stringValue { return hubConfig }
+                if let _: String = hubConfig["tokenizerClass"].string() { return hubConfig }
                 guard let modelType = try await modelType else { return hubConfig }
 
                 // If the config exists but doesn't contain a tokenizerClass, use a fallback config if we have it
                 if let fallbackConfig = Self.fallbackTokenizerConfig(for: modelType) {
-                    let configuration = fallbackConfig.dictionary.merging(hubConfig.dictionary, uniquingKeysWith: { current, _ in current })
+                    let configuration = fallbackConfig.dictionary()?.merging(hubConfig.dictionary(or: [:]), strategy: { current, _ in current }) ?? [:]
                     return Config(configuration)
                 }
 
                 // Guess by capitalizing
-                var configuration = hubConfig.dictionary
-                configuration["tokenizer_class"] = "\(modelType.capitalized)Tokenizer"
+                var configuration = hubConfig.dictionary(or: [:])
+                configuration["tokenizer_class"] = .init("\(modelType.capitalized)Tokenizer")
                 return Config(configuration)
             }
 
@@ -203,7 +134,7 @@ public class LanguageModelConfigurationFromHub {
 
     public var modelType: String? {
         get async throws {
-            try await modelConfig.modelType?.stringValue
+            try await modelConfig["modelType"].string()
         }
     }
 
@@ -265,10 +196,10 @@ public class LanguageModelConfigurationFromHub {
             let chatTemplateURL = modelFolder.appending(path: "chat_template.json")
             if FileManager.default.fileExists(atPath: chatTemplateURL.path),
                let chatTemplateConfig = try? hubApi.configuration(fileURL: chatTemplateURL),
-               let chatTemplate = chatTemplateConfig.chatTemplate?.stringValue {
+               let chatTemplate = chatTemplateConfig["chatTemplate"].string() {
                 // Create or update tokenizer config with chat template
-                if var configDict = tokenizerConfig?.dictionary {
-                    configDict["chat_template"] = chatTemplate
+                if var configDict = tokenizerConfig?.dictionary() {
+                    configDict["chat_template"] = .init(chatTemplate)
                     tokenizerConfig = Config(configDict)
                 } else {
                     tokenizerConfig = Config(["chat_template": chatTemplate])

--- a/Sources/Hub/Hub.swift
+++ b/Sources/Hub/Hub.swift
@@ -105,7 +105,7 @@ public class LanguageModelConfigurationFromHub {
         get async throws {
             if let hubConfig = try await configPromise!.value.tokenizerConfig {
                 // Try to guess the class if it's not present and the modelType is
-                if let _: String = hubConfig["tokenizerClass"].string() { return hubConfig }
+                if let _: String = hubConfig.tokenizerClass?.string() { return hubConfig }
                 guard let modelType = try await modelType else { return hubConfig }
 
                 // If the config exists but doesn't contain a tokenizerClass, use a fallback config if we have it
@@ -134,7 +134,7 @@ public class LanguageModelConfigurationFromHub {
 
     public var modelType: String? {
         get async throws {
-            try await modelConfig["modelType"].string()
+            try await modelConfig.modelType.string()
         }
     }
 
@@ -196,7 +196,7 @@ public class LanguageModelConfigurationFromHub {
             let chatTemplateURL = modelFolder.appending(path: "chat_template.json")
             if FileManager.default.fileExists(atPath: chatTemplateURL.path),
                let chatTemplateConfig = try? hubApi.configuration(fileURL: chatTemplateURL),
-               let chatTemplate = chatTemplateConfig["chatTemplate"].string() {
+               let chatTemplate = chatTemplateConfig.chatTemplate.string() {
                 // Create or update tokenizer config with chat template
                 if var configDict = tokenizerConfig?.dictionary() {
                     configDict["chat_template"] = .init(chatTemplate)

--- a/Sources/Hub/Hub.swift
+++ b/Sources/Hub/Hub.swift
@@ -68,21 +68,21 @@ public extension Hub {
     }
 }
 
-public class LanguageModelConfigurationFromHub {
+public final class LanguageModelConfigurationFromHub: Sendable {
     struct Configurations {
         var modelConfig: Config
         var tokenizerConfig: Config?
         var tokenizerData: Config
     }
 
-    private var configPromise: Task<Configurations, Error>? = nil
+    private let configPromise: Task<Configurations, Error>
 
     public init(
         modelName: String,
         hubApi: HubApi = .shared
     ) {
         self.configPromise = Task.init {
-            return try await self.loadConfig(modelName: modelName, hubApi: hubApi)
+            return try await Self.loadConfig(modelName: modelName, hubApi: hubApi)
         }
     }
 
@@ -91,19 +91,19 @@ public class LanguageModelConfigurationFromHub {
         hubApi: HubApi = .shared
     ) {
         self.configPromise = Task {
-            return try await self.loadConfig(modelFolder: modelFolder, hubApi: hubApi)
+            return try await Self.loadConfig(modelFolder: modelFolder, hubApi: hubApi)
         }
     }
 
     public var modelConfig: Config {
         get async throws {
-            try await configPromise!.value.modelConfig
+            try await configPromise.value.modelConfig
         }
     }
 
     public var tokenizerConfig: Config? {
         get async throws {
-            if let hubConfig = try await configPromise!.value.tokenizerConfig {
+            if let hubConfig = try await configPromise.value.tokenizerConfig {
                 // Try to guess the class if it's not present and the modelType is
                 if let _: String = hubConfig.tokenizerClass?.string() { return hubConfig }
                 guard let modelType = try await modelType else { return hubConfig }
@@ -128,7 +128,7 @@ public class LanguageModelConfigurationFromHub {
 
     public var tokenizerData: Config {
         get async throws {
-            try await configPromise!.value.tokenizerData
+            try await configPromise.value.tokenizerData
         }
     }
 
@@ -138,7 +138,7 @@ public class LanguageModelConfigurationFromHub {
         }
     }
 
-    func loadConfig(
+    static func loadConfig(
         modelName: String,
         hubApi: HubApi = .shared
     ) async throws -> Configurations {
@@ -165,7 +165,7 @@ public class LanguageModelConfigurationFromHub {
         }
     }
 
-    func loadConfig(
+    static func loadConfig(
         modelFolder: URL,
         hubApi: HubApi = .shared
     ) async throws -> Configurations {

--- a/Sources/Hub/HubApi.swift
+++ b/Sources/Hub/HubApi.swift
@@ -10,7 +10,7 @@ import CryptoKit
 import Network
 import os
 
-public struct HubApi {
+public struct HubApi: Sendable {
     var downloadBase: URL
     var hfToken: String?
     var endpoint: String
@@ -454,7 +454,7 @@ public extension HubApi {
             .appendingPathComponent("huggingface")
             .appendingPathComponent("download")
         
-        if useOfflineMode ?? NetworkMonitor.shared.shouldUseOfflineMode() {
+        if await NetworkMonitor.shared.state.shouldUseOfflineMode() || useOfflineMode == true {
             if !FileManager.default.fileExists(atPath: repoDestination.path) {
                 throw EnvironmentError.offlineModeError(String(localized: "Repository not available locally"))
             }
@@ -606,40 +606,47 @@ public extension HubApi {
 
 /// Network monitor helper class to help decide whether to use offline mode
 private extension HubApi {
-    private final class NetworkMonitor {
-        private var monitor: NWPathMonitor
-        private var queue: DispatchQueue
+    private actor NetworkStateActor {
+        public var isConnected: Bool = false
+        public var isExpensive: Bool = false
+        public var isConstrained: Bool = false
         
-        private(set) var isConnected: Bool = false
-        private(set) var isExpensive: Bool = false
-        private(set) var isConstrained: Bool = false
+        func update(path: NWPath) {
+            self.isConnected = path.status == .satisfied
+            self.isExpensive = path.isExpensive
+            self.isConstrained = path.isConstrained
+        }
         
+        func shouldUseOfflineMode() -> Bool {
+            return !isConnected || isExpensive || isConstrained
+        }
+    }
+    
+    private final class NetworkMonitor: Sendable {
+        private let monitor: NWPathMonitor
+        
+        public let state: NetworkStateActor = .init()
+    
         static let shared = NetworkMonitor()
         
         init() {
             monitor = NWPathMonitor()
-            queue = DispatchQueue(label: "HubApi.NetworkMonitor")
             startMonitoring()
         }
         
         func startMonitoring() {
             monitor.pathUpdateHandler = { [weak self] path in
                 guard let self = self else { return }
-                
-                self.isConnected = path.status == .satisfied
-                self.isExpensive = path.isExpensive
-                self.isConstrained = path.isConstrained
+                Task {
+                    await self.state.update(path: path)
+                }
             }
             
-            monitor.start(queue: queue)
+            monitor.start(queue: DispatchQueue(label: "HubApi.NetworkMonitor"))
         }
         
         func stopMonitoring() {
             monitor.cancel()
-        }
-        
-        func shouldUseOfflineMode() -> Bool {
-            return !isConnected || isExpensive || isConstrained
         }
         
         deinit {
@@ -743,7 +750,7 @@ public extension FileManager {
 
 /// Only allow relative redirects and reject others
 /// Reference: https://github.com/huggingface/huggingface_hub/blob/b2c9a148d465b43ab90fab6e4ebcbbf5a9df27d4/src/huggingface_hub/file_download.py#L258
-private class RedirectDelegate: NSObject, URLSessionTaskDelegate {
+private final class RedirectDelegate: NSObject, URLSessionTaskDelegate, Sendable {
     func urlSession(_ session: URLSession, task: URLSessionTask, willPerformHTTPRedirection response: HTTPURLResponse, newRequest request: URLRequest, completionHandler: @escaping (URLRequest?) -> Void) {
         // Check if it's a redirect status code (300-399)
         if (300...399).contains(response.statusCode) {

--- a/Sources/Hub/HubApi.swift
+++ b/Sources/Hub/HubApi.swift
@@ -425,14 +425,19 @@ public extension HubApi {
             try prepareDestination()
             try prepareMetadataDestination()
 
-            let downloader = Downloader(from: source, to: destination, using: hfToken, inBackground: backgroundSession, expectedSize: remoteSize)
-            let downloadSubscriber = downloader.downloadState.sink { state in
-                if case .downloading(let progress) = state {
+            let downloader = Downloader(to: destination, inBackground: backgroundSession)
+            let sub = await downloader.download(from: source, using: hfToken, expectedSize: remoteSize)
+            listen: for await state in sub {
+                switch state {
+                case .notStarted:
+                    continue
+                case .downloading(let progress):
                     progressHandler(progress)
+                case .failed(let error):
+                    throw error
+                case .completed:
+                    break listen
                 }
-            }
-            _ = try withExtendedLifetime(downloadSubscriber) {
-                try downloader.waitUntilDone()
             }
             
             try HubApi.shared.writeDownloadMetadata(commitHash: remoteCommitHash, etag: remoteEtag, metadataPath: metadataDestination)

--- a/Sources/HubCLI/HubCLI.swift
+++ b/Sources/HubCLI/HubCLI.swift
@@ -78,9 +78,9 @@ struct Whoami: AsyncParsableCommand, SubcommandWithToken {
     func run() async throws {
         let hubApi = HubApi(hfToken: hfToken)
         let userInfo = try await hubApi.whoami()
-        if let name = userInfo.name?.stringValue,
-           let fullname = userInfo.fullname?.stringValue,
-           let email = userInfo.email?.stringValue
+        if let name = userInfo["name"].string(),
+           let fullname = userInfo["fullname"].string(),
+           let email = userInfo["email"].string()
         {
             print("\(name) (\(fullname) <\(email)>)")
         } else {

--- a/Sources/Models/LanguageModel.swift
+++ b/Sources/Models/LanguageModel.swift
@@ -157,33 +157,33 @@ public extension LanguageModel {
     
     var modelType: String? {
         get async throws {
-            try await modelConfig.modelType?.stringValue
+            try await modelConfig["modelType"].string()
         }
     }
     
     var textGenerationParameters: Config? {
         get async throws {
-            try await modelConfig.taskSpecificParams?.textGeneration
+            try await modelConfig["taskSpecificParams"]["textGeneration"]
         }
     }
     
     var defaultDoSample: Bool {
         get async throws {
-            try await textGenerationParameters?.doSample?.boolValue ?? true
+            try await textGenerationParameters?["doSample"].boolean() ?? true
         }
     }
 
     var bosTokenId: Int? {
         get async throws {
             let modelConfig = try await modelConfig
-            return modelConfig.bosTokenId?.intValue
+            return modelConfig["bosTokenId"].integer()
         }
     }
     
     var eosTokenId: Int? {
         get async throws {
             let modelConfig = try await modelConfig
-            return modelConfig.eosTokenId?.intValue
+            return modelConfig["eosTokenId"].integer()
         }
     }
     

--- a/Sources/Models/LanguageModel.swift
+++ b/Sources/Models/LanguageModel.swift
@@ -157,33 +157,33 @@ public extension LanguageModel {
     
     var modelType: String? {
         get async throws {
-            try await modelConfig["modelType"].string()
+            try await modelConfig.modelType.string()
         }
     }
     
     var textGenerationParameters: Config? {
         get async throws {
-            try await modelConfig["taskSpecificParams"]["textGeneration"]
+            try await modelConfig.taskSpecificParams.textGeneration
         }
     }
     
     var defaultDoSample: Bool {
         get async throws {
-            try await textGenerationParameters?["doSample"].boolean() ?? true
+            try await textGenerationParameters?.doSample.boolean() ?? true
         }
     }
 
     var bosTokenId: Int? {
         get async throws {
             let modelConfig = try await modelConfig
-            return modelConfig["bosTokenId"].integer()
+            return modelConfig.bosTokenId.integer()
         }
     }
     
     var eosTokenId: Int? {
         get async throws {
             let modelConfig = try await modelConfig
-            return modelConfig["eosTokenId"].integer()
+            return modelConfig.eosTokenId.integer()
         }
     }
     

--- a/Sources/Tokenizers/BPETokenizer.swift
+++ b/Sources/Tokenizers/BPETokenizer.swift
@@ -20,7 +20,7 @@ struct BytePair: Hashable {
         self.a = tuple[0]
         self.b = tuple[1]
     }
-    
+
     static func == (lhs: BytePair, rhs: BytePair) -> Bool {
         return lhs.a == rhs.a && lhs.b == rhs.b
     }
@@ -30,9 +30,8 @@ struct BytePair: Hashable {
     }
 }
 
-
 class BPETokenizer: PreTrainedTokenizerModel {
-    let bpeRanks: Dictionary<BytePair, Int>
+    let bpeRanks: [BytePair: Int]
     private let tokensToIds: [NSString: Int]
     private let idsToTokens: [Int: NSString]
 
@@ -50,31 +49,41 @@ class BPETokenizer: PreTrainedTokenizerModel {
     static func mergesFromConfig(_ config: Config?) -> [[String]]? {
         guard let config = config else { return nil }
 
-        // New format (pushed with tokenizers >= 0.20.0): each merge is a list of 2 items
-        if let merges = config.value as? [[String]] { return merges }
-
-        // Legacy: each merge is a string
-        guard let merges = config.value as? [String] else { return nil }
-        return merges.map { mergeString in
-            mergeString.unicodeScalars.split(separator: " ", omittingEmptySubsequences: false).map { String($0) }
+        if let merges = config.array() {
+            return merges.reduce(into: [[String]]()) { result, element in
+                if let val: [String] = element.get() {  // New format (pushed with tokenizers >= 0.20.0): each merge is a list of 2 items
+                    result.append(val)
+                }
+                if let val: String = element.get() {  // legacy
+                    result.append(val.unicodeScalars.split(separator: " ", omittingEmptySubsequences: false).map { String($0) })
+                }
+            }
         }
+
+        return nil
     }
 
-    required init(tokenizerConfig: Config, tokenizerData: Config, addedTokens: [String : Int]) throws {
-        guard let merges = Self.mergesFromConfig(tokenizerData.model?.merges) else { fatalError("BPETokenizer requires merges") }
-        guard let vocab = tokenizerData.model?.vocab?.dictionary as? [NSString: Int] else {
+    required init(tokenizerConfig: Config, tokenizerData: Config, addedTokens: [String: Int]) throws {
+        guard let merges = Self.mergesFromConfig(tokenizerData["model"]["merges"]) else { fatalError("BPETokenizer requires merges") }
+        guard let vocab = tokenizerData["model"]["vocab"].dictionary() else {
             throw TokenizerError.missingVocab
         }
-        var bpeRanks: Dictionary<BytePair, Int> = [:]
+        var bpeRanks: [BytePair: Int] = [:]
         for (i, merge) in merges.enumerated() {
             let bp = BytePair(tuple: merge)
             bpeRanks[bp] = i
         }
         self.bpeRanks = bpeRanks
-        
-        self.tokensToIds = vocab.merging(addedTokens as [NSString : Int]) { $1 }
+
+        let addedTokens = addedTokens.reduce(into: [BinaryDistinctString: Config]()) { result, element in
+            result[BinaryDistinctString(element.key)] = .init(element.value)
+        }
+        self.tokensToIds = vocab.merging(addedTokens) { $1 }.reduce(into: [NSString: Int]()) { result, element in
+            result[element.key.nsString] = element.value.integer()
+        }
+
         self.idsToTokens = Utils.invert(self.tokensToIds)
-        
+
         // Populate tokens
         if let unknownToken = TokenizerModel.unknownToken(from: tokenizerConfig) {
             self.unknownToken = unknownToken
@@ -84,19 +93,19 @@ class BPETokenizer: PreTrainedTokenizerModel {
             self.unknownTokenId = nil
         }
 
-        eosToken = addedTokenAsString(tokenizerConfig.eosToken)
+        eosToken = addedTokenAsString(tokenizerConfig["eosToken"])
         eosTokenId = eosToken == nil ? nil : tokensToIds[eosToken! as NSString]
 
-        bosToken = addedTokenAsString(tokenizerConfig.bosToken)
+        bosToken = addedTokenAsString(tokenizerConfig["bosToken"])
         bosTokenId = bosToken == nil ? nil : tokensToIds[bosToken! as NSString]
 
-        fuseUnknownTokens = tokenizerConfig.fuseUnk?.boolValue ?? false
+        fuseUnknownTokens = tokenizerConfig["fuseUnk"].boolean(or: false)
     }
 
     func convertTokenToId(_ token: String) -> Int? {
         return tokensToIds[token as NSString] ?? self.unknownTokenId
     }
-    
+
     func convertIdToToken(_ id: Int) -> String? {
         return idsToTokens[id] as String?
     }
@@ -108,7 +117,7 @@ class BPETokenizer: PreTrainedTokenizerModel {
             return Array(token.utf8).compactMap { byteEncoder[$0] }.joined()
         }
     }
-    
+
     func hexaEncode(text: String) -> [String] {
         let RE = #"'s|'t|'re|'ve|'m|'ll|'d| ?\p{L}+| ?\p{N}+| ?[^\s\p{L}\p{N}]+|\s+(?!\S)|\s+"#
         let tokens = text.ranges(of: RE).map { String(text[$0]) }
@@ -116,27 +125,27 @@ class BPETokenizer: PreTrainedTokenizerModel {
             return Array(token.utf8).map { String(format: "<0x%02X>", $0) }
         }
     }
-    
+
     private func getPairs(word: [String]) -> Set<BytePair> {
         var s = Set<BytePair>()
-        for i in 0..<word.count-1 {
+        for i in 0..<word.count - 1 {
             let bp = BytePair(
                 word[i],
-                word[i+1]
+                word[i + 1]
             )
             s.insert(bp)
         }
         return s
     }
-    
+
     func bpe(token: String) -> String {
         if token.count <= 1 {
             return token
         }
-        
+
         var word = Array(token).map { String($0) }
         var pairs = Array(getPairs(word: word))
-        
+
         while true {
             let bigrams = pairs.filter { (bp) -> Bool in bpeRanks[bp] != nil }
             if bigrams.count == 0 {
@@ -157,9 +166,9 @@ class BPETokenizer: PreTrainedTokenizerModel {
                     newWord.append(contentsOf: word[i..<word.count])
                     break
                 }
-                
-                if word[i] == first && i < word.count - 1 && word[i+1] == second {
-                    newWord.append(first+second)
+
+                if word[i] == first && i < word.count - 1 && word[i + 1] == second {
+                    newWord.append(first + second)
                     i += 2
                 } else {
                     newWord.append(word[i])

--- a/Sources/Tokenizers/BPETokenizer.swift
+++ b/Sources/Tokenizers/BPETokenizer.swift
@@ -64,8 +64,8 @@ class BPETokenizer: PreTrainedTokenizerModel {
     }
 
     required init(tokenizerConfig: Config, tokenizerData: Config, addedTokens: [String: Int]) throws {
-        guard let merges = Self.mergesFromConfig(tokenizerData["model"]["merges"]) else { fatalError("BPETokenizer requires merges") }
-        guard let vocab = tokenizerData["model"]["vocab"].dictionary() else {
+        guard let merges = Self.mergesFromConfig(tokenizerData.model.merges) else { fatalError("BPETokenizer requires merges") }
+        guard let vocab = tokenizerData.model.vocab.dictionary() else {
             throw TokenizerError.missingVocab
         }
         var bpeRanks: [BytePair: Int] = [:]
@@ -93,13 +93,13 @@ class BPETokenizer: PreTrainedTokenizerModel {
             self.unknownTokenId = nil
         }
 
-        eosToken = addedTokenAsString(tokenizerConfig["eosToken"])
+        eosToken = addedTokenAsString(tokenizerConfig.eosToken)
         eosTokenId = eosToken == nil ? nil : tokensToIds[eosToken! as NSString]
 
-        bosToken = addedTokenAsString(tokenizerConfig["bosToken"])
+        bosToken = addedTokenAsString(tokenizerConfig.bosToken)
         bosTokenId = bosToken == nil ? nil : tokensToIds[bosToken! as NSString]
 
-        fuseUnknownTokens = tokenizerConfig["fuseUnk"].boolean(or: false)
+        fuseUnknownTokens = tokenizerConfig.fuseUnk.boolean(or: false)
     }
 
     func convertTokenToId(_ token: String) -> Int? {

--- a/Sources/Tokenizers/BertTokenizer.swift
+++ b/Sources/Tokenizers/BertTokenizer.swift
@@ -47,15 +47,15 @@ public class BertTokenizer {
     }
 
     public required convenience init(tokenizerConfig: Config, tokenizerData: Config, addedTokens: [String: Int]) throws {
-        guard let vocab = tokenizerData["model"]["vocab"].dictionary() else {
+        guard let vocab = tokenizerData.model.vocab.dictionary() else {
             throw TokenizerError.missingVocab
         }
-        let merges: [String]? = tokenizerData["model"]["merges"].get()
-        let tokenizeChineseChars = tokenizerConfig["handleChineseChars"].boolean(or: true)
-        let eosToken = tokenizerConfig["eosToken"].string()
-        let bosToken = tokenizerConfig["bosToken"].string()
-        let fuseUnknown = tokenizerConfig["fuseUnk"].boolean(or: false)
-        let doLowerCase = tokenizerConfig["doLowerCase"].boolean(or: true)
+        let merges: [String]? = tokenizerData.model.merges.get()
+        let tokenizeChineseChars = tokenizerConfig.handleChineseChars.boolean(or: true)
+        let eosToken = tokenizerConfig.eosToken.string()
+        let bosToken = tokenizerConfig.bosToken.string()
+        let fuseUnknown = tokenizerConfig.fuseUnk.boolean(or: false)
+        let doLowerCase = tokenizerConfig.doLowerCase.boolean(or: true)
 
         let vocabulary = vocab.reduce(into: [String: Int]()) { result, element in
             if let val = element.value.integer() {

--- a/Sources/Tokenizers/BertTokenizer.swift
+++ b/Sources/Tokenizers/BertTokenizer.swift
@@ -14,7 +14,7 @@ public class BertTokenizer {
     private let wordpieceTokenizer: WordpieceTokenizer
     private let maxLen = 512
     private let tokenizeChineseChars: Bool
-    
+
     private let vocab: [String: Int]
     private let ids_to_tokens: [Int: String]
 
@@ -25,13 +25,14 @@ public class BertTokenizer {
 
     public let fuseUnknownTokens: Bool
 
-    public init(vocab: [String: Int],
-                merges: [String]?,
-                tokenizeChineseChars: Bool = true,
-                bosToken: String? = nil,
-                eosToken: String? = nil,
-                fuseUnknownTokens: Bool = false,
-                doLowerCase: Bool = true
+    public init(
+        vocab: [String: Int],
+        merges: [String]?,
+        tokenizeChineseChars: Bool = true,
+        bosToken: String? = nil,
+        eosToken: String? = nil,
+        fuseUnknownTokens: Bool = false,
+        doLowerCase: Bool = true
     ) {
         self.vocab = vocab
         self.ids_to_tokens = Utils.invert(vocab)
@@ -44,21 +45,28 @@ public class BertTokenizer {
         self.eosTokenId = eosToken == nil ? nil : vocab[eosToken!]
         self.fuseUnknownTokens = fuseUnknownTokens
     }
-    
-    public required convenience init(tokenizerConfig: Config, tokenizerData: Config, addedTokens: [String : Int]) throws {
-        guard let vocab = tokenizerData.model?.vocab?.dictionary as? [String: Int] else {
+
+    public required convenience init(tokenizerConfig: Config, tokenizerData: Config, addedTokens: [String: Int]) throws {
+        guard let vocab = tokenizerData["model"]["vocab"].dictionary() else {
             throw TokenizerError.missingVocab
         }
-        let merges = tokenizerData.model?.merges?.value as? [String]
-        let tokenizeChineseChars = tokenizerConfig.handleChineseChars?.boolValue ?? true
-        let eosToken = tokenizerConfig.eosToken?.stringValue
-        let bosToken = tokenizerConfig.bosToken?.stringValue
-        let fuseUnknown = tokenizerConfig.fuseUnk?.boolValue ?? false
-        let doLowerCase = tokenizerConfig.doLowerCase?.boolValue ?? true
-        self.init(vocab: vocab, merges: merges, tokenizeChineseChars: tokenizeChineseChars, bosToken: bosToken, eosToken: eosToken, fuseUnknownTokens: fuseUnknown, doLowerCase: doLowerCase)
+        let merges: [String]? = tokenizerData["model"]["merges"].get()
+        let tokenizeChineseChars = tokenizerConfig["handleChineseChars"].boolean(or: true)
+        let eosToken = tokenizerConfig["eosToken"].string()
+        let bosToken = tokenizerConfig["bosToken"].string()
+        let fuseUnknown = tokenizerConfig["fuseUnk"].boolean(or: false)
+        let doLowerCase = tokenizerConfig["doLowerCase"].boolean(or: true)
+
+        let vocabulary = vocab.reduce(into: [String: Int]()) { result, element in
+            if let val = element.value.integer() {
+                result[element.key.string] = val
+            }
+        }
+        self.init(
+            vocab: vocabulary, merges: merges, tokenizeChineseChars: tokenizeChineseChars, bosToken: bosToken, eosToken: eosToken,
+            fuseUnknownTokens: fuseUnknown, doLowerCase: doLowerCase)
     }
-    
-    
+
     public func tokenize(text: String) -> [String] {
         let text = tokenizeChineseCharsIfNeed(text)
         var tokens: [String] = []
@@ -69,7 +77,7 @@ public class BertTokenizer {
         }
         return tokens
     }
-    
+
     private func convertTokensToIds(tokens: [String]) throws -> [Int] {
         if tokens.count > maxLen {
             throw TokenizerError.tooLong(
@@ -82,26 +90,26 @@ public class BertTokenizer {
         }
         return tokens.compactMap { vocab[$0] }
     }
-    
+
     /// Main entry point
     func tokenizeToIds(text: String) -> [Int] {
         return try! convertTokensToIds(tokens: tokenize(text: text))
     }
-    
+
     func tokenToId(token: String) -> Int {
         return vocab[token]!
     }
-    
+
     /// Un-tokenization: get tokens from tokenIds
     func unTokenize(tokens: [Int]) -> [String] {
         return tokens.compactMap { ids_to_tokens[$0] }
     }
-    
+
     /// Un-tokenization:
     func convertWordpieceToBasicTokenList(_ wordpieceTokenList: [String]) -> String {
         var tokenList: [String] = []
         var individualToken: String = ""
-        
+
         for token in wordpieceTokenList {
             if token.starts(with: "##") {
                 individualToken += String(token.suffix(token.count - 2))
@@ -109,21 +117,21 @@ public class BertTokenizer {
                 if individualToken.count > 0 {
                     tokenList.append(individualToken)
                 }
-                
+
                 individualToken = token
             }
         }
-        
+
         tokenList.append(individualToken)
-        
+
         return tokenList.joined(separator: " ")
     }
-    
+
     private func tokenizeChineseCharsIfNeed(_ text: String) -> String {
         guard tokenizeChineseChars else {
             return text
         }
-        
+
         return text.map { c in
             if let scalar = c.unicodeScalars.first, Utils.isChineseChar(scalar) {
                 " \(c) "
@@ -134,27 +142,25 @@ public class BertTokenizer {
     }
 }
 
-
 extension BertTokenizer: PreTrainedTokenizerModel {
     public var unknownToken: String? { wordpieceTokenizer.unkToken }
     public var unknownTokenId: Int? { vocab[unknownToken!] }
 
     func encode(text: String) -> [Int] { tokenizeToIds(text: text) }
-    
+
     func decode(tokens: [Int]) -> String {
         let tokens = unTokenize(tokens: tokens)
         return convertWordpieceToBasicTokenList(tokens)
     }
-    
+
     public func convertTokenToId(_ token: String) -> Int? {
         return vocab[token] ?? unknownTokenId
     }
-    
+
     public func convertIdToToken(_ id: Int) -> String? {
         return ids_to_tokens[id]
     }
 }
-
 
 class BasicTokenizer {
     let doLowerCase: Bool
@@ -164,7 +170,7 @@ class BasicTokenizer {
     }
 
     let neverSplit = [
-        "[UNK]", "[SEP]", "[PAD]", "[CLS]", "[MASK]"
+        "[UNK]", "[SEP]", "[PAD]", "[CLS]", "[MASK]",
     ]
 
     func maybeStripAccents(_ text: String) -> String {
@@ -211,11 +217,11 @@ extension Character {
         if isPunctuation { return true }
         if let value = unicodeScalars.first?.value {
             switch value {
-                case 33...47: return true
-                case 58...64: return true
-                case 91...96: return true
-                case 123...126: return true
-                default: return false
+            case 33...47: return true
+            case 58...64: return true
+            case 91...96: return true
+            case 123...126: return true
+            default: return false
             }
         }
         return false
@@ -226,11 +232,11 @@ class WordpieceTokenizer {
     let unkToken = "[UNK]"
     private let maxInputCharsPerWord = 100
     private let vocab: [String: Int]
-    
+
     init(vocab: [String: Int]) {
         self.vocab = vocab
     }
-    
+
     /// `word`: A single token.
     /// Warning: this differs from the `pytorch-transformers` implementation.
     /// This should have already been passed through `BasicTokenizer`.

--- a/Sources/Tokenizers/Decoder.swift
+++ b/Sources/Tokenizers/Decoder.swift
@@ -37,7 +37,7 @@ struct DecoderFactory {
     static func fromConfig(config: Config?, addedTokens: Set<String>? = nil) -> Decoder? {
         // TODO: not sure if we need to include `addedTokens` in all the decoder initializers (and the protocol)
         guard let config = config else { return nil }
-        guard let typeName = config["type"].string() else { return nil }
+        guard let typeName = config.type.string() else { return nil }
         let type = DecoderType(rawValue: typeName)
         switch type {
         case .Sequence    : return DecoderSequence(config: config)
@@ -61,9 +61,9 @@ class WordPieceDecoder: Decoder {
     private let re = try! NSRegularExpression(pattern: "\\s(\\.|\\?|\\!|\\,|'\\s|n't|'m|'s|'ve|'re)", options: [])
 
     required public init(config: Config) {
-        guard let prefix = config["prefix"].string() else { fatalError("Missing `prefix` configuration for WordPieceDecoder.") }
+        guard let prefix = config.prefix.string() else { fatalError("Missing `prefix` configuration for WordPieceDecoder.") }
         self.prefix = prefix
-        self.cleanup = config["cleanup"].boolean(or: false)
+        self.cleanup = config.cleanup.boolean(or: false)
     }
 
     func decode(tokens: [String]) -> [String] {
@@ -86,7 +86,7 @@ class DecoderSequence: Decoder {
     let decoders: [Decoder]
     
     required public init(config: Config) {
-        guard let configs = config["decoders"].array() else { fatalError("No decoders in Sequence") }
+        guard let configs = config.decoders.array() else { fatalError("No decoders in Sequence") }
         decoders = configs.compactMap { DecoderFactory.fromConfig(config: $0) }
     }
     
@@ -199,9 +199,9 @@ class StripDecoder: Decoder {
     let stop: Int
     
     required public init(config: Config) {
-        guard let content = config["content"].string() else { fatalError("Incorrect StripDecoder configuration: can't parse `content`.") }
-        guard let start = config["start"].integer() else { fatalError("Incorrect StripDecoder configuration: can't parse `start`.") }
-        guard let stop = config["stop"].integer() else { fatalError("Incorrect StripDecoder configuration: can't parse `stop`.") }
+        guard let content = config.content.string() else { fatalError("Incorrect StripDecoder configuration: can't parse `content`.") }
+        guard let start = config.start.integer() else { fatalError("Incorrect StripDecoder configuration: can't parse `start`.") }
+        guard let stop = config.stop.integer() else { fatalError("Incorrect StripDecoder configuration: can't parse `stop`.") }
         self.content = content
         self.start = start
         self.stop = stop
@@ -219,8 +219,8 @@ class MetaspaceDecoder: Decoder {
     let replacement: String
     
     required public init(config: Config) {
-        addPrefixSpace = config["addPrefixSpace"].boolean(or: false)
-        replacement = config["replacement"].string(or: "_")
+        addPrefixSpace = config.addPrefixSpace.boolean(or: false)
+        replacement = config.replacement.string(or: "_")
     }
 
     func decode(tokens: [String]) -> [String] {

--- a/Sources/Tokenizers/Decoder.swift
+++ b/Sources/Tokenizers/Decoder.swift
@@ -37,7 +37,7 @@ struct DecoderFactory {
     static func fromConfig(config: Config?, addedTokens: Set<String>? = nil) -> Decoder? {
         // TODO: not sure if we need to include `addedTokens` in all the decoder initializers (and the protocol)
         guard let config = config else { return nil }
-        guard let typeName = config.type?.stringValue else { return nil }
+        guard let typeName = config["type"].string() else { return nil }
         let type = DecoderType(rawValue: typeName)
         switch type {
         case .Sequence    : return DecoderSequence(config: config)
@@ -61,9 +61,9 @@ class WordPieceDecoder: Decoder {
     private let re = try! NSRegularExpression(pattern: "\\s(\\.|\\?|\\!|\\,|'\\s|n't|'m|'s|'ve|'re)", options: [])
 
     required public init(config: Config) {
-        guard let prefix = config.prefix?.stringValue else { fatalError("Missing `prefix` configuration for WordPieceDecoder.") }
+        guard let prefix = config["prefix"].string() else { fatalError("Missing `prefix` configuration for WordPieceDecoder.") }
         self.prefix = prefix
-        self.cleanup = config.cleanup?.boolValue ?? false
+        self.cleanup = config["cleanup"].boolean(or: false)
     }
 
     func decode(tokens: [String]) -> [String] {
@@ -86,7 +86,7 @@ class DecoderSequence: Decoder {
     let decoders: [Decoder]
     
     required public init(config: Config) {
-        guard let configs = config.decoders?.arrayValue else { fatalError("No decoders in Sequence") }
+        guard let configs = config["decoders"].array() else { fatalError("No decoders in Sequence") }
         decoders = configs.compactMap { DecoderFactory.fromConfig(config: $0) }
     }
     
@@ -199,9 +199,9 @@ class StripDecoder: Decoder {
     let stop: Int
     
     required public init(config: Config) {
-        guard let content = config.content?.stringValue else { fatalError("Incorrect StripDecoder configuration: can't parse `content`.") }
-        guard let start = config.start?.intValue else { fatalError("Incorrect StripDecoder configuration: can't parse `start`.") }
-        guard let stop = config.stop?.intValue else { fatalError("Incorrect StripDecoder configuration: can't parse `stop`.") }
+        guard let content = config["content"].string() else { fatalError("Incorrect StripDecoder configuration: can't parse `content`.") }
+        guard let start = config["start"].integer() else { fatalError("Incorrect StripDecoder configuration: can't parse `start`.") }
+        guard let stop = config["stop"].integer() else { fatalError("Incorrect StripDecoder configuration: can't parse `stop`.") }
         self.content = content
         self.start = start
         self.stop = stop
@@ -219,8 +219,8 @@ class MetaspaceDecoder: Decoder {
     let replacement: String
     
     required public init(config: Config) {
-        addPrefixSpace = config.addPrefixSpace?.boolValue ?? false
-        replacement = config.replacement?.stringValue ?? "_"
+        addPrefixSpace = config["addPrefixSpace"].boolean(or: false)
+        replacement = config["replacement"].string(or: "_")
     }
 
     func decode(tokens: [String]) -> [String] {

--- a/Sources/Tokenizers/Normalizer.swift
+++ b/Sources/Tokenizers/Normalizer.swift
@@ -41,7 +41,7 @@ enum NormalizerType: String {
 struct NormalizerFactory {
     static func fromConfig(config: Config?) -> Normalizer? {
         guard let config = config else { return nil }
-        guard let typeName = config["type"].string() else { return nil }
+        guard let typeName = config.type.string() else { return nil }
         let type = NormalizerType(rawValue: typeName)
         switch type {
         case .Sequence: return NormalizerSequence(config: config)
@@ -65,7 +65,7 @@ class NormalizerSequence: Normalizer {
     let normalizers: [Normalizer]
 
     required public init(config: Config) {
-        guard let configs = config["normalizers"].array() else {
+        guard let configs = config.normalizers.array() else {
             fatalError("No normalizers in Sequence")
         }
         normalizers = configs.compactMap { NormalizerFactory.fromConfig(config: $0) }
@@ -82,7 +82,7 @@ class PrependNormalizer: Normalizer {
     let prepend: String
 
     required public init(config: Config) {
-        prepend = config["prepend"].string(or: "")
+        prepend = config.prepend.string(or: "")
     }
 
     public func normalize(text: String) -> String {
@@ -150,10 +150,10 @@ class BertNormalizer: Normalizer {
     let shouldLowercase: Bool
 
     required init(config: Config) {
-        self.shouldCleanText = config["cleanText"].boolean(or: true)
-        self.shouldHandleChineseChars = config["handleChineseChars"].boolean(or: true)
-        self.shouldLowercase = config["lowercase"].boolean(or: true)
-        self.shouldStripAccents = config["stripAccents"].boolean(or: shouldLowercase)
+        self.shouldCleanText = config.cleanText.boolean(or: true)
+        self.shouldHandleChineseChars = config.handleChineseChars.boolean(or: true)
+        self.shouldLowercase = config.lowercase.boolean(or: true)
+        self.shouldStripAccents = config.stripAccents.boolean(or: shouldLowercase)
     }
 
     func normalize(text: String) -> String {
@@ -281,8 +281,8 @@ class StripNormalizer: Normalizer {
     let rightStrip: Bool
 
     required init(config: Config) {
-        self.leftStrip = config["stripLeft"].boolean(or: true)
-        self.rightStrip = config["stripRight"].boolean(or: true)
+        self.leftStrip = config.stripLeft.boolean(or: true)
+        self.rightStrip = config.stripRight.boolean(or: true)
     }
 
     func normalize(text: String) -> String {
@@ -321,11 +321,11 @@ extension StringReplacePattern {
 
 extension StringReplacePattern {
     static func from(config: Config) -> StringReplacePattern? {
-        guard let replacement = config["content"].string() else { return nil }
-        if let pattern = config["pattern"]["String"].string() {
+        guard let replacement = config.content.string() else { return nil }
+        if let pattern = config.pattern.String.string() {
             return StringReplacePattern.string(pattern: pattern, replacement: replacement)
         }
-        if let pattern = config["pattern"]["Regex"].string() {
+        if let pattern = config.pattern.Regex.string() {
             guard let regexp = try? NSRegularExpression(pattern: pattern, options: []) else {
                 fatalError("Cannot build regexp from \(pattern)")
             }

--- a/Sources/Tokenizers/Normalizer.swift
+++ b/Sources/Tokenizers/Normalizer.swift
@@ -41,7 +41,7 @@ enum NormalizerType: String {
 struct NormalizerFactory {
     static func fromConfig(config: Config?) -> Normalizer? {
         guard let config = config else { return nil }
-        guard let typeName = config.type?.stringValue else { return nil }
+        guard let typeName = config["type"].string() else { return nil }
         let type = NormalizerType(rawValue: typeName)
         switch type {
         case .Sequence: return NormalizerSequence(config: config)
@@ -65,7 +65,7 @@ class NormalizerSequence: Normalizer {
     let normalizers: [Normalizer]
 
     required public init(config: Config) {
-        guard let configs = config.normalizers?.arrayValue else {
+        guard let configs = config["normalizers"].array() else {
             fatalError("No normalizers in Sequence")
         }
         normalizers = configs.compactMap { NormalizerFactory.fromConfig(config: $0) }
@@ -82,7 +82,7 @@ class PrependNormalizer: Normalizer {
     let prepend: String
 
     required public init(config: Config) {
-        prepend = config.prepend?.stringValue ?? ""
+        prepend = config["prepend"].string(or: "")
     }
 
     public func normalize(text: String) -> String {
@@ -150,10 +150,10 @@ class BertNormalizer: Normalizer {
     let shouldLowercase: Bool
 
     required init(config: Config) {
-        self.shouldCleanText = config.cleanText?.boolValue ?? true
-        self.shouldHandleChineseChars = config.handleChineseChars?.boolValue ?? true
-        self.shouldLowercase = config.lowercase?.boolValue ?? true
-        self.shouldStripAccents = config.stripAccents?.boolValue ?? shouldLowercase
+        self.shouldCleanText = config["cleanText"].boolean(or: true)
+        self.shouldHandleChineseChars = config["handleChineseChars"].boolean(or: true)
+        self.shouldLowercase = config["lowercase"].boolean(or: true)
+        self.shouldStripAccents = config["stripAccents"].boolean(or: shouldLowercase)
     }
 
     func normalize(text: String) -> String {
@@ -281,8 +281,8 @@ class StripNormalizer: Normalizer {
     let rightStrip: Bool
 
     required init(config: Config) {
-        self.leftStrip = config.stripLeft?.boolValue ?? true
-        self.rightStrip = config.stripRight?.boolValue ?? true
+        self.leftStrip = config["stripLeft"].boolean(or: true)
+        self.rightStrip = config["stripRight"].boolean(or: true)
     }
 
     func normalize(text: String) -> String {
@@ -321,11 +321,11 @@ extension StringReplacePattern {
 
 extension StringReplacePattern {
     static func from(config: Config) -> StringReplacePattern? {
-        guard let replacement = config.content?.stringValue else { return nil }
-        if let pattern = config.pattern?.String?.stringValue {
+        guard let replacement = config["content"].string() else { return nil }
+        if let pattern = config["pattern"]["String"].string() {
             return StringReplacePattern.string(pattern: pattern, replacement: replacement)
         }
-        if let pattern = config.pattern?.Regex?.stringValue {
+        if let pattern = config["pattern"]["Regex"].string() {
             guard let regexp = try? NSRegularExpression(pattern: pattern, options: []) else {
                 fatalError("Cannot build regexp from \(pattern)")
             }

--- a/Sources/Tokenizers/PostProcessor.swift
+++ b/Sources/Tokenizers/PostProcessor.swift
@@ -1,6 +1,6 @@
 //
 //  PostProcessor.swift
-//  
+//
 //
 //  Created by Pedro Cuenca on 17/7/23.
 //
@@ -32,15 +32,15 @@ enum PostProcessorType: String {
 struct PostProcessorFactory {
     static func fromConfig(config: Config?) -> PostProcessor? {
         guard let config = config else { return nil }
-        guard let typeName = config.type?.stringValue else { return nil }
+        guard let typeName = config["type"].string() else { return nil }
         let type = PostProcessorType(rawValue: typeName)
         switch type {
-            case .TemplateProcessing : return TemplateProcessing(config: config)
-            case .ByteLevel          : return ByteLevelPostProcessor(config: config)
-            case .RobertaProcessing  : return RobertaProcessing(config: config)
-            case .BertProcessing     : return BertProcessing(config: config)
-            case .Sequence           : return SequenceProcessing(config: config)
-            default                  : fatalError("Unsupported PostProcessor type: \(typeName)")
+        case .TemplateProcessing: return TemplateProcessing(config: config)
+        case .ByteLevel: return ByteLevelPostProcessor(config: config)
+        case .RobertaProcessing: return RobertaProcessing(config: config)
+        case .BertProcessing: return BertProcessing(config: config)
+        case .Sequence: return SequenceProcessing(config: config)
+        default: fatalError("Unsupported PostProcessor type: \(typeName)")
         }
     }
 }
@@ -48,30 +48,28 @@ struct PostProcessorFactory {
 class TemplateProcessing: PostProcessor {
     let single: [Config]
     let pair: [Config]
-    
+
     required public init(config: Config) {
-        guard let single = config.single?.arrayValue else { fatalError("Missing `single` processor configuration") }
-        guard let pair = config.pair?.arrayValue else { fatalError("Missing `pair` processor configuration") }
-        
+        guard let single = config["single"].array() else { fatalError("Missing `single` processor configuration") }
+        guard let pair = config["pair"].array() else { fatalError("Missing `pair` processor configuration") }
+
         self.single = single
         self.pair = pair
     }
-    
+
     func postProcess(tokens: [String], tokensPair: [String]? = nil, addSpecialTokens: Bool = true) -> [String] {
         let config = tokensPair == nil ? single : pair
 
         var toReturn: [String] = []
         for item in config {
-            if let specialToken = item.SpecialToken {
+            if let id = item["SpecialToken"]["id"].string() {
                 if addSpecialTokens {
-                    toReturn.append(specialToken.id!.stringValue!)
+                    toReturn.append(id)
                 }
-            } else if let sequence = item.Sequence {
-                if sequence.id?.stringValue == "A" {
-                    toReturn += tokens
-                } else if sequence.id?.stringValue == "B" {
-                    toReturn += tokensPair!
-                }
+            } else if item["Sequence"]["id"].string() == "A" {
+                toReturn += tokens
+            } else if item["Sequence"]["id"].string() == "B" {
+                toReturn += tokensPair!
             }
         }
         return toReturn
@@ -92,14 +90,14 @@ class RobertaProcessing: PostProcessor {
     private let addPrefixSpace: Bool
 
     required public init(config: Config) {
-        guard let sep = config.sep?.tokenValue else { fatalError("Missing `sep` processor configuration") }
-        guard let cls = config.cls?.tokenValue else { fatalError("Missing `cls` processor configuration") }
+        guard let sep = config["sep"].token() else { fatalError("Missing `sep` processor configuration") }
+        guard let cls = config["cls"].token() else { fatalError("Missing `cls` processor configuration") }
         self.sep = sep
         self.cls = cls
-        self.trimOffset = config.trimOffset?.boolValue ?? true
-        self.addPrefixSpace = config.addPrefixSpace?.boolValue ?? true
+        self.trimOffset = config["trimOffset"].boolean(or: true)
+        self.addPrefixSpace = config["addPrefixSpace"].boolean(or: true)
     }
-    
+
     func postProcess(tokens: [String], tokensPair: [String]?, addSpecialTokens: Bool = true) -> [String] {
         var outTokens = tokens
         var tokensPair = tokensPair
@@ -107,7 +105,7 @@ class RobertaProcessing: PostProcessor {
             if addPrefixSpace {
                 outTokens = outTokens.map({ trimExtraSpaces(token: $0) })
                 tokensPair = tokensPair?.map({ trimExtraSpaces(token: $0) })
-           } else {
+            } else {
                 outTokens = outTokens.map({ $0.trimmingCharacters(in: .whitespaces) })
                 tokensPair = tokensPair?.map({ $0.trimmingCharacters(in: .whitespaces) })
             }
@@ -149,8 +147,8 @@ class BertProcessing: PostProcessor {
     private let cls: (UInt, String)
 
     required public init(config: Config) {
-        guard let sep = config.sep?.tokenValue else { fatalError("Missing `sep` processor configuration") }
-        guard let cls = config.cls?.tokenValue else { fatalError("Missing `cls` processor configuration") }
+        guard let sep = config["sep"].token() else { fatalError("Missing `sep` processor configuration") }
+        guard let cls = config["cls"].token() else { fatalError("Missing `cls` processor configuration") }
         self.sep = sep
         self.cls = cls
     }
@@ -171,7 +169,7 @@ class SequenceProcessing: PostProcessor {
     private let processors: [PostProcessor]
 
     required public init(config: Config) {
-        guard let processorConfigs = config.processors?.arrayValue else {
+        guard let processorConfigs = config["processors"].array() else {
             fatalError("Missing `processors` configuration")
         }
 

--- a/Sources/Tokenizers/PostProcessor.swift
+++ b/Sources/Tokenizers/PostProcessor.swift
@@ -32,7 +32,7 @@ enum PostProcessorType: String {
 struct PostProcessorFactory {
     static func fromConfig(config: Config?) -> PostProcessor? {
         guard let config = config else { return nil }
-        guard let typeName = config["type"].string() else { return nil }
+        guard let typeName = config.type.string() else { return nil }
         let type = PostProcessorType(rawValue: typeName)
         switch type {
         case .TemplateProcessing: return TemplateProcessing(config: config)
@@ -50,8 +50,8 @@ class TemplateProcessing: PostProcessor {
     let pair: [Config]
 
     required public init(config: Config) {
-        guard let single = config["single"].array() else { fatalError("Missing `single` processor configuration") }
-        guard let pair = config["pair"].array() else { fatalError("Missing `pair` processor configuration") }
+        guard let single = config.single.array() else { fatalError("Missing `single` processor configuration") }
+        guard let pair = config.pair.array() else { fatalError("Missing `pair` processor configuration") }
 
         self.single = single
         self.pair = pair
@@ -62,13 +62,13 @@ class TemplateProcessing: PostProcessor {
 
         var toReturn: [String] = []
         for item in config {
-            if let id = item["SpecialToken"]["id"].string() {
+            if let id = item.SpecialToken.id.string() {
                 if addSpecialTokens {
                     toReturn.append(id)
                 }
-            } else if item["Sequence"]["id"].string() == "A" {
+            } else if item.Sequence.id.string() == "A" {
                 toReturn += tokens
-            } else if item["Sequence"]["id"].string() == "B" {
+            } else if item.Sequence.id.string() == "B" {
                 toReturn += tokensPair!
             }
         }
@@ -90,12 +90,12 @@ class RobertaProcessing: PostProcessor {
     private let addPrefixSpace: Bool
 
     required public init(config: Config) {
-        guard let sep = config["sep"].token() else { fatalError("Missing `sep` processor configuration") }
-        guard let cls = config["cls"].token() else { fatalError("Missing `cls` processor configuration") }
+        guard let sep = config.sep.token() else { fatalError("Missing `sep` processor configuration") }
+        guard let cls = config.cls.token() else { fatalError("Missing `cls` processor configuration") }
         self.sep = sep
         self.cls = cls
-        self.trimOffset = config["trimOffset"].boolean(or: true)
-        self.addPrefixSpace = config["addPrefixSpace"].boolean(or: true)
+        self.trimOffset = config.trimOffset.boolean(or: true)
+        self.addPrefixSpace = config.addPrefixSpace.boolean(or: true)
     }
 
     func postProcess(tokens: [String], tokensPair: [String]?, addSpecialTokens: Bool = true) -> [String] {
@@ -147,8 +147,8 @@ class BertProcessing: PostProcessor {
     private let cls: (UInt, String)
 
     required public init(config: Config) {
-        guard let sep = config["sep"].token() else { fatalError("Missing `sep` processor configuration") }
-        guard let cls = config["cls"].token() else { fatalError("Missing `cls` processor configuration") }
+        guard let sep = config.sep.token() else { fatalError("Missing `sep` processor configuration") }
+        guard let cls = config.cls.token() else { fatalError("Missing `cls` processor configuration") }
         self.sep = sep
         self.cls = cls
     }
@@ -169,7 +169,7 @@ class SequenceProcessing: PostProcessor {
     private let processors: [PostProcessor]
 
     required public init(config: Config) {
-        guard let processorConfigs = config["processors"].array() else {
+        guard let processorConfigs = config.processors.array() else {
             fatalError("Missing `processors` configuration")
         }
 

--- a/Sources/Tokenizers/PreTokenizer.swift
+++ b/Sources/Tokenizers/PreTokenizer.swift
@@ -54,7 +54,7 @@ enum PreTokenizerType: String {
 struct PreTokenizerFactory {
     static func fromConfig(config: Config?) -> PreTokenizer? {
         guard let config = config else { return nil }
-        guard let typeName = config["type"].string() else { return nil }
+        guard let typeName = config.type.string() else { return nil }
         let type = PreTokenizerType(rawValue: typeName)
         switch type {
         case .Sequence: return PreTokenizerSequence(config: config)
@@ -87,7 +87,7 @@ class PreTokenizerSequence: PreTokenizer {
     let preTokenizers: [PreTokenizer]
 
     required init(config: Config) {
-        guard let configs = config["pretokenizers"].array() else { fatalError("No pretokenizers in Sequence") }
+        guard let configs = config.pretokenizers.array() else { fatalError("No pretokenizers in Sequence") }
         preTokenizers = configs.compactMap { PreTokenizerFactory.fromConfig(config: $0) }
     }
 
@@ -137,10 +137,10 @@ class MetaspacePreTokenizer: PreTokenizer {
     let prependScheme: PrependScheme
 
     required init(config: Config) {
-        addPrefixSpace = config["addPrefixSpace"].boolean(or: false)
-        replacement = config["replacement"].string(or: " ")
-        stringReplacement = config["strRep"].string(or: replacement)
-        prependScheme = PrependScheme.from(rawValue: config["prependScheme"].string())
+        addPrefixSpace = config.addPrefixSpace.boolean(or: false)
+        replacement = config.replacement.string(or: " ")
+        stringReplacement = config.strRep.string(or: replacement)
+        prependScheme = PrependScheme.from(rawValue: config.prependScheme.string())
     }
 
     // https://github.com/huggingface/tokenizers/blob/accd0650b802f2180df40ef1def3bce32156688e/tokenizers/src/pre_tokenizers/metaspace.rs#L114
@@ -179,9 +179,9 @@ class ByteLevelPreTokenizer: PreTokenizer {
     let RE = #"'s|'t|'re|'ve|'m|'ll|'d| ?\p{L}+| ?\p{N}+| ?[^\s\p{L}\p{N}]+|\s+(?!\S)|\s+"#
 
     required init(config: Config) {
-        addPrefixSpace = config["addPrefixSpace"].boolean(or: false)
-        trimOffsets = config["trimOffsets"].boolean(or: true)
-        useRegex = config["useRegex"].boolean(or: true)
+        addPrefixSpace = config.addPrefixSpace.boolean(or: false)
+        trimOffsets = config.trimOffsets.boolean(or: true)
+        useRegex = config.useRegex.boolean(or: true)
     }
 
     func preTokenize(text: String, options: PreTokenizerOptions = [.firstSection]) -> [String] {
@@ -215,7 +215,7 @@ class DigitsPreTokenizer: PreTokenizer {
     let re: String
 
     required init(config: Config) {
-        let individualDigits = config["individualDigits"].boolean(or: false)
+        let individualDigits = config.individualDigits.boolean(or: false)
         re = "[^\\d]+|\\d\(individualDigits ? "" : "+")"
     }
 
@@ -230,7 +230,7 @@ class SplitPreTokenizer: PreTokenizer {
 
     required init(config: Config) {
         pattern = StringSplitPattern.from(config: config)
-        invert = config["invert"].boolean(or: false)
+        invert = config.invert.boolean(or: false)
     }
 
     func preTokenize(text: String, options: PreTokenizerOptions = [.firstSection]) -> [String] {
@@ -257,10 +257,10 @@ extension StringSplitPattern {
 
 extension StringSplitPattern {
     static func from(config: Config) -> StringSplitPattern? {
-        if let pattern = config["pattern"]["String"].string() {
+        if let pattern = config.pattern.String.string() {
             return StringSplitPattern.string(pattern: pattern)
         }
-        if let pattern = config["pattern"]["Regex"].string() {
+        if let pattern = config.pattern.Regex.string() {
             return StringSplitPattern.regexp(regexp: pattern)
         }
         return nil

--- a/Sources/Tokenizers/PreTokenizer.swift
+++ b/Sources/Tokenizers/PreTokenizer.swift
@@ -1,6 +1,6 @@
 //
 //  PreTokenizer.swift
-//  
+//
 //
 //  Created by Pedro Cuenca on 18/7/23.
 //
@@ -31,7 +31,7 @@ extension PreTokenizer {
     func callAsFunction(texts: [String], options: PreTokenizerOptions = [.firstSection]) -> [String] {
         return preTokenize(texts: texts, options: options)
     }
-    
+
     func callAsFunction(text: String, options: PreTokenizerOptions = [.firstSection]) -> [String] {
         return preTokenize(text: text, options: options)
     }
@@ -54,10 +54,10 @@ enum PreTokenizerType: String {
 struct PreTokenizerFactory {
     static func fromConfig(config: Config?) -> PreTokenizer? {
         guard let config = config else { return nil }
-        guard let typeName = config.type?.stringValue else { return nil }
+        guard let typeName = config["type"].string() else { return nil }
         let type = PreTokenizerType(rawValue: typeName)
         switch type {
-        case .Sequence : return PreTokenizerSequence(config: config)
+        case .Sequence: return PreTokenizerSequence(config: config)
         case .ByteLevel: return ByteLevelPreTokenizer(config: config)
         case .Punctuation: return PunctuationPreTokenizer(config: config)
         case .Digits: return DigitsPreTokenizer(config: config)
@@ -85,12 +85,12 @@ class BertPreTokenizer: PreTokenizer {
 
 class PreTokenizerSequence: PreTokenizer {
     let preTokenizers: [PreTokenizer]
-    
+
     required init(config: Config) {
-        guard let configs = config.pretokenizers?.arrayValue else { fatalError("No pretokenizers in Sequence") }
+        guard let configs = config["pretokenizers"].array() else { fatalError("No pretokenizers in Sequence") }
         preTokenizers = configs.compactMap { PreTokenizerFactory.fromConfig(config: $0) }
     }
-    
+
     func preTokenize(text: String, options: PreTokenizerOptions = [.firstSection]) -> [String] {
         preTokenizers.reduce([text]) { current, preTokenizer in
             preTokenizer(texts: current, options: options)
@@ -114,40 +114,40 @@ class WhitespacePreTokenizer: PreTokenizer {
 class MetaspacePreTokenizer: PreTokenizer {
     /// Whether to add a prefix space to the first token
     let addPrefixSpace: Bool
-    
+
     /// Replacement character
     let replacement: String
-    
+
     /// Optional string representation of the replacement character.
     let stringReplacement: String
-    
+
     enum PrependScheme: String {
         case first
         case never
         case always
-        
+
         static var defaultScheme: PrependScheme { .always }
         static func from(rawValue value: String?) -> PrependScheme {
             guard let value = value else { return defaultScheme }
             return PrependScheme(rawValue: value) ?? defaultScheme
         }
     }
-    
+
     /// The metaspace prepend scheme, see https://github.com/huggingface/tokenizers/pull/1357
     let prependScheme: PrependScheme
-    
+
     required init(config: Config) {
-        addPrefixSpace = config.addPrefixSpace?.boolValue ?? false
-        replacement = config.replacement?.stringValue ?? " "
-        stringReplacement = config.strRep?.stringValue ?? replacement
-        prependScheme = PrependScheme.from(rawValue: config.prependScheme?.stringValue)
+        addPrefixSpace = config["addPrefixSpace"].boolean(or: false)
+        replacement = config["replacement"].string(or: " ")
+        stringReplacement = config["strRep"].string(or: replacement)
+        prependScheme = PrependScheme.from(rawValue: config["prependScheme"].string())
     }
-    
+
     // https://github.com/huggingface/tokenizers/blob/accd0650b802f2180df40ef1def3bce32156688e/tokenizers/src/pre_tokenizers/metaspace.rs#L114
     // https://github.com/xenova/transformers.js/blob/b07336d8f7ff57453cc164cc68aead2a79cbd57e/src/tokenizers.js#L2153
     func preTokenize(text: String, options: PreTokenizerOptions = [.firstSection]) -> [String] {
         let normalized = text.replacingOccurrences(of: " ", with: stringReplacement)
-        
+
         // We add a prefix space if:
         //  (1) The addPrefixSpace option is enabled and the normalized
         //      token does not already start with the replacement character.
@@ -165,7 +165,7 @@ class MetaspacePreTokenizer: PreTokenizer {
                 prepend = stringReplacement
             }
         }
-        
+
         // Split in `MergedWithNext` mode, although usually the input to this function is already pre-tokenized
         // https://github.com/huggingface/tokenizers/blob/accd0650b802f2180df40ef1def3bce32156688e/tokenizers/src/pre_tokenizers/metaspace.rs#L127
         return (prepend + normalized).split(by: replacement, behavior: .mergedWithNext)
@@ -177,13 +177,13 @@ class ByteLevelPreTokenizer: PreTokenizer {
     let trimOffsets: Bool
     let useRegex: Bool
     let RE = #"'s|'t|'re|'ve|'m|'ll|'d| ?\p{L}+| ?\p{N}+| ?[^\s\p{L}\p{N}]+|\s+(?!\S)|\s+"#
-    
+
     required init(config: Config) {
-        addPrefixSpace = config.addPrefixSpace?.boolValue ?? false
-        trimOffsets = config.trimOffsets?.boolValue ?? true
-        useRegex = config.useRegex?.boolValue ?? true
+        addPrefixSpace = config["addPrefixSpace"].boolean(or: false)
+        trimOffsets = config["trimOffsets"].boolean(or: true)
+        useRegex = config["useRegex"].boolean(or: true)
     }
-    
+
     func preTokenize(text: String, options: PreTokenizerOptions = [.firstSection]) -> [String] {
         // Split on whitespace and punctuation
         let tokens = useRegex ? text.ranges(of: RE).map({ String(text[$0]) }) : [text]
@@ -215,7 +215,7 @@ class DigitsPreTokenizer: PreTokenizer {
     let re: String
 
     required init(config: Config) {
-        let individualDigits = config.individualDigits?.boolValue ?? false
+        let individualDigits = config["individualDigits"].boolean(or: false)
         re = "[^\\d]+|\\d\(individualDigits ? "" : "+")"
     }
 
@@ -230,7 +230,7 @@ class SplitPreTokenizer: PreTokenizer {
 
     required init(config: Config) {
         pattern = StringSplitPattern.from(config: config)
-        invert = config.invert?.boolValue ?? false
+        invert = config["invert"].boolean(or: false)
     }
 
     func preTokenize(text: String, options: PreTokenizerOptions = [.firstSection]) -> [String] {
@@ -257,18 +257,18 @@ extension StringSplitPattern {
 
 extension StringSplitPattern {
     static func from(config: Config) -> StringSplitPattern? {
-        if let pattern = config.pattern?.String?.stringValue {
+        if let pattern = config["pattern"]["String"].string() {
             return StringSplitPattern.string(pattern: pattern)
         }
-        if let pattern = config.pattern?.Regex?.stringValue {
+        if let pattern = config["pattern"]["Regex"].string() {
             return StringSplitPattern.regexp(regexp: pattern)
         }
         return nil
     }
 }
 
-public extension String {
-    func ranges(of string: String, options: CompareOptions = .regularExpression) -> [Range<Index>] {
+extension String {
+    public func ranges(of string: String, options: CompareOptions = .regularExpression) -> [Range<Index>] {
         var result: [Range<Index>] = []
         var start = startIndex
         while let range = range(of: string, options: options, range: start..<endIndex) {
@@ -277,8 +277,10 @@ public extension String {
         }
         return result
     }
-        
-    func split(by string: String, options: CompareOptions = .regularExpression, includeSeparators: Bool = false, omittingEmptySubsequences: Bool = true) -> [String] {
+
+    public func split(by string: String, options: CompareOptions = .regularExpression, includeSeparators: Bool = false, omittingEmptySubsequences: Bool = true)
+        -> [String]
+    {
         var result: [String] = []
         var start = startIndex
         while let range = range(of: string, options: options, range: start..<endIndex) {
@@ -291,7 +293,7 @@ public extension String {
             }
             start = range.upperBound
         }
-        
+
         if omittingEmptySubsequences && start < endIndex {
             result.append(String(self[start...]))
         }
@@ -299,7 +301,7 @@ public extension String {
     }
 
     /// This version supports capture groups, wheres the one above doesn't
-    func split(by captureRegex: NSRegularExpression) -> [String] {
+    public func split(by captureRegex: NSRegularExpression) -> [String] {
         // Find the matching capture groups
         let selfRange = NSRange(startIndex..<endIndex, in: self)
         let matches = captureRegex.matches(in: self, options: [], range: selfRange)
@@ -345,8 +347,8 @@ public enum SplitDelimiterBehavior {
     case mergedWithNext
 }
 
-public extension String {
-    func split(by string: String, options: CompareOptions = .regularExpression, behavior: SplitDelimiterBehavior) -> [String] {
+extension String {
+    public func split(by string: String, options: CompareOptions = .regularExpression, behavior: SplitDelimiterBehavior) -> [String] {
         func mergedWithNext(ranges: [Range<String.Index>]) -> [Range<String.Index>] {
             var merged: [Range<String.Index>] = []
             var currentStart = startIndex
@@ -361,7 +363,7 @@ public extension String {
             }
             return merged
         }
-        
+
         func mergedWithPrevious(ranges: [Range<String.Index>]) -> [Range<String.Index>] {
             var merged: [Range<String.Index>] = []
             var currentStart = startIndex

--- a/Sources/Tokenizers/Tokenizer.swift
+++ b/Sources/Tokenizers/Tokenizer.swift
@@ -5,8 +5,8 @@
 //  Created by Pedro Cuenca on 6/5/23.
 //
 
-import Hub
 import Foundation
+import Hub
 import Jinja
 
 public typealias Message = [String: Any]
@@ -69,57 +69,57 @@ public protocol TokenizingModel {
 // Helper - possibly to be moved somewhere else
 func addedTokenAsString(_ addedToken: Config?) -> String? {
     guard let addedToken = addedToken else { return nil }
-    if let stringValue = addedToken.stringValue {
+    if let stringValue = addedToken.string() {
         return stringValue
     }
     // This is possibly a serialization of the AddedToken class
     // TODO: support lstrip, rstrip, normalized, etc.
-    return addedToken.content?.stringValue
+    return addedToken["content"].string()
 }
 
-public extension TokenizingModel {
-    func callAsFunction(_ text: String) -> [String] {
+extension TokenizingModel {
+    public func callAsFunction(_ text: String) -> [String] {
         tokenize(text: text)
     }
 
-    func convertTokensToIds(_ tokens: [String]) -> [Int?] {
+    public func convertTokensToIds(_ tokens: [String]) -> [Int?] {
         return tokens.map { convertTokenToId($0) }
     }
 
-    func convertIdsToTokens(_ ids: [Int]) -> [String?] {
+    public func convertIdsToTokens(_ ids: [Int]) -> [String?] {
         return ids.map { convertIdToToken($0) }
     }
 }
 
 /// A tokenizer model that is set up with Hub configuration data
 public protocol PreTrainedTokenizerModel: TokenizingModel {
-    init(tokenizerConfig: Config, tokenizerData: Config, addedTokens: [String : Int]) throws
+    init(tokenizerConfig: Config, tokenizerData: Config, addedTokens: [String: Int]) throws
 }
 
 struct TokenizerModel {
-    static let knownTokenizers: [String : PreTrainedTokenizerModel.Type] = [
-        "BertTokenizer"      : BertTokenizer.self,
+    static let knownTokenizers: [String: PreTrainedTokenizerModel.Type] = [
+        "BertTokenizer": BertTokenizer.self,
         "DistilbertTokenizer": BertTokenizer.self,
         "DistilBertTokenizer": BertTokenizer.self,
-        "CodeGenTokenizer"   : CodeGenTokenizer.self,
-        "CodeLlamaTokenizer" : CodeLlamaTokenizer.self,
-        "FalconTokenizer"    : FalconTokenizer.self,
-        "GemmaTokenizer"     : GemmaTokenizer.self,
-        "GPT2Tokenizer"      : GPT2Tokenizer.self,
-        "LlamaTokenizer"     : LlamaTokenizer.self,
-        "T5Tokenizer"        : T5Tokenizer.self,
-        "WhisperTokenizer"   : WhisperTokenizer.self,
-        "CohereTokenizer"    : CohereTokenizer.self,
-        "Qwen2Tokenizer"     : Qwen2Tokenizer.self,
-        "PreTrainedTokenizer": BPETokenizer.self
+        "CodeGenTokenizer": CodeGenTokenizer.self,
+        "CodeLlamaTokenizer": CodeLlamaTokenizer.self,
+        "FalconTokenizer": FalconTokenizer.self,
+        "GemmaTokenizer": GemmaTokenizer.self,
+        "GPT2Tokenizer": GPT2Tokenizer.self,
+        "LlamaTokenizer": LlamaTokenizer.self,
+        "T5Tokenizer": T5Tokenizer.self,
+        "WhisperTokenizer": WhisperTokenizer.self,
+        "CohereTokenizer": CohereTokenizer.self,
+        "Qwen2Tokenizer": Qwen2Tokenizer.self,
+        "PreTrainedTokenizer": BPETokenizer.self,
     ]
 
     static func unknownToken(from tokenizerConfig: Config) -> String? {
-        return tokenizerConfig.unkToken?.content?.stringValue ?? tokenizerConfig.unkToken?.stringValue
+        return tokenizerConfig["unkToken"]["content"].string() ?? tokenizerConfig["unkToken"].string()
     }
 
-    public static func from(tokenizerConfig: Config, tokenizerData: Config, addedTokens: [String : Int]) throws -> TokenizingModel {
-        guard let tokenizerClassName = tokenizerConfig.tokenizerClass?.stringValue else {
+    public static func from(tokenizerConfig: Config, tokenizerData: Config, addedTokens: [String: Int]) throws -> TokenizingModel {
+        guard let tokenizerClassName = tokenizerConfig["tokenizerClass"].string() else {
             throw TokenizerError.missingTokenizerClassInConfig
         }
 
@@ -219,27 +219,29 @@ extension Tokenizer {
         additionalContext: [String: Any]?
     ) throws -> [Int] {
         if additionalContext == nil {
-            try applyChatTemplate(messages: messages, chatTemplate: chatTemplate, addGenerationPrompt: addGenerationPrompt, truncation: truncation, maxLength: maxLength, tools: tools)
+            try applyChatTemplate(
+                messages: messages, chatTemplate: chatTemplate, addGenerationPrompt: addGenerationPrompt, truncation: truncation, maxLength: maxLength,
+                tools: tools)
         } else {
             throw TokenizerError.chatTemplate("Not implemented")
         }
     }
 }
 
-public extension Tokenizer {
-    func callAsFunction(_ text: String, addSpecialTokens: Bool = true) -> [Int] {
+extension Tokenizer {
+    public func callAsFunction(_ text: String, addSpecialTokens: Bool = true) -> [Int] {
         encode(text: text, addSpecialTokens: addSpecialTokens)
     }
-    
-    func decode(tokens: [Int]) -> String {
+
+    public func decode(tokens: [Int]) -> String {
         decode(tokens: tokens, skipSpecialTokens: false)
     }
 
-    func convertTokensToIds(_ tokens: [String]) -> [Int?] {
+    public func convertTokensToIds(_ tokens: [String]) -> [Int?] {
         return tokens.map { convertTokenToId($0) }
     }
 
-    func convertIdsToTokens(_ ids: [Int]) -> [String?] {
+    public func convertIdsToTokens(_ ids: [Int]) -> [String?] {
         return ids.map { convertIdToToken($0) }
     }
 }
@@ -252,7 +254,7 @@ let specialTokenAttributes: [String] = [
     "pad_token",
     "cls_token",
     "mask_token",
-    "additional_special_tokens"
+    "additional_special_tokens",
 ]
 
 public class PreTrainedTokenizer: Tokenizer {
@@ -279,24 +281,24 @@ public class PreTrainedTokenizer: Tokenizer {
     private let cleanUpTokenizationSpaces: Bool
 
     required public init(tokenizerConfig: Config, tokenizerData: Config) throws {
-        var addedTokens: [String : Int] = [:]
-        var specialTokens: [String : Int] = [:]
-        for addedToken in tokenizerData.addedTokens?.arrayValue ?? [] {
-            guard let id = addedToken.id?.intValue else { continue /* malformed: token with no id */ }
-            guard let content = addedToken.content?.stringValue else { continue /* malformed: token with no content */ }
+        var addedTokens: [String: Int] = [:]
+        var specialTokens: [String: Int] = [:]
+        for addedToken in tokenizerData["addedTokens"].array(or: []) {
+            guard let id = addedToken["id"].integer() else { continue /* malformed: token with no id */ }
+            guard let content = addedToken["content"].string() else { continue /* malformed: token with no content */ }
             addedTokens[content] = id
 
-            if addedToken.special?.boolValue ?? false {
+            if addedToken["special"].boolean(or: false) {
                 specialTokens[content] = id
             }
         }
 
         // Convert to tuples for easier access, then sort by length (descending) to avoid early partial matches
         // (https://github.com/xenova/transformers.js/commit/c305c3824f628f1f02806a6310bd3b18b0f7f8f5)
-        let unwrappedAddedTokens : [(content: String, prefix: Bool, suffix: Bool)] = (tokenizerData.addedTokens?.arrayValue ?? []).compactMap { addedToken in
-            guard let content = addedToken.content?.stringValue else { return nil }
-            let prefix = addedToken.lstrip?.boolValue ?? false
-            let suffix = addedToken.rstrip?.boolValue ?? false
+        let unwrappedAddedTokens: [(content: String, prefix: Bool, suffix: Bool)] = (tokenizerData["addedTokens"].array(or: [])).compactMap { addedToken -> (String, Bool, Bool)? in
+            guard let content = addedToken["content"].string() else { return nil }
+            let prefix = addedToken["lstrip"].boolean(or: false)
+            let suffix = addedToken["rstrip"].boolean(or: false)
             return (content: content, prefix: prefix, suffix: suffix)
         }.sorted {
             $0.content.count > $1.content.count
@@ -315,11 +317,11 @@ public class PreTrainedTokenizer: Tokenizer {
         self.specialTokens = specialTokens
         self.addedTokens = Set(addedTokens.keys)
 
-        self.preTokenizer = PreTokenizerFactory.fromConfig(config: tokenizerData.preTokenizer)
-        self.normalizer = NormalizerFactory.fromConfig(config: tokenizerData.normalizer)
-        self.postProcessor = PostProcessorFactory.fromConfig(config: tokenizerData.postProcessor)
-        self.decoder = DecoderFactory.fromConfig(config: tokenizerData.decoder, addedTokens: self.addedTokens)
-        self.cleanUpTokenizationSpaces = tokenizerConfig.cleanUpTokenizationSpaces?.boolValue ?? true
+        self.preTokenizer = PreTokenizerFactory.fromConfig(config: tokenizerData["preTokenizer"])
+        self.normalizer = NormalizerFactory.fromConfig(config: tokenizerData["normalizer"])
+        self.postProcessor = PostProcessorFactory.fromConfig(config: tokenizerData["postProcessor"])
+        self.decoder = DecoderFactory.fromConfig(config: tokenizerData["decoder"], addedTokens: self.addedTokens)
+        self.cleanUpTokenizationSpaces = tokenizerConfig["cleanUpTokenizationSpaces"].boolean(or: true)
         self.tokenizerConfig = tokenizerConfig
 
         model = try TokenizerModel.from(tokenizerConfig: tokenizerConfig, tokenizerData: tokenizerData, addedTokens: addedTokens)
@@ -349,7 +351,8 @@ public class PreTrainedTokenizer: Tokenizer {
     func cleanUp(text: String) -> String {
         guard cleanUpTokenizationSpaces else { return text }
 
-        return text
+        return
+            text
             .replacingOccurrences(of: " .", with: ".")
             .replacingOccurrences(of: " ?", with: "?")
             .replacingOccurrences(of: " !", with: "!")
@@ -393,7 +396,8 @@ public class PreTrainedTokenizer: Tokenizer {
 
     /// Main entry point
     public func encode(text: String, addSpecialTokens: Bool = true) -> [Int] {
-        return postProcess(tokenize(text: text), addSpecialTokens: addSpecialTokens).map { model.convertTokenToId($0)! }
+        let tokens = tokenize(text: text)
+        return postProcess(tokens, addSpecialTokens: addSpecialTokens).map { model.convertTokenToId($0)! }
     }
 
     public func encode(text: String) -> [Int] {
@@ -405,7 +409,8 @@ public class PreTrainedTokenizer: Tokenizer {
         let tokenStrings: [String]
         if skipSpecialTokens {
             let specialTokenIDs = Set(specialTokens.values)
-            tokenStrings = tokens
+            tokenStrings =
+                tokens
                 .filter { !specialTokenIDs.contains($0) }
                 .compactMap { model.convertIdToToken($0) }
         } else {
@@ -425,7 +430,7 @@ public class PreTrainedTokenizer: Tokenizer {
     }
 
     public var hasChatTemplate: Bool {
-        return tokenizerConfig.chatTemplate != nil
+        return !tokenizerConfig["chatTemplate"].isNull()
     }
 
     public func applyChatTemplate(messages: [Message]) throws -> [Int] {
@@ -463,7 +468,9 @@ public class PreTrainedTokenizer: Tokenizer {
         maxLength: Int? = nil,
         tools: [ToolSpec]? = nil
     ) throws -> [Int] {
-        try applyChatTemplate(messages: messages, chatTemplate: chatTemplate, addGenerationPrompt: addGenerationPrompt, truncation: truncation, maxLength: maxLength, tools: tools, additionalContext: nil)
+        try applyChatTemplate(
+            messages: messages, chatTemplate: chatTemplate, addGenerationPrompt: addGenerationPrompt, truncation: truncation, maxLength: maxLength,
+            tools: tools, additionalContext: nil)
     }
 
     public func applyChatTemplate(
@@ -484,15 +491,17 @@ public class PreTrainedTokenizer: Tokenizer {
         if let chatTemplate, case .literal(let template) = chatTemplate {
             // Use chat template from argument
             selectedChatTemplate = template
-        } else if let valueFromConfig = tokenizerConfig.chatTemplate {
-            if let arrayValue = valueFromConfig.arrayValue {
+        } else if !tokenizerConfig["chatTemplate"].isNull() {
+            let valueFromConfig = tokenizerConfig["chatTemplate"]
+            if let arrayValue = valueFromConfig.array() {
                 // If the config specifies a list of chat templates, convert them to a dictionary
-                let templateDict = Dictionary<String, String>(uniqueKeysWithValues: arrayValue.compactMap { item in
-                    guard let name = item.name?.stringValue, let template = item.template?.stringValue else {
-                        return nil
-                    }
-                    return (name, template)
-                })
+                let templateDict = [String: String](
+                    uniqueKeysWithValues: arrayValue.compactMap { item in
+                        guard let name = item["name"].string(), let template = item["template"].string() else {
+                            return nil
+                        }
+                        return (name, template)
+                    })
                 if let chatTemplate, case .name(let name) = chatTemplate {
                     // Select chat template from config by name
                     if let matchingDictEntry = templateDict[name] {
@@ -507,7 +516,7 @@ public class PreTrainedTokenizer: Tokenizer {
                     // Use default chat template from config
                     selectedChatTemplate = defaultChatTemplate
                 }
-            } else if let stringValue = valueFromConfig.stringValue {
+            } else if let stringValue = valueFromConfig.string() {
                 // Use chat template from config
                 selectedChatTemplate = stringValue
             }
@@ -537,14 +546,16 @@ public class PreTrainedTokenizer: Tokenizer {
         }
 
         // TODO: maybe keep NSString here
-        for (key, value) in tokenizerConfig.dictionary as [String : Any] {
-            if specialTokenAttributes.contains(key), !(value is NSNull) {
-                if let stringValue = value as? String {
-                    context[key] = stringValue
-                } else if let dictionary = value as? [NSString:Any] {
-                    context[key] = addedTokenAsString(Config(dictionary))
+        for (key, value) in tokenizerConfig.dictionary(or: [:]) {
+            if specialTokenAttributes.contains(key.string), !value.isNull() {
+                if let stringValue = value.string() {
+                    context[key.string] = stringValue
+                } else if let dictionary = value.dictionary() {
+                    context[key.string] = addedTokenAsString(Config(dictionary))
+                } else if let array: [String] = value.get() {
+                    context[key.string] = array
                 } else {
-                    context[key] = value
+                    context[key.string] = value
                 }
             }
         }
@@ -552,7 +563,7 @@ public class PreTrainedTokenizer: Tokenizer {
         let rendered = try template.render(context)
         var encodedTokens = encode(text: rendered, addSpecialTokens: false)
         var maxLength = maxLength ?? encodedTokens.count
-        maxLength = min(maxLength, tokenizerConfig.modelMaxLength?.intValue ?? maxLength)
+        maxLength = min(maxLength, tokenizerConfig["modelMaxLength"].integer() ?? maxLength)
         if encodedTokens.count > maxLength {
             if truncation {
                 encodedTokens = Array(encodedTokens.prefix(maxLength))
@@ -570,14 +581,14 @@ public struct AutoTokenizer {}
 struct PreTrainedTokenizerClasses {
     /// Class overrides for custom behaviour
     /// Not to be confused with the TokenizerModel classes defined in TokenizerModel
-    static let tokenizerClasses: [String : PreTrainedTokenizer.Type] = [
+    static let tokenizerClasses: [String: PreTrainedTokenizer.Type] = [
         "LlamaTokenizer": LlamaPreTrainedTokenizer.self
     ]
 }
 
 extension AutoTokenizer {
     static func tokenizerClass(for tokenizerConfig: Config) -> PreTrainedTokenizer.Type {
-        guard let tokenizerClassName = tokenizerConfig.tokenizerClass?.stringValue else {
+        guard let tokenizerClassName = tokenizerConfig["tokenizerClass"].string() else {
             return PreTrainedTokenizer.self
         }
 
@@ -620,18 +631,17 @@ extension AutoTokenizer {
 
 // MARK: - Tokenizer model classes
 
-class GPT2Tokenizer     : BPETokenizer {}
-class FalconTokenizer   : BPETokenizer {}
-class LlamaTokenizer    : BPETokenizer {}
-class CodeGenTokenizer  : BPETokenizer {}
-class WhisperTokenizer  : BPETokenizer {}
-class GemmaTokenizer    : BPETokenizer {}
+class GPT2Tokenizer: BPETokenizer {}
+class FalconTokenizer: BPETokenizer {}
+class LlamaTokenizer: BPETokenizer {}
+class CodeGenTokenizer: BPETokenizer {}
+class WhisperTokenizer: BPETokenizer {}
+class GemmaTokenizer: BPETokenizer {}
 class CodeLlamaTokenizer: BPETokenizer {}
-class CohereTokenizer   : BPETokenizer {}
-class Qwen2Tokenizer    : BPETokenizer {}
+class CohereTokenizer: BPETokenizer {}
+class Qwen2Tokenizer: BPETokenizer {}
 
-class T5Tokenizer       : UnigramTokenizer {}
-
+class T5Tokenizer: UnigramTokenizer {}
 
 // MARK: - PreTrainedTokenizer classes
 
@@ -645,20 +655,20 @@ func maybeUpdatePostProcessor(tokenizerConfig: Config, processorConfig: Config?)
     let postProcessor = PostProcessorFactory.fromConfig(config: processorConfig)
     guard !(postProcessor is TemplateProcessing) else { return nil }
 
-    let addBosToken = tokenizerConfig.addBosToken?.boolValue ?? false
-    let bosToken = addedTokenAsString(tokenizerConfig.bosToken)
+    let addBosToken = tokenizerConfig["addBosToken"].boolean(or: false)
+    let bosToken = addedTokenAsString(tokenizerConfig["bosToken"])
     if addBosToken && bosToken == nil {
         throw TokenizerError.mismatchedConfig("add_bos_token is True but bos_token is nil")
     }
 
-    let addEosToken = tokenizerConfig.addEosToken?.boolValue ?? false
-    let eosToken = addedTokenAsString(tokenizerConfig.eosToken)
+    let addEosToken = tokenizerConfig["addEosToken"].boolean(or: false)
+    let eosToken = addedTokenAsString(tokenizerConfig["eosToken"])
     if addEosToken && eosToken == nil {
         throw TokenizerError.mismatchedConfig("add_eos_token is True but eos_token is nil")
     }
 
     // alt implementation
-    var single: [[String : Any]] = []
+    var single: [[String: Any]] = []
     if addBosToken {
         single = single + [["SpecialToken": ["id": bosToken!, "type_id": 0]]]
     }
@@ -667,7 +677,7 @@ func maybeUpdatePostProcessor(tokenizerConfig: Config, processorConfig: Config?)
         single = single + [["SpecialToken": ["id": eosToken!, "type_id": 0]]]
     }
 
-    var pair: [[String : Any]] = single
+    var pair: [[String: Any]] = single
     if addBosToken {
         pair = pair + [["SpecialToken": ["id": bosToken!, "type_id": 1]]]
     }
@@ -685,19 +695,20 @@ class LlamaPreTrainedTokenizer: PreTrainedTokenizer {
     let isLegacy: Bool
 
     required init(tokenizerConfig: Config, tokenizerData: Config) throws {
-        isLegacy = tokenizerConfig.legacy?.boolValue ?? true
-        var configDictionary = tokenizerData.dictionary
+        isLegacy = tokenizerConfig["legacy"].boolean(or: true)
+        var configDictionary = tokenizerData.dictionary(or: [:])
         if !isLegacy {
-            configDictionary.removeValue(forKey: "normalizer")
-            configDictionary["pre_tokenizer"] = ["type": "Metaspace", "replacement": sentencePieceUnderline, "add_prefix_space": true, "prepend_scheme": "first"]
+            _ = configDictionary.removeValue(forKey: "normalizer")
+            configDictionary["pre_tokenizer"] = [
+                "type": "Metaspace", "replacement": .init(sentencePieceUnderline), "add_prefix_space": true, "prepend_scheme": "first",
+            ]
         }
 
-        if let postProcessorConfig = try maybeUpdatePostProcessor(tokenizerConfig: tokenizerConfig, processorConfig: tokenizerData.postProcessor) {
-            configDictionary["post_processor"] = postProcessorConfig.dictionary
+        if let postProcessorConfig = try maybeUpdatePostProcessor(tokenizerConfig: tokenizerConfig, processorConfig: tokenizerData["postProcessor"]) {
+            configDictionary["post_processor"] = .init(postProcessorConfig.dictionary(or: [:]))
         }
 
         let updatedData = Config(configDictionary)
         try super.init(tokenizerConfig: tokenizerConfig, tokenizerData: updatedData)
     }
 }
-

--- a/Sources/Tokenizers/UnigramTokenizer.swift
+++ b/Sources/Tokenizers/UnigramTokenizer.swift
@@ -36,7 +36,7 @@ class UnigramTokenizer: PreTrainedTokenizerModel {
     private let trie: Trie<Character>
         
     required init(tokenizerConfig: Config, tokenizerData: Config, addedTokens: [String : Int]) throws {
-        guard let configVocab = tokenizerData["model"]["vocab"].array() else {
+        guard let configVocab = tokenizerData.model.vocab.array() else {
             throw TokenizerError.missingVocab
         }
         
@@ -66,14 +66,14 @@ class UnigramTokenizer: PreTrainedTokenizerModel {
             min(partial, token.score)
         }
         
-        guard let unknownTokenId = tokenizerData["model"]["unkId"].integer() else { throw TokenizerError.malformedVocab }
+        guard let unknownTokenId = tokenizerData.model["unkId"].integer() else { throw TokenizerError.malformedVocab }
         self.unknownTokenId = unknownTokenId
         self.unknownPiece = SentencePieceToken(token: vocab[unknownTokenId].token, score: minScore - 10)
         
         tokensToIds = Dictionary(uniqueKeysWithValues: vocab.map { $0.token as NSString }.enumerated().map { ($1, $0) })
         bosTokenId = tokensToIds[bosToken! as NSString]      // May be nil
 
-        eosToken = tokenizerConfig["eosToken"].string()
+        eosToken = tokenizerConfig.eosToken.string()
         eosTokenId = eosToken == nil ? nil : tokensToIds[eosToken! as NSString]
 
         trie = Trie()

--- a/Sources/Tokenizers/UnigramTokenizer.swift
+++ b/Sources/Tokenizers/UnigramTokenizer.swift
@@ -36,21 +36,25 @@ class UnigramTokenizer: PreTrainedTokenizerModel {
     private let trie: Trie<Character>
         
     required init(tokenizerConfig: Config, tokenizerData: Config, addedTokens: [String : Int]) throws {
-        guard let configVocab = tokenizerData.model?.vocab?.value as? [[Any]] else {
+        guard let configVocab = tokenizerData["model"]["vocab"].array() else {
             throw TokenizerError.missingVocab
         }
         
         vocab = try configVocab.map { piece in
-            guard let token = piece.first as? String,
-                  let scoreValue = piece.last else {
+            let tuple = piece.array(or: [])
+            
+            guard let token = tuple.first?.string(),
+                  let scoreValue = tuple.last else {
+
                 throw TokenizerError.malformedVocab
             }
 
             let score: Float
-            if let floatScore = scoreValue as? Float {
+            if let floatScore = scoreValue.floating() {
                 score = floatScore
-            } else if let numberScore = scoreValue as? NSNumber {
-                score = numberScore.floatValue
+            } else if let numberScore = scoreValue.integer() {
+                score = Float(numberScore)
+
             } else {
                 throw TokenizerError.malformedVocab
             }
@@ -62,14 +66,14 @@ class UnigramTokenizer: PreTrainedTokenizerModel {
             min(partial, token.score)
         }
         
-        guard let unknownTokenId = tokenizerData.model?.unkId?.intValue else { throw TokenizerError.malformedVocab }
+        guard let unknownTokenId = tokenizerData["model"]["unkId"].integer() else { throw TokenizerError.malformedVocab }
         self.unknownTokenId = unknownTokenId
         self.unknownPiece = SentencePieceToken(token: vocab[unknownTokenId].token, score: minScore - 10)
         
         tokensToIds = Dictionary(uniqueKeysWithValues: vocab.map { $0.token as NSString }.enumerated().map { ($1, $0) })
         bosTokenId = tokensToIds[bosToken! as NSString]      // May be nil
 
-        eosToken = tokenizerConfig.eosToken?.stringValue
+        eosToken = tokenizerConfig["eosToken"].string()
         eosTokenId = eosToken == nil ? nil : tokensToIds[eosToken! as NSString]
 
         trie = Trie()

--- a/Tests/HubTests/ConfigTests.swift
+++ b/Tests/HubTests/ConfigTests.swift
@@ -6,94 +6,12 @@
 //
 
 import Foundation
-import Testing
 import Jinja
+import Testing
 
 @testable import Hub
 
 @Suite struct ConfigGeneral {
-    func string() async throws {
-        let cfg = Config("a")
-
-        #expect(cfg == "a")
-        #expect(cfg.get() == "a")
-        #expect(cfg.get(or: "b") == "a")
-        #expect(cfg.string() == "a")
-        #expect(cfg.string(or: "b") == "a")
-        #expect(cfg.get() == BinaryDistinctString("a"))
-        #expect(cfg.get(or: "b") == BinaryDistinctString("a"))
-        #expect(cfg.binaryDistinctString() == "a")
-        #expect(cfg.binaryDistinctString(or: "b") == "a")
-    }
-
-    func integer() async throws {
-        let cfg = Config(1)
-
-        #expect(cfg == 1)
-        #expect(cfg.get() == 1)
-        #expect(cfg.get(or: 2) == 1)
-        #expect(cfg.integer() == 1)
-        #expect(cfg.integer(or: 2) == 1)
-    }
-
-    @Test(arguments: [
-        (Config(1.1), 1.1 as Float),
-        (Config(1), 1.0 as Float),
-    ])
-    func floating(cfg: Config, exp: Float) async throws {
-        #expect(cfg == .init(exp))
-        #expect(cfg.get() == exp)
-        #expect(cfg.get(or: 2.2) == exp)
-        #expect(cfg.floating() == exp)
-        #expect(cfg.floating(or: 2.2) == exp)
-    }
-
-    @Test(arguments: [
-        (Config(true), true),
-        (Config(1), true),
-        (Config("T"), true),
-        (Config("t"), true),
-        (Config("TRUE"), true),
-        (Config("True"), true),
-        (Config("true"), true),
-        (Config("F"), false),
-        (Config("f"), false),
-        (Config("FALSE"), false),
-        (Config("False"), false),
-        (Config("false"), false),
-    ])
-    func boolean(cfg: Config, exp: Bool) async throws {
-        #expect(cfg.get() == exp)
-        #expect(cfg.get(or: !exp) == exp)
-        #expect(cfg.boolean() == exp)
-        #expect(cfg.boolean(or: !exp) == exp)
-    }
-
-    func token() async throws {
-        let cfg = Config((1, "a"))
-        let exp: (UInt, String) = (1, "a")
-
-        #expect(cfg == .init((1, "a")))
-        #expect(cfg.get()! == exp)
-        #expect(cfg.get(or: (2, "b")) == exp)
-        #expect(cfg.token()! == exp)
-        #expect(cfg.token(or: (2, "b")) == exp)
-    }
-
-    @Test(arguments: [
-        (Config(["a": 1]), 1),
-        (Config(["a": 2] as [NSString: Any]), 2),
-        (Config(["a": 3] as [NSString: Config]), 3),
-        (Config([BinaryDistinctString("a"): 4] as [BinaryDistinctString: Config]), 4),
-        (Config(["a": Config(5)]), 5),
-        (Config(["a": 6]), 6),
-        (Config((BinaryDistinctString("a"), 7)), 7),
-    ])
-    func dictionary(cfg: Config, exp: Int) async throws {
-        #expect(cfg["a"] == Config(exp))
-        #expect(cfg.get(or: [:])["a"] == Config(exp))
-    }
-
     @Test(arguments: [
         (Config.Data.integer(1), Config.Data.integer(2)),
         (Config.Data.string("a"), Config.Data.string("2")),
@@ -300,6 +218,90 @@ import Jinja
     }
 }
 
+@Suite struct ConfigEquatable {
+    @Test func string() async throws {
+        let cfg = Config("a")
+
+        #expect(cfg == "a")
+        #expect(cfg.get() == "a")
+        #expect(cfg.get(or: "b") == "a")
+        #expect(cfg.string() == "a")
+        #expect(cfg.string(or: "b") == "a")
+        #expect(cfg.get() == BinaryDistinctString("a"))
+        #expect(cfg.get(or: "b") == BinaryDistinctString("a"))
+        #expect(cfg.binaryDistinctString() == "a")
+        #expect(cfg.binaryDistinctString(or: "b") == "a")
+    }
+
+    @Test func integer() async throws {
+        let cfg = Config(1)
+
+        #expect(cfg == 1)
+        #expect(cfg.get() == 1)
+        #expect(cfg.get(or: 2) == 1)
+        #expect(cfg.integer() == 1)
+        #expect(cfg.integer(or: 2) == 1)
+    }
+
+    @Test(arguments: [
+        (Config(1.1), 1.1 as Float),
+        (Config(1), 1.0 as Float),
+    ])
+    func floating(cfg: Config, exp: Float) async throws {
+        #expect(cfg == .init(exp))
+        #expect(cfg.get() == exp)
+        #expect(cfg.get(or: 2.2) == exp)
+        #expect(cfg.floating() == exp)
+        #expect(cfg.floating(or: 2.2) == exp)
+    }
+
+    @Test(arguments: [
+        (Config(true), true),
+        (Config(1), true),
+        (Config("T"), true),
+        (Config("t"), true),
+        (Config("TRUE"), true),
+        (Config("True"), true),
+        (Config("true"), true),
+        (Config("F"), false),
+        (Config("f"), false),
+        (Config("FALSE"), false),
+        (Config("False"), false),
+        (Config("false"), false),
+    ])
+    func boolean(cfg: Config, exp: Bool) async throws {
+        #expect(cfg.get() == exp)
+        #expect(cfg.get(or: !exp) == exp)
+        #expect(cfg.boolean() == exp)
+        #expect(cfg.boolean(or: !exp) == exp)
+    }
+
+    @Test func token() async throws {
+        let cfg = Config((1, "a"))
+        let exp: (UInt, String) = (1, "a")
+
+        #expect(cfg == .init((1, "a")))
+        #expect(cfg.get()! == exp)
+        #expect(cfg.get(or: (2, "b")) == exp)
+        #expect(cfg.token()! == exp)
+        #expect(cfg.token(or: (2, "b")) == exp)
+    }
+
+    @Test(arguments: [
+        (Config(["a": 1]), 1),
+        (Config(["a": 2] as [NSString: Any]), 2),
+        (Config(["a": 3] as [NSString: Config]), 3),
+        (Config([BinaryDistinctString("a"): 4] as [BinaryDistinctString: Config]), 4),
+        (Config(["a": Config(5)]), 5),
+        (Config(["a": 6]), 6),
+        (Config((BinaryDistinctString("a"), 7)), 7),
+    ])
+    func dictionary(cfg: Config, exp: Int) async throws {
+        #expect(cfg["a"] == Config(exp))
+        #expect(cfg.get(or: [:])["a"] == Config(exp))
+    }
+}
+
 @Suite struct ConfigTextEncoding {
     private func createFile(with content: String, encoding: String.Encoding, fileName: String) throws -> URL {
         let tempDir = FileManager.default.temporaryDirectory
@@ -383,54 +385,54 @@ import Jinja
             "null": Config(),
         ])
         let template = """
-        {{ config["dict_of_floats"]["key1"] }}
-        {{ config["dict_of_tokens"]["key6"]["12"] }}
-        {{ config["arr_of_ints"][0] }}
-        {{ config["arr_of_ints"][1] }}
-        {{ config["arr_of_ints"][2] }}
-        {{ config["arr_of_floats"][0] }}
-        {{ config["arr_of_floats"][1] }}
-        {{ config["arr_of_strings"][0] }}
-        {{ config["arr_of_strings"][1] }}
-        {{ config["arr_of_bools"][0] }}
-        {{ config["arr_of_bools"][1] }}
-        {{ config["arr_of_dicts"][0]["key7"] }}
-        {{ config["arr_of_dicts"][1]["key8"] }}
-        {{ config["arr_of_tokens"][0]["1"] }}
-        {{ config["arr_of_tokens"][1]["2"] }}
-        {{ config["int"] }}
-        {{ config["float"] }}
-        {{ config["string"] }}
-        {{ config["bool"] }}
-        {{ config["token"]["1"] }}
-        """
+            {{ config["dict_of_floats"]["key1"] }}
+            {{ config["dict_of_tokens"]["key6"]["12"] }}
+            {{ config["arr_of_ints"][0] }}
+            {{ config["arr_of_ints"][1] }}
+            {{ config["arr_of_ints"][2] }}
+            {{ config["arr_of_floats"][0] }}
+            {{ config["arr_of_floats"][1] }}
+            {{ config["arr_of_strings"][0] }}
+            {{ config["arr_of_strings"][1] }}
+            {{ config["arr_of_bools"][0] }}
+            {{ config["arr_of_bools"][1] }}
+            {{ config["arr_of_dicts"][0]["key7"] }}
+            {{ config["arr_of_dicts"][1]["key8"] }}
+            {{ config["arr_of_tokens"][0]["1"] }}
+            {{ config["arr_of_tokens"][1]["2"] }}
+            {{ config["int"] }}
+            {{ config["float"] }}
+            {{ config["string"] }}
+            {{ config["bool"] }}
+            {{ config["token"]["1"] }}
+            """
         let exp = """
-        1.1
-        dfe
-        1
-        2
-        3
-        1.1
-        1.2
-        tre
-        jeq
-        true
-        false
-        1.1
-        1.2
-        ghz
-        pkr
-        678
-        1.1
-        hha
-        true
-        iop
-        """
-        
+            1.1
+            dfe
+            1
+            2
+            3
+            1.1
+            1.2
+            tre
+            jeq
+            true
+            false
+            1.1
+            1.2
+            ghz
+            pkr
+            678
+            1.1
+            hha
+            true
+            iop
+            """
+
         let got = try Template(template).render([
-            "config": cfg.toJinjaCompatible(),
+            "config": cfg.toJinjaCompatible()
         ])
-        
+
         #expect(got == exp)
     }
 }

--- a/Tests/HubTests/ConfigTests.swift
+++ b/Tests/HubTests/ConfigTests.swift
@@ -1,0 +1,436 @@
+//
+//  ConfigTests.swift
+//  swift-transformers
+//
+//  Created by Piotr Kowalczuk on 13.03.25.
+//
+
+import Foundation
+import Testing
+import Jinja
+
+@testable import Hub
+
+@Suite struct ConfigGeneral {
+    func string() async throws {
+        let cfg = Config("a")
+
+        #expect(cfg == "a")
+        #expect(cfg.get() == "a")
+        #expect(cfg.get(or: "b") == "a")
+        #expect(cfg.string() == "a")
+        #expect(cfg.string(or: "b") == "a")
+        #expect(cfg.get() == BinaryDistinctString("a"))
+        #expect(cfg.get(or: "b") == BinaryDistinctString("a"))
+        #expect(cfg.binaryDistinctString() == "a")
+        #expect(cfg.binaryDistinctString(or: "b") == "a")
+    }
+
+    func integer() async throws {
+        let cfg = Config(1)
+
+        #expect(cfg == 1)
+        #expect(cfg.get() == 1)
+        #expect(cfg.get(or: 2) == 1)
+        #expect(cfg.integer() == 1)
+        #expect(cfg.integer(or: 2) == 1)
+    }
+
+    @Test(arguments: [
+        (Config(1.1), 1.1 as Float),
+        (Config(1), 1.0 as Float),
+    ])
+    func floating(cfg: Config, exp: Float) async throws {
+        #expect(cfg == .init(exp))
+        #expect(cfg.get() == exp)
+        #expect(cfg.get(or: 2.2) == exp)
+        #expect(cfg.floating() == exp)
+        #expect(cfg.floating(or: 2.2) == exp)
+    }
+
+    @Test(arguments: [
+        (Config(true), true),
+        (Config(1), true),
+        (Config("T"), true),
+        (Config("t"), true),
+        (Config("TRUE"), true),
+        (Config("True"), true),
+        (Config("true"), true),
+        (Config("F"), false),
+        (Config("f"), false),
+        (Config("FALSE"), false),
+        (Config("False"), false),
+        (Config("false"), false),
+    ])
+    func boolean(cfg: Config, exp: Bool) async throws {
+        #expect(cfg.get() == exp)
+        #expect(cfg.get(or: !exp) == exp)
+        #expect(cfg.boolean() == exp)
+        #expect(cfg.boolean(or: !exp) == exp)
+    }
+
+    func token() async throws {
+        let cfg = Config((1, "a"))
+        let exp: (UInt, String) = (1, "a")
+
+        #expect(cfg == .init((1, "a")))
+        #expect(cfg.get()! == exp)
+        #expect(cfg.get(or: (2, "b")) == exp)
+        #expect(cfg.token()! == exp)
+        #expect(cfg.token(or: (2, "b")) == exp)
+    }
+
+    @Test(arguments: [
+        (Config(["a": 1]), 1),
+        (Config(["a": 2] as [NSString: Any]), 2),
+        (Config(["a": 3] as [NSString: Config]), 3),
+        (Config([BinaryDistinctString("a"): 4] as [BinaryDistinctString: Config]), 4),
+        (Config(["a": Config(5)]), 5),
+        (Config(["a": 6]), 6),
+        (Config((BinaryDistinctString("a"), 7)), 7),
+    ])
+    func dictionary(cfg: Config, exp: Int) async throws {
+        #expect(cfg["a"] == Config(exp))
+        #expect(cfg.get(or: [:])["a"] == Config(exp))
+    }
+
+    @Test(arguments: [
+        (Config.Data.integer(1), Config.Data.integer(2)),
+        (Config.Data.string("a"), Config.Data.string("2")),
+        (Config.Data.boolean(true), Config.Data.string("T")),
+        (Config.Data.boolean(true), Config.Data.boolean(false)),
+        (Config.Data.floating(1.1), Config.Data.floating(1.1000001)),
+        (Config.Data.token((1, "a")), Config.Data.token((1, "b"))),
+        (Config.Data.token((1, "a")), Config.Data.token((2, "a"))),
+        (Config.Data.dictionary(["1": Config()]), Config.Data.dictionary(["1": 1])),
+        (Config.Data.dictionary(["1": 10]), Config.Data.dictionary(["2": 10])),
+        (Config.Data.array(["1", "2"]), Config.Data.array(["1", "3"])),
+        (Config.Data.array([1, 2]), Config.Data.array([2, 1])),
+        (Config.Data.array([true, false]), Config.Data.array([true, true])),
+    ])
+    func hashable(lhs: Config.Data, rhs: Config.Data) async throws {
+        var lhsh = Hasher()
+        var rhsh = Hasher()
+
+        lhs.hash(into: &lhsh)
+        rhs.hash(into: &rhsh)
+
+        #expect(lhsh.finalize() != rhsh.finalize())
+    }
+}
+
+@Suite struct ConfigAsLiteral {
+    @Test("Config can be represented as a string literal")
+    func stringLiteral() async throws {
+        let cfg: Config = "test"
+
+        #expect(cfg == "test")
+    }
+
+    @Test("Config can be represented as a integer literal")
+    func integerLiteral() async throws {
+        let cfg: Config = 678
+
+        #expect(cfg == 678)
+    }
+
+    @Test("Config can be represented as a boolean literal")
+    func booleanLiteral() async throws {
+        let cfg: Config = true
+
+        #expect(cfg == true)
+    }
+
+    @Test("Config can be represented as a boolean literal")
+    func floatLiteral() async throws {
+        let cfg: Config = 1.1
+
+        #expect(cfg == 1.1)
+    }
+
+    @Test("Config can be represented as a dictionary literal")
+    func dictionaryLiteral() async throws {
+        let cfg: Config = ["key": 1.1]
+
+        #expect(cfg["key"].floating(or: 0) == 1.1)
+    }
+
+    @Test("Config can be represented as a dictionary literal")
+    func arrayLiteral() async throws {
+        let cfg: Config = [1.1, 1.2]
+
+        #expect(cfg[0] == 1.1)
+        #expect(cfg[1] == 1.2)
+    }
+}
+
+@Suite struct ConfigAccessors {
+    @Test("Config can be accessed via key subscript")
+    func keySubscript() async throws {
+        let cfg: Config = ["key": 1.1]
+
+        #expect(cfg["key"] == 1.1)
+        #expect(cfg["non_existent"].isNull())
+        #expect(cfg[1].isNull())
+    }
+
+    @Test("Config can be accessed via index subscript")
+    func indexSubscript() async throws {
+        let cfg: Config = [1, 2, 3, 4]
+
+        #expect(cfg[1] == 2)
+        #expect(cfg[99].isNull())
+        #expect(cfg[-1].isNull())
+    }
+
+    @Test("Config can be converted to an array")
+    func array() async throws {
+        let cfg: Config = [1, 2, 3, 4]
+
+        #expect(cfg.array() == [1, 2, 3, 4])
+        #expect(cfg.get() == [1, 2, 3, 4])
+        #expect(cfg.get(or: []) == [1, 2, 3, 4])
+        #expect(cfg["fake_key"].isNull())
+        #expect(cfg.dictionary() == nil)
+        #expect(cfg.dictionary(or: ["a": 1]) == ["a": 1])
+    }
+
+    @Test("Config can be converted to an array of strings")
+    func arrayOfStrings() async throws {
+        let cfg: Config = ["a", "b", "c"]
+
+        #expect(cfg.array() == ["a", "b", "c"])
+        #expect(cfg.get() == ["a", "b", "c"])
+        #expect(cfg.get() == [BinaryDistinctString("a"), BinaryDistinctString("b"), BinaryDistinctString("c")])
+        #expect(cfg.get(or: []) == [BinaryDistinctString("a"), BinaryDistinctString("b"), BinaryDistinctString("c")])
+        #expect(cfg.get(or: []) == ["a", "b", "c"])
+        #expect(cfg.dictionary() == nil)
+        #expect(cfg.dictionary(or: ["a": 1]) == ["a": 1])
+    }
+
+    @Test("Config can be converted to an array of strings")
+    func arrayOfConfigs() async throws {
+        let cfg: Config = [Config("a"), Config("b")]
+
+        #expect(cfg.array() == ["a", "b"])
+        #expect(cfg.get() == ["a", "b"])
+        #expect(cfg.get() == [BinaryDistinctString("a"), BinaryDistinctString("b")])
+        #expect(cfg.get(or: []) == [BinaryDistinctString("a"), BinaryDistinctString("b")])
+        #expect(cfg.get(or: []) == ["a", "b"])
+        #expect(cfg.dictionary() == nil)
+        #expect(cfg.dictionary(or: ["a": 1]) == ["a": 1])
+    }
+
+    @Test("Config can be converted to a dictionary of ints")
+    func dictionary() async throws {
+        let cfg: Config = ["a": 1, "b": 2, "c": 3, "d": 4]
+
+        #expect(cfg.dictionary() == ["a": 1, "b": 2, "c": 3, "d": 4])
+        #expect(cfg.get() == ["a": 1, "b": 2, "c": 3, "d": 4])
+        #expect(cfg.get(or: [:]) == ["a": 1, "b": 2, "c": 3, "d": 4])
+        #expect(cfg[666].isNull())
+        #expect(cfg.array() == nil)
+        #expect(cfg.array(or: ["a"]) == ["a"])
+    }
+    @Test("Config can be converted to a dictionary of configs")
+    func dictionaryOfConfigs() async throws {
+        let cfg: Config = ["a": .init([1, 2]), "b": .init([3, 4])]
+        let exp = [BinaryDistinctString("a"): Config([1, 2]), BinaryDistinctString("b"): Config([3, 4])]
+
+        #expect(cfg.dictionary() == exp)
+        #expect(cfg.get() == exp)
+        #expect(cfg.get(or: [:]) == exp)
+        #expect(cfg[666].isNull())
+        #expect(cfg.array() == nil)
+        #expect(cfg.array(or: ["a"]) == ["a"])
+    }
+}
+
+@Suite struct ConfigCodable {
+    @Test("Config can be serialized and deserialized")
+    func completeHappyExample() async throws {
+        let cfg: Config = [
+            "dict_of_floats": ["key1": 1.1],
+            "dict_of_ints": ["key2": 100],
+            "dict_of_strings": ["key3": "abc"],
+            "dict_of_bools": ["key4": false],
+            "dict_of_dicts": ["key5": ["key_inside": 99]],
+            "dict_of_tokens": ["key6": .init((12, "dfe"))],
+            "arr_empty": [],
+            "arr_of_ints": [1, 2, 3],
+            "arr_of_floats": [1.1, 1.2],
+            "arr_of_strings": ["a", "b"],
+            "arr_of_bools": [true, false],
+            "arr_of_dicts": [["key7": 1.1], ["key8": 1.2]],
+            "arr_of_tokens": [.init((1, "a")), .init((2, "b"))],
+            "int": 678,
+            "float": 1.1,
+            "string": "test",
+            "bool": true,
+            "token": .init((1, "test")),
+            "null": Config(),
+        ]
+
+        let data = try JSONEncoder().encode(cfg)
+
+        let got = try JSONDecoder().decode(Config.self, from: data)
+
+        #expect(got == cfg)
+        #expect(got["dict_of_floats"]["key1"] == 1.1)
+        #expect(got["dict_of_ints"]["key2"] == 100)
+        #expect(got["dict_of_strings"]["key3"] == "abc")
+        #expect(got["dict_of_bools"]["key4"] == false)
+        #expect(got["dict_of_dicts"]["key5"]["key_inside"] == 99)
+        #expect(got["dict_of_tokens"]["key6"].token()?.0 == 12)
+        #expect(got["dict_of_tokens"]["key6"].token()?.1 == "dfe")
+        #expect(got["arr_empty"].array()?.count == 0)
+        #expect(got["arr_of_ints"] == [1, 2, 3])
+        #expect(got["arr_of_floats"] == [1.1, 1.2])
+        #expect(got["arr_of_strings"] == ["a", "b"])
+        #expect(got["arr_of_bools"] == [true, false])
+        #expect(got["arr_of_dicts"][1]["key8"] == 1.2)
+        #expect(got["arr_of_tokens"][1].token(or: (0, "")) == (2, "b"))
+        #expect(got["arr_of_tokens"][2].token() == nil)
+        #expect(got["int"] == 678)
+        #expect(got["float"] == 1.1)
+        #expect(got["string"] == "test")
+        #expect(got["bool"] == true)
+        #expect(got["token"].token(or: (0, "")) == (1, "test"))
+        #expect(got["null"].isNull())
+    }
+}
+
+@Suite struct ConfigTextEncoding {
+    private func createFile(with content: String, encoding: String.Encoding, fileName: String) throws -> URL {
+        let tempDir = FileManager.default.temporaryDirectory
+        let fileURL = tempDir.appendingPathComponent(fileName)
+        guard let data = content.data(using: encoding) else {
+            throw NSError(domain: "EncodingError", code: 0, userInfo: [NSLocalizedDescriptionKey: "Could not encode string with \(encoding)"])
+        }
+        try data.write(to: fileURL)
+        return fileURL
+    }
+
+    @Test func utf16() async throws {
+        let json = """
+                {
+                  "a": ["val_1", "val_2"],
+                  "b": 2,
+                  "c": [[10, "tkn_1"], [12, "tkn_2"], [4, "tkn_3"]],
+                  "d": false,
+                  "e": {
+                    "e_1": 1.1,
+                    "e_2": [1, 2, 3]
+                  },
+                  "f": null
+                }
+            """
+
+        let urlUTF8 = try createFile(with: json, encoding: .utf8, fileName: "config_utf8.json")
+        let urlUTF16LE = try createFile(with: json, encoding: .utf16LittleEndian, fileName: "config_utf16_le.json")
+        let urlUTF16BE = try createFile(with: json, encoding: .utf16BigEndian, fileName: "config_utf16_be.json")
+
+        let dataUTF8 = try Data(contentsOf: urlUTF8)
+        let dataUTF16LE = try Data(contentsOf: urlUTF16LE)
+        let dataUTF16BE = try Data(contentsOf: urlUTF16BE)
+
+        #expect(dataUTF8.count != dataUTF16LE.count)
+        #expect(dataUTF8.count != dataUTF16BE.count)
+
+        let decoder = JSONDecoder()
+        let configUTF8 = try decoder.decode(Config.self, from: dataUTF8)
+        let configUTF16LE = try decoder.decode(Config.self, from: dataUTF16LE)
+        let configUTF16BE = try decoder.decode(Config.self, from: dataUTF16BE)
+
+        #expect(configUTF8 == configUTF16LE)
+        #expect(configUTF8 == configUTF16BE)
+
+        try FileManager.default.removeItem(at: urlUTF8)
+        try FileManager.default.removeItem(at: urlUTF16LE)
+        try FileManager.default.removeItem(at: urlUTF16BE)
+    }
+
+    @Test func unicode() {
+        // These are two different characters
+        let json = "{\"vocab\": {\"à\": 1, \"à\": 2}}"
+        let data = json.data(using: .utf8)
+        let dict = try! JSONSerialization.jsonObject(with: data!, options: []) as! [NSString: Any]
+        let config = Config(dict)
+
+        let vocab = config["vocab"].dictionary(or: [:])
+
+        #expect(vocab.count == 2)
+    }
+}
+
+@Suite struct ConfigTemplating {
+    @Test func completeHappyExample() async throws {
+        let cfg = Config([
+            "dict_of_floats": ["key1": 1.1],
+            "dict_of_tokens": ["key6": .init((12, "dfe"))],
+            "arr_empty": [],
+            "arr_of_ints": [1, 2, 3],
+            "arr_of_floats": [1.1, 1.2],
+            "arr_of_strings": ["tre", "jeq"],
+            "arr_of_bools": [true, false],
+            "arr_of_dicts": [["key7": 1.1], ["key8": 1.2]],
+            "arr_of_tokens": [.init((1, "ghz")), .init((2, "pkr"))],
+            "int": 678,
+            "float": 1.1,
+            "string": "hha",
+            "bool": true,
+            "token": .init((1, "iop")),
+            "null": Config(),
+        ])
+        let template = """
+        {{ config["dict_of_floats"]["key1"] }}
+        {{ config["dict_of_tokens"]["key6"]["12"] }}
+        {{ config["arr_of_ints"][0] }}
+        {{ config["arr_of_ints"][1] }}
+        {{ config["arr_of_ints"][2] }}
+        {{ config["arr_of_floats"][0] }}
+        {{ config["arr_of_floats"][1] }}
+        {{ config["arr_of_strings"][0] }}
+        {{ config["arr_of_strings"][1] }}
+        {{ config["arr_of_bools"][0] }}
+        {{ config["arr_of_bools"][1] }}
+        {{ config["arr_of_dicts"][0]["key7"] }}
+        {{ config["arr_of_dicts"][1]["key8"] }}
+        {{ config["arr_of_tokens"][0]["1"] }}
+        {{ config["arr_of_tokens"][1]["2"] }}
+        {{ config["int"] }}
+        {{ config["float"] }}
+        {{ config["string"] }}
+        {{ config["bool"] }}
+        {{ config["token"]["1"] }}
+        """
+        let exp = """
+        1.1
+        dfe
+        1
+        2
+        3
+        1.1
+        1.2
+        tre
+        jeq
+        true
+        false
+        1.1
+        1.2
+        ghz
+        pkr
+        678
+        1.1
+        hha
+        true
+        iop
+        """
+        
+        let got = try Template(template).render([
+            "config": cfg.toJinjaCompatible(),
+        ])
+        
+        #expect(got == exp)
+    }
+}

--- a/Tests/HubTests/DownloaderTests.swift
+++ b/Tests/HubTests/DownloaderTests.swift
@@ -57,31 +57,22 @@ final class DownloaderTests: XCTestCase {
         
         """
         
-        let downloader = Downloader(
-            from: url,
-            to: destination
-        )
+        let downloader = Downloader(to: destination)
+        let sub = await downloader.download(from: url)
         
-        // Store subscriber outside the continuation to maintain its lifecycle
-        var subscriber: AnyCancellable?
-        
-        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
-            subscriber = downloader.downloadState.sink { state in
-                switch state {
-                case .completed:
-                    continuation.resume()
-                case .failed(let error):
-                    continuation.resume(throwing: error)
-                case .downloading:
-                    break
-                case .notStarted:
-                    break
-                }
+        listen: for await state in sub {
+            switch state {
+            case .notStarted:
+                continue
+            case .downloading(let progress):
+                print("download progress \(progress)")
+                continue
+            case .failed(let error):
+                throw error
+            case .completed:
+                break listen
             }
         }
-        
-        // Cancel subscription after continuation completes
-        subscriber?.cancel()
         
         // Verify download completed successfully
         XCTAssertTrue(FileManager.default.fileExists(atPath: destination.path))
@@ -93,18 +84,22 @@ final class DownloaderTests: XCTestCase {
         let url = URL(string: "https://huggingface.co/coreml-projects/Llama-2-7b-chat-coreml/resolve/main/config.json")!
         let destination = tempDir.appendingPathComponent("config.json")
         
-        // Create downloader with incorrect expected size
-        let downloader = Downloader(
-            from: url,
-            to: destination,
-            expectedSize: 999999  // Incorrect size
-        )
-        
-        do {
-            try downloader.waitUntilDone()
-            XCTFail("Download should have failed due to size mismatch")
-        } catch {
-            
+        let downloader = Downloader(to: destination)
+        // Download with incorrect expected size
+        let sub = await downloader.download(from: url, expectedSize: 999999) // Incorrect size
+        listen: for await state in sub {
+            switch state {
+            case .notStarted:
+                continue
+            case .downloading(let progress):
+                print("download progress \(progress)")
+                continue
+            case .failed:
+                break listen
+            case .completed:
+                XCTFail("Download should have failed due to size mismatch")
+                break listen
+            }
         }
         
         // Verify no file was created at destination
@@ -121,40 +116,53 @@ final class DownloaderTests: XCTestCase {
         try FileManager.default.createDirectory(at: destination.deletingLastPathComponent(),
                                              withIntermediateDirectories: true)
                 
-        let downloader = Downloader(
-            from: url,
-            to: destination,
-            expectedSize: 73194001 // Correct size for verification
-        )
+        let downloader = Downloader(to: destination)
+        let sub = await downloader.download(from: url, expectedSize: 73194001) // Correct size for verification
         
         // First interruption point at 50%
         var threshold = 0.5
         
-        var subscriber: AnyCancellable?
-        
         do {
             // Monitor download progress and interrupt at thresholds to test if
             // download continues from where it left off
-            try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
-                subscriber = downloader.downloadState.sink { state in
-                    switch state {
-                    case .downloading(let progress):
-                        if threshold != 1.0 && progress >= threshold {
-                            // Move to next threshold and interrupt
-                            threshold = threshold == 0.5 ? 0.75 : 1.0
-                            downloader.cancel()
-                        }
-                    case .completed:
-                        continuation.resume()
-                    case .failed(let error):
-                        continuation.resume(throwing: error)
-                    case .notStarted:
-                        break
+            listen: for await state in sub {
+                switch state {
+                case .notStarted:
+                    continue
+                case .downloading(let progress):
+                    if threshold != 1.0 && progress >= threshold {
+                        // Move to next threshold and interrupt
+                        threshold = threshold == 0.5 ? 0.75 : 1.0
+                        await downloader.cancel()
                     }
+                case .failed(let error):
+                    throw error
+                case .completed:
+                    break listen
                 }
             }
             
-            subscriber?.cancel()
+            
+//            try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+//                subscriber = downloader.downloadState.sink { state in
+//                    switch state {
+//                    case .downloading(let progress):
+//                        if threshold != 1.0 && progress >= threshold {
+//                            // Move to next threshold and interrupt
+//                            threshold = threshold == 0.5 ? 0.75 : 1.0
+//                            downloader.cancel()
+//                        }
+//                    case .completed:
+//                        continuation.resume()
+//                    case .failed(let error):
+//                        continuation.resume(throwing: error)
+//                    case .notStarted:
+//                        break
+//                    }
+//                }
+//            }
+            
+//            subscriber?.cancel()
             
             // Verify the file exists and is complete
             if FileManager.default.fileExists(atPath: destination.path) {

--- a/Tests/HubTests/HubTests.swift
+++ b/Tests/HubTests/HubTests.swift
@@ -32,34 +32,33 @@ class HubTests: XCTestCase {
             let config = try await configLoader.modelConfig
             
             // Test leaf value (Int)
-            guard let eos = config.eos_token_id?.intValue else {
+            guard let eos = config["eos_token_id"].integer() else {
                 XCTFail("nil leaf value (Int)")
                 return
             }
             XCTAssertEqual(eos, 1)
             
             // Test leaf value (String)
-            guard let modelType = config.model_type?.stringValue else {
+            guard let modelType = config["model_type"].string() else {
                 XCTFail("nil leaf value (String)")
                 return
             }
             XCTAssertEqual(modelType, "t5")
             
             // Test leaf value (Array)
-            guard let architectures = config.architectures?.value as? [String] else {
+            guard let architectures: [String] = config["architectures"].get() else {
                 XCTFail("nil array")
                 return
             }
             XCTAssertEqual(architectures, ["T5ForConditionalGeneration"])
             
             // Test nested wrapper
-            guard let taskParams = config.task_specific_params else {
+            guard !config["task_specific_params"].isNull() else {
                 XCTFail("nil nested wrapper")
                 return
             }
-            XCTAssertTrue(type(of: taskParams) == Config.self)
 
-            guard let summarizationMaxLength = config.task_specific_params?.summarization?.max_length?.intValue else {
+            guard let summarizationMaxLength = config["task_specific_params"]["summarization"]["max_length"].integer() else {
                 XCTFail("cannot traverse nested containers")
                 return
             }
@@ -75,20 +74,20 @@ class HubTests: XCTestCase {
             let config = try await configLoader.modelConfig
 
             // Test leaf value (Int)
-            guard let eos = config.eosTokenId?.intValue else {
+            guard let eos = config["eosTokenId"].integer() else {
                 XCTFail("nil leaf value (Int)")
                 return
             }
             XCTAssertEqual(eos, 1)
             
             // Test leaf value (String)
-            guard let modelType = config.modelType?.stringValue else {
+            guard let modelType = config["modelType"].string() else {
                 XCTFail("nil leaf value (String)")
                 return
             }
             XCTAssertEqual(modelType, "t5")
                         
-            guard let summarizationMaxLength = config.taskSpecificParams?.summarization?.maxLength?.intValue else {
+            guard let summarizationMaxLength = config["taskSpecificParams"]["summarization"]["maxLength"].integer() else {
                 XCTFail("cannot traverse nested containers")
                 return
             }
@@ -105,17 +104,8 @@ class HubTests: XCTestCase {
         let dict = try! JSONSerialization.jsonObject(with: data!, options: []) as! [NSString: Any]
         let config = Config(dict)
 
-        let vocab_nsdict = config.dictionary["vocab"] as! NSDictionary
-        let vocab_nsstring = config.dictionary["vocab"] as! [NSString: Int]
-        let vocab = config.vocab!.dictionary
+        let vocab = config["vocab"].dictionary(or: [:])
 
-        XCTAssertEqual(vocab_nsdict.count, 2)
-        XCTAssertEqual(vocab_nsstring.count, 2)
         XCTAssertEqual(vocab.count, 2)
-
-        // This is expected because, unlike with NSString, String comparison uses the canonical Unicode representation
-        // https://developer.apple.com/documentation/swift/string#Modifying-and-Comparing-Strings
-        let vocab_dict = config.dictionary["vocab"] as! [String: Int]
-        XCTAssertNotEqual(vocab_dict.count, 2)
     }
 }

--- a/Tests/NormalizerTests/NormalizerTests.swift
+++ b/Tests/NormalizerTests/NormalizerTests.swift
@@ -19,7 +19,7 @@ class NormalizerTests: XCTestCase {
         ]
 
         for (arg, expect) in testCases {
-            let config = Config(BinaryDistinctDictionary())
+            let config = Config([String: Config]())
             let normalizer = LowercaseNormalizer(config: config)
             XCTAssertEqual(normalizer.normalize(text: arg), expect)
         }
@@ -42,7 +42,7 @@ class NormalizerTests: XCTestCase {
         ]
 
         for (arg, expect) in testCases {
-            let config = Config(BinaryDistinctDictionary())
+            let config = Config([String: Config]())
             let normalizer = NFDNormalizer(config: config)
             XCTAssertEqual(normalizer.normalize(text: arg), expect)
         }
@@ -65,7 +65,7 @@ class NormalizerTests: XCTestCase {
         ]
 
         for (arg, expect) in testCases {
-            let config = Config(BinaryDistinctDictionary())
+            let config = Config([String: Config]())
             let normalizer = NFCNormalizer(config: config)
             XCTAssertEqual(normalizer.normalize(text: arg), expect)
         }
@@ -88,7 +88,7 @@ class NormalizerTests: XCTestCase {
         ]
 
         for (arg, expect) in testCases {
-            let config = Config(BinaryDistinctDictionary())
+            let config = Config([String: Config]())
             let normalizer = NFKDNormalizer(config: config)
             XCTAssertEqual(normalizer.normalize(text: arg), expect)
         }
@@ -111,7 +111,7 @@ class NormalizerTests: XCTestCase {
         ]
 
         for (arg, expect) in testCases {
-            let config = Config(BinaryDistinctDictionary())
+            let config = Config([String: Config]())
             let normalizer = NFKCNormalizer(config: config)
             XCTAssertEqual(normalizer.normalize(text: arg), expect)
         }
@@ -171,7 +171,7 @@ class NormalizerTests: XCTestCase {
         ]
 
         for (arg, expect) in testCases {
-            let config = Config(BinaryDistinctDictionary())
+            let config = Config([String: Config]())
             let normalizer = BertNormalizer(config: config)
             XCTAssertEqual(normalizer.normalize(text: arg), expect)
         }
@@ -196,7 +196,7 @@ class NormalizerTests: XCTestCase {
         ]
 
         for (arg, expect) in testCases {
-            let config = Config(BinaryDistinctDictionary())
+            let config = Config([String: Config]())
             let normalizer = PrecompiledNormalizer(config: config)
             XCTAssertEqual(normalizer.normalize(text: arg), expect)
         }
@@ -219,7 +219,7 @@ class NormalizerTests: XCTestCase {
         ]
 
         for (arg, expect) in testCases {
-            let config = Config(BinaryDistinctDictionary())
+            let config = Config([String: Config]())
             let normalizer = StripAccentsNormalizer(config: config)
             XCTAssertEqual(normalizer.normalize(text: arg), expect)
         }

--- a/Tests/NormalizerTests/NormalizerTests.swift
+++ b/Tests/NormalizerTests/NormalizerTests.swift
@@ -19,7 +19,7 @@ class NormalizerTests: XCTestCase {
         ]
 
         for (arg, expect) in testCases {
-            let config = Config([:])
+            let config = Config(BinaryDistinctDictionary())
             let normalizer = LowercaseNormalizer(config: config)
             XCTAssertEqual(normalizer.normalize(text: arg), expect)
         }
@@ -42,7 +42,7 @@ class NormalizerTests: XCTestCase {
         ]
 
         for (arg, expect) in testCases {
-            let config = Config([:])
+            let config = Config(BinaryDistinctDictionary())
             let normalizer = NFDNormalizer(config: config)
             XCTAssertEqual(normalizer.normalize(text: arg), expect)
         }
@@ -65,7 +65,7 @@ class NormalizerTests: XCTestCase {
         ]
 
         for (arg, expect) in testCases {
-            let config = Config([:])
+            let config = Config(BinaryDistinctDictionary())
             let normalizer = NFCNormalizer(config: config)
             XCTAssertEqual(normalizer.normalize(text: arg), expect)
         }
@@ -88,7 +88,7 @@ class NormalizerTests: XCTestCase {
         ]
 
         for (arg, expect) in testCases {
-            let config = Config([:])
+            let config = Config(BinaryDistinctDictionary())
             let normalizer = NFKDNormalizer(config: config)
             XCTAssertEqual(normalizer.normalize(text: arg), expect)
         }
@@ -111,7 +111,7 @@ class NormalizerTests: XCTestCase {
         ]
 
         for (arg, expect) in testCases {
-            let config = Config([:])
+            let config = Config(BinaryDistinctDictionary())
             let normalizer = NFKCNormalizer(config: config)
             XCTAssertEqual(normalizer.normalize(text: arg), expect)
         }
@@ -171,7 +171,7 @@ class NormalizerTests: XCTestCase {
         ]
 
         for (arg, expect) in testCases {
-            let config = Config([:])
+            let config = Config(BinaryDistinctDictionary())
             let normalizer = BertNormalizer(config: config)
             XCTAssertEqual(normalizer.normalize(text: arg), expect)
         }
@@ -196,7 +196,7 @@ class NormalizerTests: XCTestCase {
         ]
 
         for (arg, expect) in testCases {
-            let config = Config([:])
+            let config = Config(BinaryDistinctDictionary())
             let normalizer = PrecompiledNormalizer(config: config)
             XCTAssertEqual(normalizer.normalize(text: arg), expect)
         }
@@ -219,7 +219,7 @@ class NormalizerTests: XCTestCase {
         ]
 
         for (arg, expect) in testCases {
-            let config = Config([:])
+            let config = Config(BinaryDistinctDictionary())
             let normalizer = StripAccentsNormalizer(config: config)
             XCTAssertEqual(normalizer.normalize(text: arg), expect)
         }

--- a/Tests/PreTokenizerTests/PreTokenizerTests.swift
+++ b/Tests/PreTokenizerTests/PreTokenizerTests.swift
@@ -11,7 +11,7 @@ import Hub
 class PreTokenizerTests: XCTestCase {
 
     func testWhitespacePreTokenizer() {
-        let preTokenizer = WhitespacePreTokenizer(config: Config(BinaryDistinctDictionary()))
+        let preTokenizer = WhitespacePreTokenizer(config: Config([String: Config]()))
 
         XCTAssertEqual(
             preTokenizer.preTokenize(text: "Hey friend!"),
@@ -28,7 +28,7 @@ class PreTokenizerTests: XCTestCase {
     }
 
     func testPunctuationPreTokenizer() {
-        let preTokenizer = PunctuationPreTokenizer(config: Config(BinaryDistinctDictionary()))
+        let preTokenizer = PunctuationPreTokenizer(config: Config([String: Config]()))
 
         XCTAssertEqual(
             preTokenizer.preTokenize(text: "Hey friend!"),
@@ -45,7 +45,7 @@ class PreTokenizerTests: XCTestCase {
     }
 
     func testByteLevelPreTokenizer() {
-        let preTokenizer1 = ByteLevelPreTokenizer(config: Config(BinaryDistinctDictionary()))
+        let preTokenizer1 = ByteLevelPreTokenizer(config: Config([String: Config]()))
 
         XCTAssertEqual(
             preTokenizer1.preTokenize(text: "Hey friend!"),
@@ -92,7 +92,7 @@ class PreTokenizerTests: XCTestCase {
     }
 
     func testDigitsPreTokenizer() {
-        let preTokenizer1 = DigitsPreTokenizer(config: Config(BinaryDistinctDictionary()))
+        let preTokenizer1 = DigitsPreTokenizer(config: Config([String: Config]()))
 
         XCTAssertEqual(
             preTokenizer1.preTokenize(text: "1 12 123! 1234abc"),
@@ -174,7 +174,7 @@ class PreTokenizerTests: XCTestCase {
     }
 
     func testBertPreTokenizer() {
-        let preTokenizer1 = BertPreTokenizer(config: Config(BinaryDistinctDictionary()))
+        let preTokenizer1 = BertPreTokenizer(config: Config([String: Config]()))
         XCTAssertEqual(
             preTokenizer1.preTokenize(text: "Hey friend!"),
             ["Hey", "friend", "!"]

--- a/Tests/PreTokenizerTests/PreTokenizerTests.swift
+++ b/Tests/PreTokenizerTests/PreTokenizerTests.swift
@@ -11,7 +11,7 @@ import Hub
 class PreTokenizerTests: XCTestCase {
 
     func testWhitespacePreTokenizer() {
-        let preTokenizer = WhitespacePreTokenizer(config: Config([:]))
+        let preTokenizer = WhitespacePreTokenizer(config: Config(BinaryDistinctDictionary()))
 
         XCTAssertEqual(
             preTokenizer.preTokenize(text: "Hey friend!"),
@@ -28,7 +28,7 @@ class PreTokenizerTests: XCTestCase {
     }
 
     func testPunctuationPreTokenizer() {
-        let preTokenizer = PunctuationPreTokenizer(config: Config([:]))
+        let preTokenizer = PunctuationPreTokenizer(config: Config(BinaryDistinctDictionary()))
 
         XCTAssertEqual(
             preTokenizer.preTokenize(text: "Hey friend!"),
@@ -45,7 +45,7 @@ class PreTokenizerTests: XCTestCase {
     }
 
     func testByteLevelPreTokenizer() {
-        let preTokenizer1 = ByteLevelPreTokenizer(config: Config([:]))
+        let preTokenizer1 = ByteLevelPreTokenizer(config: Config(BinaryDistinctDictionary()))
 
         XCTAssertEqual(
             preTokenizer1.preTokenize(text: "Hey friend!"),
@@ -92,7 +92,7 @@ class PreTokenizerTests: XCTestCase {
     }
 
     func testDigitsPreTokenizer() {
-        let preTokenizer1 = DigitsPreTokenizer(config: Config([:]))
+        let preTokenizer1 = DigitsPreTokenizer(config: Config(BinaryDistinctDictionary()))
 
         XCTAssertEqual(
             preTokenizer1.preTokenize(text: "1 12 123! 1234abc"),
@@ -174,7 +174,7 @@ class PreTokenizerTests: XCTestCase {
     }
 
     func testBertPreTokenizer() {
-        let preTokenizer1 = BertPreTokenizer(config: Config([:]))
+        let preTokenizer1 = BertPreTokenizer(config: Config(BinaryDistinctDictionary()))
         XCTAssertEqual(
             preTokenizer1.preTokenize(text: "Hey friend!"),
             ["Hey", "friend", "!"]


### PR DESCRIPTION
This PR is a follow-up for https://github.com/huggingface/swift-transformers/pull/189. It changes the remaining parts the the Hub package to be compatible with structured concurrency. As a result:
- `Downloader`, `LanguageModelConfigurationFromHub` and `HubApi` conforms to the `Sendable` protocol.
- `Broadcaster<E: Sendable>` got added as a building block replacing `CurrentValueSubject`.
- Extra flags added to `Package.swift` that enable selective support for Swift 6 to `Hub` and `HubTests` packages. 


This PR can be merged after https://github.com/huggingface/swift-transformers/pull/189 becomes part of the mainline. In its current form, it's quite verbose. Relevant changes to this PR are located in `Source/Hub/Hub`, `Source/Hub/HubApi` and `Tests/HubTests/DownloaderTests.swift`