### PR TITLE
Add incomplete download support

### DIFF
--- a/Sources/Hub/Downloader.swift
+++ b/Sources/Hub/Downloader.swift
@@ -129,6 +129,8 @@ class Downloader: NSObject, ObservableObject {
                         requestHeaders["Authorization"] = "Bearer \(authToken)"
                     }
                     
+                    self.downloadedSize = resumeSize
+                    
                     // Set Range header if we're resuming
                     if resumeSize > 0 {
                         requestHeaders["Range"] = "bytes=\(resumeSize)-"
@@ -207,7 +209,7 @@ class Downloader: NSObject, ObservableObject {
             throw DownloadError.unexpectedError
         }
 
-        downloadedSize = resumeSize
+//        downloadedSize = resumeSize
         
         // Create a buffer to collect bytes before writing to disk
         var buffer = Data(capacity: chunkSize)
@@ -283,6 +285,7 @@ class Downloader: NSObject, ObservableObject {
 
     func cancel() {
         urlSession?.invalidateAndCancel()
+        downloadState.value = .failed(URLError(.cancelled))
     }
 }
 

--- a/Sources/Hub/Hub.swift
+++ b/Sources/Hub/Hub.swift
@@ -51,13 +51,13 @@ public extension Hub {
         }
     }
 
-    enum RepoType: String {
+    enum RepoType: String, Codable {
         case models
         case datasets
         case spaces
     }
-
-    struct Repo {
+    
+    struct Repo: Codable {
         public let id: String
         public let type: RepoType
 

--- a/Sources/Hub/HubApi.swift
+++ b/Sources/Hub/HubApi.swift
@@ -432,10 +432,7 @@ public extension HubApi {
             if FileManager.default.fileExists(atPath: incompleteFile.path) {
                 if let fileAttributes = try? FileManager.default.attributesOfItem(atPath: incompleteFile.path) {
                     resumeSize = (fileAttributes[FileAttributeKey.size] as? Int) ?? 0
-                    print("[HubApi] Found existing incomplete file for \(destination.lastPathComponent): \(resumeSize) bytes at \(incompleteFile.path)")
                 }
-            } else {
-                print("[HubApi] No existing incomplete file found for \(destination.lastPathComponent)")
             }
             
             let downloader = Downloader(
@@ -465,7 +462,6 @@ public extension HubApi {
                 return destination
             } catch {
                 // If download fails, leave the incomplete file in place for future resume
-                print("[HubApi] Download failed but incomplete file is preserved for future resume: \(error.localizedDescription)")
                 throw error
             }
         }

--- a/Sources/Hub/HubApi.swift
+++ b/Sources/Hub/HubApi.swift
@@ -366,7 +366,7 @@ public extension HubApi {
             FileManager.default.fileExists(atPath: destination.path)
         }
         
-        // We're using incomplete destination to prepare cache destination because incomplete files include lfs + non-lfs files (vs only lfs for metadata files)
+        /// We're using incomplete destination to prepare cache destination because incomplete files include lfs + non-lfs files (vs only lfs for metadata files)
         func prepareCacheDestination(_ incompleteDestination: URL) throws {
             let directoryURL = incompleteDestination.deletingLastPathComponent()
             try FileManager.default.createDirectory(at: directoryURL, withIntermediateDirectories: true, attributes: nil)

--- a/Tests/HubTests/DownloaderTests.swift
+++ b/Tests/HubTests/DownloaderTests.swift
@@ -59,9 +59,16 @@ final class DownloaderTests: XCTestCase {
 
         """
         
+        let cacheDir = tempDir.appendingPathComponent("cache")
+        try? FileManager.default.createDirectory(at: cacheDir, withIntermediateDirectories: true)
+
+        let incompleteDestination = cacheDir.appendingPathComponent("config.json.incomplete")
+        FileManager.default.createFile(atPath: incompleteDestination.path, contents: nil, attributes: nil)
+        
         let downloader = Downloader(
             from: url,
-            to: destination
+            to: destination,
+            incompleteDestination: incompleteDestination
         )
         
         // Store subscriber outside the continuation to maintain its lifecycle
@@ -95,10 +102,17 @@ final class DownloaderTests: XCTestCase {
         let url = URL(string: "https://huggingface.co/coreml-projects/Llama-2-7b-chat-coreml/resolve/main/config.json")!
         let destination = tempDir.appendingPathComponent("config.json")
         
+        let cacheDir = tempDir.appendingPathComponent("cache")
+        try? FileManager.default.createDirectory(at: cacheDir, withIntermediateDirectories: true)
+
+        let incompleteDestination = cacheDir.appendingPathComponent("config.json.incomplete")
+        FileManager.default.createFile(atPath: incompleteDestination.path, contents: nil, attributes: nil)
+
         // Create downloader with incorrect expected size
         let downloader = Downloader(
             from: url,
             to: destination,
+            incompleteDestination: incompleteDestination,
             expectedSize: 999999 // Incorrect size
         )
         
@@ -120,10 +134,17 @@ final class DownloaderTests: XCTestCase {
         // Create parent directory if it doesn't exist
         try FileManager.default.createDirectory(at: destination.deletingLastPathComponent(),
                                                 withIntermediateDirectories: true)
-                
+        
+        let cacheDir = tempDir.appendingPathComponent("cache")
+        try? FileManager.default.createDirectory(at: cacheDir, withIntermediateDirectories: true)
+
+        let incompleteDestination = cacheDir.appendingPathComponent("config.json.incomplete")
+        FileManager.default.createFile(atPath: incompleteDestination.path, contents: nil, attributes: nil)
+
         let downloader = Downloader(
             from: url,
             to: destination,
+            incompleteDestination: incompleteDestination,
             expectedSize: 73194001 // Correct size for verification
         )
         
@@ -167,29 +188,5 @@ final class DownloaderTests: XCTestCase {
         } catch {
             throw error
         }
-    }
-    
-    func testAutomaticIncompleteFileDetection() throws {
-        let url = URL(string: "https://huggingface.co/coreml-projects/sam-2-studio/resolve/main/SAM%202%20Studio%201.1.zip")!
-        let destination = tempDir.appendingPathComponent("SAM%202%20Studio%201.1.zip")
-        
-        // Create a sample incomplete file with test content
-        let incompletePath = Downloader.incompletePath(for: destination)
-        try FileManager.default.createDirectory(at: incompletePath.deletingLastPathComponent(), withIntermediateDirectories: true)
-        let testContent = Data(repeating: 65, count: 1024) // 1KB of data
-        FileManager.default.createFile(atPath: incompletePath.path, contents: testContent)
-        
-        // Create a downloader for the same destination
-        // It should automatically detect and use the incomplete file
-        let downloader = Downloader(
-            from: url,
-            to: destination
-        )
-        
-        // Verify the downloader found and is using the incomplete file
-        XCTAssertEqual(downloader.downloadedSize, 1024, "Should have detected the incomplete file and set resumeSize")
-        
-        // Clean up
-        try? FileManager.default.removeItem(at: incompletePath)
     }
 }

--- a/Tests/HubTests/DownloaderTests.swift
+++ b/Tests/HubTests/DownloaderTests.swift
@@ -24,9 +24,9 @@ enum DownloadError: LocalizedError {
     }
 }
 
-fileprivate extension Downloader {
+private extension Downloader {
     func interruptDownload() {
-        self.session?.invalidateAndCancel()
+        session?.invalidateAndCancel()
     }
 }
 

--- a/Tests/HubTests/HubApiTests.swift
+++ b/Tests/HubTests/HubApiTests.swift
@@ -173,9 +173,9 @@ class SnapshotDownloadTests: XCTestCase {
         let base = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first!
         return base.appending(component: "huggingface-tests")
     }()
-
+    
     override func setUp() { }
-
+    
     override func tearDown() {
         do {
             try FileManager.default.removeItem(at: downloadDestination)
@@ -183,11 +183,11 @@ class SnapshotDownloadTests: XCTestCase {
             print("Can't remove test download destination \(downloadDestination), error: \(error)")
         }
     }
-
+    
     func getRelativeFiles(url: URL, repo: String) -> [String] {
         var filenames: [String] = []
         let prefix = downloadDestination.appending(path: "models/\(repo)").path.appending("/")
-
+        
         if let enumerator = FileManager.default.enumerator(at: url, includingPropertiesForKeys: [.isRegularFileKey], options: [.skipsHiddenFiles], errorHandler: nil) {
             for case let fileURL as URL in enumerator {
                 do {
@@ -202,7 +202,7 @@ class SnapshotDownloadTests: XCTestCase {
         }
         return filenames
     }
-
+    
     func testDownload() async throws {
         let hubApi = HubApi(downloadBase: downloadDestination)
         var lastProgress: Progress? = nil
@@ -226,7 +226,7 @@ class SnapshotDownloadTests: XCTestCase {
         XCTAssertEqual(lastProgress?.fractionCompleted, 1)
         XCTAssertEqual(lastProgress?.completedUnitCount, 6)
         XCTAssertEqual(downloadedTo, downloadDestination.appending(path: "models/\(repo)"))
-
+        
         XCTAssertEqual(
             Set(downloadedFilenames),
             Set([
@@ -237,7 +237,7 @@ class SnapshotDownloadTests: XCTestCase {
             ])
         )
     }
-
+    
     /// Background sessions get rate limited by the OS, see discussion here: https://github.com/huggingface/swift-transformers/issues/61
     /// Test only one file at a time
     func testDownloadInBackground() async throws {
@@ -251,7 +251,7 @@ class SnapshotDownloadTests: XCTestCase {
         XCTAssertEqual(lastProgress?.fractionCompleted, 1)
         XCTAssertEqual(lastProgress?.completedUnitCount, 1)
         XCTAssertEqual(downloadedTo, downloadDestination.appending(path: "models/\(repo)"))
-
+        
         let downloadedFilenames = getRelativeFiles(url: downloadDestination, repo: repo)
         XCTAssertEqual(
             Set(downloadedFilenames),
@@ -260,7 +260,7 @@ class SnapshotDownloadTests: XCTestCase {
             ])
         )
     }
-
+    
     func testCustomEndpointDownload() async throws {
         let hubApi = HubApi(downloadBase: downloadDestination, endpoint: "https://hf-mirror.com")
         var lastProgress: Progress? = nil
@@ -272,7 +272,7 @@ class SnapshotDownloadTests: XCTestCase {
         XCTAssertEqual(lastProgress?.fractionCompleted, 1)
         XCTAssertEqual(lastProgress?.completedUnitCount, 6)
         XCTAssertEqual(downloadedTo, downloadDestination.appending(path: "models/\(repo)"))
-
+        
         let downloadedFilenames = getRelativeFiles(url: downloadDestination, repo: repo)
         XCTAssertEqual(
             Set(downloadedFilenames),
@@ -326,7 +326,7 @@ class SnapshotDownloadTests: XCTestCase {
     func testDownloadFileMetadataExists() async throws {
         let hubApi = HubApi(downloadBase: downloadDestination)
         var lastProgress: Progress? = nil
-
+        
         let downloadedTo = try await hubApi.snapshot(from: repo, matching: "*.json") { progress in
             print("Total Progress: \(progress.fractionCompleted)")
             print("Files Completed: \(progress.completedUnitCount) of \(progress.totalUnitCount)")
@@ -336,7 +336,7 @@ class SnapshotDownloadTests: XCTestCase {
         XCTAssertEqual(lastProgress?.fractionCompleted, 1)
         XCTAssertEqual(lastProgress?.completedUnitCount, 6)
         XCTAssertEqual(downloadedTo, downloadDestination.appending(path: "models/\(repo)"))
-
+        
         let downloadedFilenames = getRelativeFiles(url: downloadDestination, repo: repo)
         XCTAssertEqual(
             Set(downloadedFilenames),
@@ -375,7 +375,7 @@ class SnapshotDownloadTests: XCTestCase {
         
         attributes = try FileManager.default.attributesOfItem(atPath: configPath.path)
         let secondDownloadTimestamp = attributes[.modificationDate] as! Date
-
+        
         // File will not be downloaded again thus last modified date will remain unchanged
         XCTAssertTrue(originalTimestamp == secondDownloadTimestamp)
     }
@@ -383,7 +383,7 @@ class SnapshotDownloadTests: XCTestCase {
     func testDownloadFileMetadataSame() async throws {
         let hubApi = HubApi(downloadBase: downloadDestination)
         var lastProgress: Progress? = nil
-
+        
         let downloadedTo = try await hubApi.snapshot(from: repo, matching: "tokenizer.json") { progress in
             print("Total Progress: \(progress.fractionCompleted)")
             print("Files Completed: \(progress.completedUnitCount) of \(progress.totalUnitCount)")
@@ -393,7 +393,7 @@ class SnapshotDownloadTests: XCTestCase {
         XCTAssertEqual(lastProgress?.fractionCompleted, 1)
         XCTAssertEqual(lastProgress?.completedUnitCount, 1)
         XCTAssertEqual(downloadedTo, downloadDestination.appending(path: "models/\(repo)"))
-
+        
         let downloadedFilenames = getRelativeFiles(url: downloadDestination, repo: repo)
         XCTAssertEqual(Set(downloadedFilenames), Set(["tokenizer.json"]))
         
@@ -430,7 +430,7 @@ class SnapshotDownloadTests: XCTestCase {
     func testDownloadFileMetadataCorrupted() async throws {
         let hubApi = HubApi(downloadBase: downloadDestination)
         var lastProgress: Progress? = nil
-
+        
         let downloadedTo = try await hubApi.snapshot(from: repo, matching: "*.json") { progress in
             print("Total Progress: \(progress.fractionCompleted)")
             print("Files Completed: \(progress.completedUnitCount) of \(progress.totalUnitCount)")
@@ -440,7 +440,7 @@ class SnapshotDownloadTests: XCTestCase {
         XCTAssertEqual(lastProgress?.fractionCompleted, 1)
         XCTAssertEqual(lastProgress?.completedUnitCount, 6)
         XCTAssertEqual(downloadedTo, downloadDestination.appending(path: "models/\(repo)"))
-
+        
         let downloadedFilenames = getRelativeFiles(url: downloadDestination, repo: repo)
         XCTAssertEqual(
             Set(downloadedFilenames),
@@ -483,7 +483,7 @@ class SnapshotDownloadTests: XCTestCase {
         
         attributes = try FileManager.default.attributesOfItem(atPath: configPath.path)
         let secondDownloadTimestamp = attributes[.modificationDate] as! Date
-
+        
         // File will be downloaded again thus last modified date will change
         XCTAssertTrue(originalTimestamp != secondDownloadTimestamp)
         
@@ -499,7 +499,7 @@ class SnapshotDownloadTests: XCTestCase {
         
         attributes = try FileManager.default.attributesOfItem(atPath: configPath.path)
         let thirdDownloadTimestamp = attributes[.modificationDate] as! Date
-
+        
         // File will be downloaded again thus last modified date will change
         XCTAssertTrue(originalTimestamp != thirdDownloadTimestamp)
     }
@@ -507,7 +507,7 @@ class SnapshotDownloadTests: XCTestCase {
     func testDownloadLargeFileMetadataCorrupted() async throws {
         let hubApi = HubApi(downloadBase: downloadDestination)
         var lastProgress: Progress? = nil
-
+        
         let downloadedTo = try await hubApi.snapshot(from: repo, matching: "*.mlmodel") { progress in
             print("Total Progress: \(progress.fractionCompleted)")
             print("Files Completed: \(progress.completedUnitCount) of \(progress.totalUnitCount)")
@@ -517,7 +517,7 @@ class SnapshotDownloadTests: XCTestCase {
         XCTAssertEqual(lastProgress?.fractionCompleted, 1)
         XCTAssertEqual(lastProgress?.completedUnitCount, 1)
         XCTAssertEqual(downloadedTo, downloadDestination.appending(path: "models/\(repo)"))
-
+        
         let downloadedFilenames = getRelativeFiles(url: downloadDestination, repo: repo)
         XCTAssertEqual(
             Set(downloadedFilenames),
@@ -552,7 +552,7 @@ class SnapshotDownloadTests: XCTestCase {
         
         attributes = try FileManager.default.attributesOfItem(atPath: modelPath.path)
         let thirdDownloadTimestamp = attributes[.modificationDate] as! Date
-
+        
         // File will not be downloaded again because this is an LFS file.
         // While downloading LFS files, we first check if local file ETag is the same as remote ETag.
         // If that's the case we just update the metadata and keep the local file.
@@ -577,7 +577,7 @@ class SnapshotDownloadTests: XCTestCase {
         XCTAssertEqual(lastProgress?.fractionCompleted, 1)
         XCTAssertEqual(lastProgress?.completedUnitCount, 1)
         XCTAssertEqual(downloadedTo, downloadDestination.appending(path: "models/\(repo)"))
-
+        
         let downloadedFilenames = getRelativeFiles(url: downloadDestination, repo: repo)
         XCTAssertEqual(Set(downloadedFilenames), Set(["llama-2-7b-chat.mlpackage/Data/com.apple.CoreML/model.mlmodel"]))
         
@@ -590,7 +590,7 @@ class SnapshotDownloadTests: XCTestCase {
         
         let metadataFile = metadataDestination.appendingPathComponent("llama-2-7b-chat.mlpackage/Data/com.apple.CoreML/model.mlmodel.metadata")
         let metadataString = try String(contentsOfFile: metadataFile.path)
-                
+        
         let expected = "eaf97358a37d03fd48e5a87d15aff2e8423c1afb\nfc329090bfbb2570382c9af997cffd5f4b78b39b8aeca62076db69534e020107"
         XCTAssertTrue(metadataString.contains(expected))
     }
@@ -607,7 +607,7 @@ class SnapshotDownloadTests: XCTestCase {
         XCTAssertEqual(lastProgress?.fractionCompleted, 1)
         XCTAssertEqual(lastProgress?.completedUnitCount, 1)
         XCTAssertEqual(downloadedTo, downloadDestination.appending(path: "models/\(lfsRepo)"))
-
+        
         let downloadedFilenames = getRelativeFiles(url: downloadDestination, repo: lfsRepo)
         XCTAssertEqual(Set(downloadedFilenames), Set(["x.bin"]))
         
@@ -637,7 +637,7 @@ class SnapshotDownloadTests: XCTestCase {
         XCTAssertEqual(lastProgress?.fractionCompleted, 1)
         XCTAssertEqual(lastProgress?.completedUnitCount, 1)
         XCTAssertEqual(downloadedTo, downloadDestination.appending(path: "models/\(lfsRepo)"))
-
+        
         let downloadedFilenames = getRelativeFiles(url: downloadDestination, repo: lfsRepo)
         XCTAssertEqual(Set(downloadedFilenames), Set(["x.bin"]))
         
@@ -665,7 +665,7 @@ class SnapshotDownloadTests: XCTestCase {
     func testLFSFileNoMetadata() async throws {
         let hubApi = HubApi(downloadBase: downloadDestination)
         var lastProgress: Progress? = nil
-
+        
         let downloadedTo = try await hubApi.snapshot(from: lfsRepo, matching: "x.bin") { progress in
             print("Total Progress: \(progress.fractionCompleted)")
             print("Files Completed: \(progress.completedUnitCount) of \(progress.totalUnitCount)")
@@ -675,7 +675,7 @@ class SnapshotDownloadTests: XCTestCase {
         XCTAssertEqual(lastProgress?.fractionCompleted, 1)
         XCTAssertEqual(lastProgress?.completedUnitCount, 1)
         XCTAssertEqual(downloadedTo, downloadDestination.appending(path: "models/\(lfsRepo)"))
-
+        
         let downloadedFilenames = getRelativeFiles(url: downloadDestination, repo: lfsRepo)
         XCTAssertEqual(Set(downloadedFilenames), Set(["x.bin"]))
         
@@ -702,7 +702,7 @@ class SnapshotDownloadTests: XCTestCase {
         
         attributes = try FileManager.default.attributesOfItem(atPath: filePath.path)
         let secondDownloadTimestamp = attributes[.modificationDate] as! Date
-
+        
         // File will not be downloaded again thus last modified date will remain unchanged
         XCTAssertTrue(originalTimestamp == secondDownloadTimestamp)
         XCTAssertTrue(FileManager.default.fileExists(atPath: metadataDestination.path))
@@ -716,7 +716,7 @@ class SnapshotDownloadTests: XCTestCase {
     func testLFSFileCorruptedMetadata() async throws {
         let hubApi = HubApi(downloadBase: downloadDestination)
         var lastProgress: Progress? = nil
-
+        
         let downloadedTo = try await hubApi.snapshot(from: lfsRepo, matching: "x.bin") { progress in
             print("Total Progress: \(progress.fractionCompleted)")
             print("Files Completed: \(progress.completedUnitCount) of \(progress.totalUnitCount)")
@@ -726,7 +726,7 @@ class SnapshotDownloadTests: XCTestCase {
         XCTAssertEqual(lastProgress?.fractionCompleted, 1)
         XCTAssertEqual(lastProgress?.completedUnitCount, 1)
         XCTAssertEqual(downloadedTo, downloadDestination.appending(path: "models/\(lfsRepo)"))
-
+        
         let downloadedFilenames = getRelativeFiles(url: downloadDestination, repo: lfsRepo)
         XCTAssertEqual(Set(downloadedFilenames), Set(["x.bin"]))
         
@@ -744,7 +744,7 @@ class SnapshotDownloadTests: XCTestCase {
         
         let metadataFile = metadataDestination.appendingPathComponent("x.bin.metadata")
         try "a".write(to: metadataFile, atomically: true, encoding: .utf8)
-
+        
         let _ = try await hubApi.snapshot(from: lfsRepo, matching: "x.bin") { progress in
             print("Total Progress: \(progress.fractionCompleted)")
             print("Files Completed: \(progress.completedUnitCount) of \(progress.totalUnitCount)")
@@ -753,7 +753,7 @@ class SnapshotDownloadTests: XCTestCase {
         
         attributes = try FileManager.default.attributesOfItem(atPath: filePath.path)
         let secondDownloadTimestamp = attributes[.modificationDate] as! Date
-
+        
         // File will not be downloaded again thus last modified date will remain unchanged
         XCTAssertTrue(originalTimestamp == secondDownloadTimestamp)
         XCTAssertTrue(FileManager.default.fileExists(atPath: metadataDestination.path))
@@ -767,7 +767,7 @@ class SnapshotDownloadTests: XCTestCase {
     func testNonLFSFileRedownload() async throws {
         let hubApi = HubApi(downloadBase: downloadDestination)
         var lastProgress: Progress? = nil
-
+        
         let downloadedTo = try await hubApi.snapshot(from: repo, matching: "config.json") { progress in
             print("Total Progress: \(progress.fractionCompleted)")
             print("Files Completed: \(progress.completedUnitCount) of \(progress.totalUnitCount)")
@@ -777,7 +777,7 @@ class SnapshotDownloadTests: XCTestCase {
         XCTAssertEqual(lastProgress?.fractionCompleted, 1)
         XCTAssertEqual(lastProgress?.completedUnitCount, 1)
         XCTAssertEqual(downloadedTo, downloadDestination.appending(path: "models/\(repo)"))
-
+        
         let downloadedFilenames = getRelativeFiles(url: downloadDestination, repo: repo)
         XCTAssertEqual(Set(downloadedFilenames), Set(["config.json"]))
         
@@ -804,7 +804,7 @@ class SnapshotDownloadTests: XCTestCase {
         
         attributes = try FileManager.default.attributesOfItem(atPath: filePath.path)
         let secondDownloadTimestamp = attributes[.modificationDate] as! Date
-
+        
         // File will be downloaded again thus last modified date will change
         XCTAssertTrue(originalTimestamp != secondDownloadTimestamp)
         XCTAssertTrue(FileManager.default.fileExists(atPath: metadataDestination.path))
@@ -818,7 +818,7 @@ class SnapshotDownloadTests: XCTestCase {
     func testOfflineModeReturnsDestination() async throws {
         var hubApi = HubApi(downloadBase: downloadDestination)
         var lastProgress: Progress? = nil
-
+        
         var downloadedTo = try await hubApi.snapshot(from: repo, matching: "*.json") { progress in
             print("Total Progress: \(progress.fractionCompleted)")
             print("Files Completed: \(progress.completedUnitCount) of \(progress.totalUnitCount)")
@@ -831,7 +831,7 @@ class SnapshotDownloadTests: XCTestCase {
         XCTAssertEqual(downloadedTo, downloadDestination.appending(path: "models/\(repo)"))
         
         hubApi = HubApi(downloadBase: downloadDestination, useOfflineMode: true)
-    
+        
         downloadedTo = try await hubApi.snapshot(from: repo, matching: "*.json") { progress in
             print("Total Progress: \(progress.fractionCompleted)")
             print("Files Completed: \(progress.completedUnitCount) of \(progress.totalUnitCount)")
@@ -845,7 +845,7 @@ class SnapshotDownloadTests: XCTestCase {
     
     func testOfflineModeThrowsError() async throws {
         let hubApi = HubApi(downloadBase: downloadDestination, useOfflineMode: true)
-            
+        
         do {
             try await hubApi.snapshot(from: repo, matching: "*.json")
             XCTFail("Expected an error to be thrown")
@@ -901,7 +901,7 @@ class SnapshotDownloadTests: XCTestCase {
     func testOfflineModeWithCorruptedLFSMetadata() async throws {
         var hubApi = HubApi(downloadBase: downloadDestination)
         var lastProgress: Progress? = nil
-
+        
         let downloadedTo = try await hubApi.snapshot(from: lfsRepo, matching: "*") { progress in
             print("Total Progress: \(progress.fractionCompleted)")
             print("Files Completed: \(progress.completedUnitCount) of \(progress.totalUnitCount)")
@@ -918,7 +918,7 @@ class SnapshotDownloadTests: XCTestCase {
         try "77b984598d90af6143d73d5a2d6214b23eba7e27\n98ea6e4f216f2ab4b69fff9b3a44842c38686ca685f3f55dc48c5d3fb1107be4\n0\n".write(to: metadataDestination, atomically: true, encoding: .utf8)
         
         hubApi = HubApi(downloadBase: downloadDestination, useOfflineMode: true)
-    
+        
         do {
             try await hubApi.snapshot(from: lfsRepo, matching: "*")
             XCTFail("Expected an error to be thrown")
@@ -937,7 +937,7 @@ class SnapshotDownloadTests: XCTestCase {
     func testOfflineModeWithNoFiles() async throws {
         var hubApi = HubApi(downloadBase: downloadDestination)
         var lastProgress: Progress? = nil
-
+        
         let downloadedTo = try await hubApi.snapshot(from: lfsRepo, matching: "x.bin") { progress in
             print("Total Progress: \(progress.fractionCompleted)")
             print("Files Completed: \(progress.completedUnitCount) of \(progress.totalUnitCount)")
@@ -953,7 +953,7 @@ class SnapshotDownloadTests: XCTestCase {
         try FileManager.default.removeItem(at: fileDestination)
         
         hubApi = HubApi(downloadBase: downloadDestination, useOfflineMode: true)
-    
+        
         do {
             try await hubApi.snapshot(from: lfsRepo, matching: "x.bin")
             XCTFail("Expected an error to be thrown")
@@ -972,13 +972,15 @@ class SnapshotDownloadTests: XCTestCase {
     func testResumeDownloadFromEmptyIncomplete() async throws {
         let hubApi = HubApi(downloadBase: downloadDestination)
         var lastProgress: Progress? = nil
-        var downloadedTo = FileManager.default.homeDirectoryForCurrentUser
-    .appendingPathComponent("Library/Caches/huggingface-tests/models/coreml-projects/Llama-2-7b-chat-coreml")
+        var downloadedTo = FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent("Library/Caches/huggingface-tests/models/coreml-projects/Llama-2-7b-chat-coreml")
         
         let metadataDestination = downloadedTo.appending(component: ".cache/huggingface/download")
         
+        let url = URL(string: "https://huggingface.co/coreml-projects/Llama-2-7b-chat-coreml/resolve/main/config.json")!
+        let etag = try await Hub.getFileMetadata(fileURL: url).etag!
+        
         try FileManager.default.createDirectory(at: metadataDestination, withIntermediateDirectories: true, attributes: nil)
-        try "".write(to: metadataDestination.appendingPathComponent("config.json.incomplete"), atomically: true, encoding: .utf8)
+        try "".write(to: metadataDestination.appendingPathComponent("config.json.\(etag).incomplete"), atomically: true, encoding: .utf8)
         downloadedTo = try await hubApi.snapshot(from: repo, matching: "config.json") { progress in
             print("Total Progress: \(progress.fractionCompleted)")
             print("Files Completed: \(progress.completedUnitCount) of \(progress.totalUnitCount)")
@@ -1001,7 +1003,7 @@ class SnapshotDownloadTests: XCTestCase {
           "pad_token_id": 0,
           "vocab_size": 32000
         }
-
+        
         """
         XCTAssertTrue(fileContents.contains(expected))
     }
@@ -1010,12 +1012,15 @@ class SnapshotDownloadTests: XCTestCase {
         let hubApi = HubApi(downloadBase: downloadDestination)
         var lastProgress: Progress? = nil
         var downloadedTo = FileManager.default.homeDirectoryForCurrentUser
-    .appendingPathComponent("Library/Caches/huggingface-tests/models/coreml-projects/Llama-2-7b-chat-coreml")
+            .appendingPathComponent("Library/Caches/huggingface-tests/models/coreml-projects/Llama-2-7b-chat-coreml")
         
         let metadataDestination = downloadedTo.appending(component: ".cache/huggingface/download")
         
+        let url = URL(string: "https://huggingface.co/coreml-projects/Llama-2-7b-chat-coreml/resolve/main/config.json")!
+        let etag = try await Hub.getFileMetadata(fileURL: url).etag!
+        
         try FileManager.default.createDirectory(at: metadataDestination, withIntermediateDirectories: true, attributes: nil)
-        try "X".write(to: metadataDestination.appendingPathComponent("config.json.incomplete"), atomically: true, encoding: .utf8)
+        try "X".write(to: metadataDestination.appendingPathComponent("config.json.\(etag).incomplete"), atomically: true, encoding: .utf8)
         downloadedTo = try await hubApi.snapshot(from: repo, matching: "config.json") { progress in
             print("Total Progress: \(progress.fractionCompleted)")
             print("Files Completed: \(progress.completedUnitCount) of \(progress.totalUnitCount)")
@@ -1024,9 +1029,9 @@ class SnapshotDownloadTests: XCTestCase {
         XCTAssertEqual(lastProgress?.fractionCompleted, 1)
         XCTAssertEqual(lastProgress?.completedUnitCount, 1)
         XCTAssertEqual(downloadedTo, downloadDestination.appending(path: "models/\(repo)"))
-
+        
         let fileContents = try String(contentsOfFile: downloadedTo.appendingPathComponent("config.json").path)
-                
+        
         let expected = """
         X
           "architectures": [
@@ -1038,11 +1043,11 @@ class SnapshotDownloadTests: XCTestCase {
           "pad_token_id": 0,
           "vocab_size": 32000
         }
-
+        
         """
         XCTAssertTrue(fileContents.contains(expected))
     }
-
+    
     func testRealDownloadInterruptionAndResumption() async throws {
         // Use the DepthPro model weights file
         let targetFile = "DepthProNormalizedInverseDepth.mlpackage/Data/com.apple.CoreML/weights/weight.bin"
@@ -1059,8 +1064,12 @@ class SnapshotDownloadTests: XCTestCase {
         try await Task.sleep(nanoseconds: 15_000_000_000)
         downloadTask.cancel()
         
-        try await hubApi.snapshot(from: repo, matching: targetFile) { progress in
+        let downloadedTo = try await hubApi.snapshot(from: repo, matching: targetFile) { progress in
             print("Progress reached 2 \(progress.fractionCompleted * 100)%")
         }
+        
+        let filePath = downloadedTo.appendingPathComponent(targetFile)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: filePath.path),
+                      "Downloaded file should exist at \(filePath.path)")
     }
 }

--- a/Tests/HubTests/HubApiTests.swift
+++ b/Tests/HubTests/HubApiTests.swift
@@ -1042,4 +1042,25 @@ class SnapshotDownloadTests: XCTestCase {
         """
         XCTAssertTrue(fileContents.contains(expected))
     }
+
+    func testRealDownloadInterruptionAndResumption() async throws {
+        // Use the DepthPro model weights file
+        let targetFile = "DepthProNormalizedInverseDepth.mlpackage/Data/com.apple.CoreML/weights/weight.bin"
+        let repo = "coreml-projects/DepthPro-coreml-normalized-inverse-depth"
+        let hubApi = HubApi(downloadBase: downloadDestination)
+        
+        // Create a task for the download
+        let downloadTask = Task {
+            try await hubApi.snapshot(from: repo, matching: targetFile) { progress in
+                print("Progress reached 1 \(progress.fractionCompleted * 100)%")
+            }
+        }
+        
+        try await Task.sleep(nanoseconds: 15_000_000_000)
+        downloadTask.cancel()
+        
+        try await hubApi.snapshot(from: repo, matching: targetFile) { progress in
+            print("Progress reached 2 \(progress.fractionCompleted * 100)%")
+        }
+    }
 }

--- a/Tests/HubTests/HubApiTests.swift
+++ b/Tests/HubTests/HubApiTests.swift
@@ -1003,7 +1003,6 @@ class SnapshotDownloadTests: XCTestCase {
           "pad_token_id": 0,
           "vocab_size": 32000
         }
-            
         """
         XCTAssertTrue(fileContents.contains(expected))
     }
@@ -1043,7 +1042,6 @@ class SnapshotDownloadTests: XCTestCase {
           "pad_token_id": 0,
           "vocab_size": 32000
         }
-            
         """
         XCTAssertTrue(fileContents.contains(expected))
     }


### PR DESCRIPTION
This PR:

- Expands on #187 which downloads incomplete files directly into the target directory, which could lead to runtime errors while trying to read those files in the case a download did not fully complete. This is resolved by downloading incomplete files first to the cache directory then moving them to their final locations. This increases swift-transformers' download logic parity with the huggingface_hub library as laid out [here](https://github.com/huggingface/swift-transformers/pull/187#issuecomment)
- Also adds download cancellation support. Previously, if you were downloading a file inside a task and cancelled the task, the download would continue to run even if the task was canceled. This is done via adding `withTaskCancellationHandler` inside `HubFileDownloader`'s `Download`  method, which would immediately invalidate the url session and updates progress as cancelled.
- Renames urlSession to session in `Downloader` class to resolve naming conflict with URLSessionDownloadDelegate methods with the same name.
- Creates target directory structure lazily (as opposed to eagerly before) when moving the incomplete files to their final locations.
- Adds/improves test cases to verify new functionality.
