### PR TITLE
Fix formatting

### DIFF
--- a/.swiftformat
+++ b/.swiftformat
@@ -83,5 +83,5 @@
 --disable blankLineAfterImports,unusedArguments
 --enable docComments
 --disable enumnamespaces
---trimwhitespace nonblank-lines
+--trimwhitespace always
 --disable preferKeyPath

--- a/Sources/Generation/Generation.swift
+++ b/Sources/Generation/Generation.swift
@@ -30,7 +30,7 @@ public typealias PredictionStringCallback = (String) -> Void
 // TODO: callbacks (for streaming)
 public protocol Generation {
     func greedySearch(config: GenerationConfig, tokens: InputTokens, model: NextTokenModel, callback: PredictionTokensCallback?) async -> GenerationOutput
-    
+
     func generate(config: GenerationConfig, prompt: String, model: NextTokenModel, tokenizer: Tokenizer, callback: PredictionStringCallback?) async -> String
 }
 
@@ -48,7 +48,7 @@ public extension Generation {
         }
         return outputTokens
     }
-    
+
     /// https://github.com/huggingface/transformers/blob/42017d82baa083da2bee3055fdac80c81ee97b8a/src/transformers/generation/utils.py#L1552
     func sample(config: GenerationConfig, tokens: InputTokens, model: NextTokenModel, callback: PredictionTokensCallback? = nil) async -> GenerationOutput {
         // Iterate until we find the eos token or reach the max length
@@ -86,7 +86,7 @@ public extension Generation {
         default:
             fatalError("Generation mode \(generationConfig.generationMode) not implemented yet")
         }
-        
+
         return tokenizer.decode(tokens: output)
     }
 

--- a/Sources/Generation/GenerationConfig.swift
+++ b/Sources/Generation/GenerationConfig.swift
@@ -19,11 +19,11 @@ public struct GenerationConfig {
     public var topK = 50
     public var topP = 1.0
     public var repetitionPenalty = 1.0
-    
+
     public var padTokenId: Int?
     public var bosTokenId: Int?
     public var eosTokenId: Int?
-    
+
     public init(maxLength: Int = 20, maxNewTokens: Int, doSample: Bool = false, numBeams: Int = 1, numBeamGroups: Int = 1, penaltyAlpha: Double? = nil, temperature: Double = 1.0, topK: Int = 50, topP: Double = 1.0, repetitionPenalty: Double = 1.0) {
         self.maxLength = maxLength
         self.maxNewTokens = maxNewTokens
@@ -44,7 +44,7 @@ public extension GenerationConfig {
         if topK > 1, !doSample, penaltyAlpha != nil, penaltyAlpha! > 0 {
             return .contrastiveSearch
         }
-        
+
         switch (numBeams, numBeamGroups, doSample) {
         case (1, 1, false): return .greedy
         case (1, 1, true): return .sample

--- a/Sources/Hub/Hub.swift
+++ b/Sources/Hub/Hub.swift
@@ -56,7 +56,7 @@ public extension Hub {
         case datasets
         case spaces
     }
-    
+
     struct Repo: Codable {
         public let id: String
         public let type: RepoType

--- a/Sources/Hub/HubApi.swift
+++ b/Sources/Hub/HubApi.swift
@@ -16,11 +16,11 @@ public struct HubApi {
     var endpoint: String
     var useBackgroundSession: Bool
     var useOfflineMode: Bool?
-    
+
     private let networkMonitor = NetworkMonitor()
     public typealias RepoType = Hub.RepoType
     public typealias Repo = Hub.Repo
-    
+
     public init(downloadBase: URL? = nil, hfToken: String? = nil, endpoint: String = "https://huggingface.co", useBackgroundSession: Bool = false, useOfflineMode: Bool? = nil) {
         self.hfToken = hfToken ?? Self.hfTokenFromEnv()
         if let downloadBase {
@@ -34,12 +34,12 @@ public struct HubApi {
         self.useOfflineMode = useOfflineMode
         NetworkMonitor.shared.startMonitoring()
     }
-    
+
     let sha256Pattern = "^[0-9a-f]{64}$"
     let commitHashPattern = "^[0-9a-f]{40}$"
-    
+
     public static let shared = HubApi()
-    
+
     private static let logger = Logger()
 }
 
@@ -81,11 +81,11 @@ public extension HubApi {
     struct Sibling: Codable {
         let rfilename: String
     }
-    
+
     struct SiblingsResponse: Codable {
         let siblings: [Sibling]
     }
-        
+
     /// Throws error if the response code is not 20X
     func httpGet(for url: URL) async throws -> (Data, HTTPURLResponse) {
         var request = URLRequest(url: url)
@@ -125,10 +125,10 @@ public extension HubApi {
             request.setValue("Bearer \(hfToken)", forHTTPHeaderField: "Authorization")
         }
         request.setValue("identity", forHTTPHeaderField: "Accept-Encoding")
-        
+
         let redirectDelegate = RedirectDelegate()
         let session = URLSession(configuration: .default, delegate: redirectDelegate, delegateQueue: nil)
-        
+
         let (data, response) = try await session.data(for: request)
         guard let response = response as? HTTPURLResponse else { throw Hub.HubClientError.unexpectedError }
 
@@ -137,10 +137,10 @@ public extension HubApi {
         case 400..<500: throw Hub.HubClientError.authorizationRequired
         default: throw Hub.HubClientError.httpStatusCode(response.statusCode)
         }
-                
+
         return (data, response)
     }
-    
+
     func getFilenames(from repo: Repo, matching globs: [String] = []) async throws -> [String] {
         // Read repo info and only parse "siblings"
         let url = URL(string: "\(endpoint)/api/\(repo.type)/\(repo.id)")!
@@ -148,22 +148,22 @@ public extension HubApi {
         let response = try JSONDecoder().decode(SiblingsResponse.self, from: data)
         let filenames = response.siblings.map { $0.rfilename }
         guard globs.count > 0 else { return filenames }
-        
+
         var selected: Set<String> = []
         for glob in globs {
             selected = selected.union(filenames.matching(glob: glob))
         }
         return Array(selected)
     }
-    
+
     func getFilenames(from repoId: String, matching globs: [String] = []) async throws -> [String] {
         try await getFilenames(from: Repo(id: repoId), matching: globs)
     }
-    
+
     func getFilenames(from repo: Repo, matching glob: String) async throws -> [String] {
         try await getFilenames(from: repo, matching: [glob])
     }
-    
+
     func getFilenames(from repoId: String, matching glob: String) async throws -> [String] {
         try await getFilenames(from: Repo(id: repoId), matching: [glob])
     }
@@ -200,7 +200,7 @@ public extension HubApi {
         let fileURL = localRepoLocation(repo).appending(path: filename)
         return try configuration(fileURL: fileURL)
     }
-    
+
     /// Assumes the file is already present at local url.
     /// `fileURL` is a complete local file path for the given model
     func configuration(fileURL: URL) throws -> Config {
@@ -215,7 +215,7 @@ public extension HubApi {
 public extension HubApi {
     func whoami() async throws -> Config {
         guard hfToken != nil else { throw Hub.HubClientError.authorizationRequired }
-        
+
         let url = URL(string: "\(endpoint)/api/whoami-v2")!
         let (data, _) = try await httpGet(for: url)
 
@@ -230,7 +230,7 @@ public extension HubApi {
     func localRepoLocation(_ repo: Repo) -> URL {
         downloadBase.appending(component: repo.type.rawValue).appending(component: repo.id)
     }
-    
+
     /// Reads metadata about a file in the local directory related to a download process.
     ///
     /// Reference: https://github.com/huggingface/huggingface_hub/blob/b2c9a148d465b43ab90fab6e4ebcbbf5a9df27d4/src/huggingface_hub/_local_folder.py#L263
@@ -289,7 +289,7 @@ public extension HubApi {
         let range = NSRange(location: 0, length: hash.utf16.count)
         return regex?.firstMatch(in: hash, options: [], range: range) != nil
     }
-    
+
     func computeFileHash(file url: URL) throws -> String {
         // Open file for reading
         guard let fileHandle = try? FileHandle(forReadingFrom: url) else {
@@ -341,7 +341,7 @@ public extension HubApi {
         let hfToken: String?
         let endpoint: String?
         let backgroundSession: Bool
-        
+
         var source: URL {
             // https://huggingface.co/coreml-projects/Llama-2-7b-chat-coreml/resolve/main/tokenizer.json?download=true
             var url = URL(string: endpoint ?? "https://huggingface.co")!
@@ -353,19 +353,19 @@ public extension HubApi {
             url = url.appending(path: relativeFilename)
             return url
         }
-        
+
         var destination: URL {
             repoDestination.appending(path: relativeFilename)
         }
-        
+
         var metadataDestination: URL {
             repoMetadataDestination.appending(path: relativeFilename + ".metadata")
         }
-        
+
         var downloaded: Bool {
             FileManager.default.fileExists(atPath: destination.path)
         }
-        
+
         /// We're using incomplete destination to prepare cache destination because incomplete files include lfs + non-lfs files (vs only lfs for metadata files)
         func prepareCacheDestination(_ incompleteDestination: URL) throws {
             let directoryURL = incompleteDestination.deletingLastPathComponent()
@@ -374,7 +374,7 @@ public extension HubApi {
                 try "".write(to: incompleteDestination, atomically: true, encoding: .utf8)
             }
         }
-        
+
         /// Note we go from Combine in Downloader to callback-based progress reporting
         /// We'll probably need to support Combine as well to play well with Swift UI
         /// (See for example PipelineLoader in swift-coreml-diffusers)
@@ -382,15 +382,15 @@ public extension HubApi {
         func download(progressHandler: @escaping (Double) -> Void) async throws -> URL {
             let localMetadata = try hub.readDownloadMetadata(metadataPath: metadataDestination)
             let remoteMetadata = try await hub.getFileMetadata(url: source)
-            
+
             let localCommitHash = localMetadata?.commitHash ?? ""
             let remoteCommitHash = remoteMetadata.commitHash ?? ""
-            
+
             // Local file exists + metadata exists + commit_hash matches => return file
             if hub.isValidHash(hash: remoteCommitHash, pattern: hub.commitHashPattern), downloaded, localMetadata != nil, localCommitHash == remoteCommitHash {
                 return destination
             }
-            
+
             // From now on, etag, commit_hash, url and size are not empty
             guard let remoteCommitHash = remoteMetadata.commitHash,
                   let remoteEtag = remoteMetadata.etag,
@@ -399,7 +399,7 @@ public extension HubApi {
             else {
                 throw EnvironmentError.invalidMetadataError("File metadata must have been retrieved from server")
             }
-            
+
             // Local file exists => check if it's up-to-date
             if downloaded {
                 // etag matches => update metadata and return file
@@ -407,7 +407,7 @@ public extension HubApi {
                     try hub.writeDownloadMetadata(commitHash: remoteCommitHash, etag: remoteEtag, metadataPath: metadataDestination)
                     return destination
                 }
-                
+
                 // etag is a sha256
                 // => means it's an LFS file (large)
                 // => let's compute local hash and compare
@@ -420,7 +420,7 @@ public extension HubApi {
                     }
                 }
             }
-            
+
             // Otherwise, let's download the file!
             let incompleteDestination = repoMetadataDestination.appending(path: relativeFilename + ".\(remoteEtag).incomplete")
             try prepareCacheDestination(incompleteDestination)
@@ -433,7 +433,7 @@ public extension HubApi {
                 inBackground: backgroundSession,
                 expectedSize: remoteSize
             )
-            
+
             return try await withTaskCancellationHandler {
                 let downloadSubscriber = downloader.downloadState.sink { state in
                     switch state {
@@ -447,9 +447,9 @@ public extension HubApi {
                     _ = try withExtendedLifetime(downloadSubscriber) {
                         try downloader.waitUntilDone()
                     }
-                    
+
                     try hub.writeDownloadMetadata(commitHash: remoteCommitHash, etag: remoteEtag, metadataPath: metadataDestination)
-                    
+
                     return destination
                 } catch {
                     // If download fails, leave the incomplete file in place for future resume
@@ -468,7 +468,7 @@ public extension HubApi {
             .appendingPathComponent(".cache")
             .appendingPathComponent("huggingface")
             .appendingPathComponent("download")
-        
+
         if useOfflineMode ?? NetworkMonitor.shared.shouldUseOfflineMode() {
             if !FileManager.default.fileExists(atPath: repoDestination.path) {
                 throw EnvironmentError.offlineModeError(String(localized: "Repository not available locally"))
@@ -527,17 +527,17 @@ public extension HubApi {
         progressHandler(progress)
         return repoDestination
     }
-    
+
     @discardableResult
     func snapshot(from repoId: String, matching globs: [String] = [], progressHandler: @escaping (Progress) -> Void = { _ in }) async throws -> URL {
         try await snapshot(from: Repo(id: repoId), matching: globs, progressHandler: progressHandler)
     }
-    
+
     @discardableResult
     func snapshot(from repo: Repo, matching glob: String, progressHandler: @escaping (Progress) -> Void = { _ in }) async throws -> URL {
         try await snapshot(from: repo, matching: [glob], progressHandler: progressHandler)
     }
-    
+
     @discardableResult
     func snapshot(from repoId: String, matching glob: String, progressHandler: @escaping (Progress) -> Void = { _ in }) async throws -> URL {
         try await snapshot(from: Repo(id: repoId), matching: [glob], progressHandler: progressHandler)
@@ -550,29 +550,29 @@ public extension HubApi {
     struct FileMetadata {
         /// The commit hash related to the file
         public let commitHash: String?
-        
+
         /// Etag of the file on the server
         public let etag: String?
-        
+
         /// Location where to download the file. Can be a Hub url or not (CDN).
         public let location: String
-        
+
         /// Size of the file. In case of an LFS file, contains the size of the actual LFS file, not the pointer.
         public let size: Int?
     }
-    
+
     /// Metadata about a file in the local directory related to a download process
     struct LocalDownloadFileMetadata {
         /// Commit hash of the file in the repo
         public let commitHash: String
-        
+
         /// ETag of the file in the repo. Used to check if the file has changed.
         /// For LFS files, this is the sha256 of the file. For regular files, it corresponds to the git hash.
         public let etag: String
-        
+
         /// Path of the file in the repo
         public let filename: String
-        
+
         /// The timestamp of when the metadata was saved i.e. when the metadata was accurate
         public let timestamp: Date
     }
@@ -581,11 +581,11 @@ public extension HubApi {
         guard let etag else { return nil }
         return etag.trimmingPrefix("W/").trimmingCharacters(in: CharacterSet(charactersIn: "\""))
     }
-    
+
     func getFileMetadata(url: URL) async throws -> FileMetadata {
         let (_, response) = try await httpHead(for: url)
         let location = response.statusCode == 302 ? response.value(forHTTPHeaderField: "Location") : response.url?.absoluteString
-        
+
         return FileMetadata(
             commitHash: response.value(forHTTPHeaderField: "X-Repo-Commit"),
             etag: normalizeEtag(
@@ -595,7 +595,7 @@ public extension HubApi {
             size: Int(response.value(forHTTPHeaderField: "X-Linked-Size") ?? response.value(forHTTPHeaderField: "Content-Length") ?? "")
         )
     }
-    
+
     func getFileMetadata(from repo: Repo, matching globs: [String] = []) async throws -> [FileMetadata] {
         let files = try await getFilenames(from: repo, matching: globs)
         let url = URL(string: "\(endpoint)/\(repo.id)/resolve/main")! // TODO: revisions
@@ -606,15 +606,15 @@ public extension HubApi {
         }
         return selectedMetadata
     }
-    
+
     func getFileMetadata(from repoId: String, matching globs: [String] = []) async throws -> [FileMetadata] {
         try await getFileMetadata(from: Repo(id: repoId), matching: globs)
     }
-    
+
     func getFileMetadata(from repo: Repo, matching glob: String) async throws -> [FileMetadata] {
         try await getFileMetadata(from: repo, matching: [glob])
     }
-    
+
     func getFileMetadata(from repoId: String, matching glob: String) async throws -> [FileMetadata] {
         try await getFileMetadata(from: Repo(id: repoId), matching: [glob])
     }
@@ -625,39 +625,39 @@ private extension HubApi {
     private final class NetworkMonitor {
         private var monitor: NWPathMonitor
         private var queue: DispatchQueue
-        
+
         private(set) var isConnected: Bool = false
         private(set) var isExpensive: Bool = false
         private(set) var isConstrained: Bool = false
-        
+
         static let shared = NetworkMonitor()
-        
+
         init() {
             monitor = NWPathMonitor()
             queue = DispatchQueue(label: "HubApi.NetworkMonitor")
             startMonitoring()
         }
-        
+
         func startMonitoring() {
             monitor.pathUpdateHandler = { [weak self] path in
                 guard let self else { return }
-                
+
                 isConnected = path.status == .satisfied
                 isExpensive = path.isExpensive
                 isConstrained = path.isConstrained
             }
-            
+
             monitor.start(queue: queue)
         }
-        
+
         func stopMonitoring() {
             monitor.cancel()
         }
-        
+
         func shouldUseOfflineMode() -> Bool {
             !isConnected || isExpensive || isConstrained
         }
-        
+
         deinit {
             stopMonitoring()
         }
@@ -669,55 +669,55 @@ public extension Hub {
     static func getFilenames(from repo: Hub.Repo, matching globs: [String] = []) async throws -> [String] {
         try await HubApi.shared.getFilenames(from: repo, matching: globs)
     }
-    
+
     static func getFilenames(from repoId: String, matching globs: [String] = []) async throws -> [String] {
         try await HubApi.shared.getFilenames(from: Repo(id: repoId), matching: globs)
     }
-    
+
     static func getFilenames(from repo: Repo, matching glob: String) async throws -> [String] {
         try await HubApi.shared.getFilenames(from: repo, matching: glob)
     }
-    
+
     static func getFilenames(from repoId: String, matching glob: String) async throws -> [String] {
         try await HubApi.shared.getFilenames(from: Repo(id: repoId), matching: glob)
     }
-    
+
     static func snapshot(from repo: Repo, matching globs: [String] = [], progressHandler: @escaping (Progress) -> Void = { _ in }) async throws -> URL {
         try await HubApi.shared.snapshot(from: repo, matching: globs, progressHandler: progressHandler)
     }
-    
+
     static func snapshot(from repoId: String, matching globs: [String] = [], progressHandler: @escaping (Progress) -> Void = { _ in }) async throws -> URL {
         try await HubApi.shared.snapshot(from: Repo(id: repoId), matching: globs, progressHandler: progressHandler)
     }
-    
+
     static func snapshot(from repo: Repo, matching glob: String, progressHandler: @escaping (Progress) -> Void = { _ in }) async throws -> URL {
         try await HubApi.shared.snapshot(from: repo, matching: glob, progressHandler: progressHandler)
     }
-    
+
     static func snapshot(from repoId: String, matching glob: String, progressHandler: @escaping (Progress) -> Void = { _ in }) async throws -> URL {
         try await HubApi.shared.snapshot(from: Repo(id: repoId), matching: glob, progressHandler: progressHandler)
     }
-    
+
     static func whoami(token: String) async throws -> Config {
         try await HubApi(hfToken: token).whoami()
     }
-    
+
     static func getFileMetadata(fileURL: URL) async throws -> HubApi.FileMetadata {
         try await HubApi.shared.getFileMetadata(url: fileURL)
     }
-    
+
     static func getFileMetadata(from repo: Repo, matching globs: [String] = []) async throws -> [HubApi.FileMetadata] {
         try await HubApi.shared.getFileMetadata(from: repo, matching: globs)
     }
-    
+
     static func getFileMetadata(from repoId: String, matching globs: [String] = []) async throws -> [HubApi.FileMetadata] {
         try await HubApi.shared.getFileMetadata(from: Repo(id: repoId), matching: globs)
     }
-    
+
     static func getFileMetadata(from repo: Repo, matching glob: String) async throws -> [HubApi.FileMetadata] {
         try await HubApi.shared.getFileMetadata(from: repo, matching: [glob])
     }
-    
+
     static func getFileMetadata(from repoId: String, matching glob: String) async throws -> [HubApi.FileMetadata] {
         try await HubApi.shared.getFileMetadata(from: Repo(id: repoId), matching: [glob])
     }
@@ -732,7 +732,7 @@ public extension [String] {
 public extension FileManager {
     func getFileUrls(at directoryUrl: URL) throws -> [URL] {
         var fileUrls = [URL]()
-        
+
         // Get all contents including subdirectories
         guard let enumerator = FileManager.default.enumerator(
             at: directoryUrl,
@@ -741,7 +741,7 @@ public extension FileManager {
         ) else {
             return fileUrls
         }
-        
+
         for case let fileURL as URL in enumerator {
             do {
                 let resourceValues = try fileURL.resourceValues(forKeys: [.isRegularFileKey, .isHiddenKey])
@@ -752,7 +752,7 @@ public extension FileManager {
                 throw error
             }
         }
-        
+
         return fileUrls
     }
 }
@@ -776,7 +776,7 @@ private class RedirectDelegate: NSObject, URLSessionTaskDelegate {
                         // Update the path component with the relative path
                         components.path = locationUrl.path
                         components.query = locationUrl.query
-                        
+
                         // Create new request with the resolved URL
                         if let resolvedUrl = components.url {
                             var newRequest = URLRequest(url: resolvedUrl)
@@ -792,7 +792,7 @@ private class RedirectDelegate: NSObject, URLSessionTaskDelegate {
                 }
             }
         }
-        
+
         // For all other cases (non-redirects or absolute redirects), prevent redirect
         completionHandler(nil)
     }

--- a/Sources/HubCLI/HubCLI.swift
+++ b/Sources/HubCLI/HubCLI.swift
@@ -32,7 +32,7 @@ struct Download: AsyncParsableCommand, SubcommandWithToken {
         case model
         case dataset
         case space
-        
+
         var asHubApiRepoType: HubApi.RepoType {
             switch self {
             case .model: .models
@@ -41,7 +41,7 @@ struct Download: AsyncParsableCommand, SubcommandWithToken {
             }
         }
     }
-    
+
     @Argument(help: "Repo ID")
     var repo: String
 
@@ -50,10 +50,10 @@ struct Download: AsyncParsableCommand, SubcommandWithToken {
 
     @Option(help: "Glob patterns for files to include")
     var include: [String] = []
-    
+
     @Option(help: "Hugging Face token. If empty, will attempt to read from the filesystem at \(defaultTokenLocation)")
     var token: String? = nil
-        
+
     func run() async throws {
         let hubApi = HubApi(hfToken: hfToken)
         let repo = Hub.Repo(id: repo, type: repoType.asHubApiRepoType)
@@ -70,10 +70,10 @@ struct Download: AsyncParsableCommand, SubcommandWithToken {
 
 struct Whoami: AsyncParsableCommand, SubcommandWithToken {
     static let configuration = CommandConfiguration(abstract: "whoami")
-         
+
     @Option(help: "Hugging Face token. If empty, will attempt to read from the filesystem at \(defaultTokenLocation)")
     var token: String? = nil
-    
+
     func run() async throws {
         let hubApi = HubApi(hfToken: hfToken)
         let userInfo = try await hubApi.whoami()

--- a/Sources/Models/LanguageModel.swift
+++ b/Sources/Models/LanguageModel.swift
@@ -12,13 +12,13 @@ import Tokenizers
 
 public class LanguageModel {
     public let model: MLModel
-    
+
     public let minContextLength: Int
     public let maxContextLength: Int
-    
+
     let input_ids = "input_ids"
     let attention_mask = "attention_mask"
-    
+
     struct Configurations {
         var modelConfig: Config
         var tokenizerConfig: Config?
@@ -30,15 +30,15 @@ public class LanguageModel {
 
     public required init(model: MLModel) {
         self.model = model
-        
+
         // We assume inputs named "input_ids" with shape (1, seq_length)
         // Perhaps we should convert to vectors of shape (seq_length) and use sequenceConstraint instead of shapeConstraint
         let inputDescription = model.modelDescription.inputDescriptionsByName["input_ids"]
-        
+
         guard let shapeConstraint = inputDescription?.multiArrayConstraint?.shapeConstraint else {
             fatalError("Cannot obtain shape information")
         }
-        
+
         switch shapeConstraint.type {
         case .enumerated:
             // TODO: support a set of fixed shapes (keeping the first one here)
@@ -55,7 +55,7 @@ public class LanguageModel {
             minContextLength = 128
             maxContextLength = 128
         }
-                
+
         configuration = LanguageModelConfigurationFromHub(modelName: modelName)
     }
 }
@@ -78,7 +78,7 @@ public extension LanguageModel {
         }
         return model.configuration.modelDisplayName ?? ""
     }
-    
+
     /// `name_or_path` in the Python world
     var modelName: String {
         if let userFields = model.modelDescription.metadata[MLModelMetadataKey.creatorDefinedKey] as? [String: String],
@@ -90,33 +90,33 @@ public extension LanguageModel {
         guard let modelName = model.configuration.modelDisplayName else { fatalError("Models must have a name that identifies them") }
         return modelName
     }
-        
+
     var inputIdsDescription: MLFeatureDescription {
         model.modelDescription.inputDescriptionsByName[input_ids]!
     }
-    
+
     var inputIdsName: String {
         inputIdsDescription.name
     }
-    
+
     /// The expected shape of the models latent sample input
     var inputIdsShape: [Int] {
         inputIdsDescription.multiArrayConstraint!.shape.map { $0.intValue }
     }
-    
+
     var requiresAttention: Bool {
         model.modelDescription.inputDescriptionsByName[attention_mask] != nil
     }
-    
+
     /// MLShapedArrayProtocol is either a MLShapedArray or a MLShapedArraySlice
     func predictNextTokenScores(_ tokens: InputTokens, config: GenerationConfig) -> any MLShapedArrayProtocol {
         // TODO: exceptions
-        
+
         // Maybe pad or truncate
         let maxTokens = min(tokens.count, maxContextLength)
         let padLength = maxTokens >= minContextLength ? 0 : minContextLength - maxTokens
         let inputTokens = Array(tokens[0..<maxTokens]) + Array(repeating: config.padTokenId ?? 0, count: padLength)
-        
+
         let inputIds = MLShapedArray<Int32>(scalars: inputTokens.map { Int32($0) }, shape: inputIdsShape)
         var inputDictionary = [inputIdsName: MLFeatureValue(shapedArray: inputIds)]
         if requiresAttention {
@@ -125,9 +125,9 @@ public extension LanguageModel {
             inputDictionary[attention_mask] = MLFeatureValue(shapedArray: attentionMask)
         }
         let input = try! MLDictionaryFeatureProvider(dictionary: inputDictionary)
-        
+
         let output = try! model.prediction(from: input)
-        
+
         // TODO: maybe try to support models with "token_scores" too (after the softmax)
         assert(output.featureNames.first! == "logits")
 
@@ -144,31 +144,31 @@ public extension LanguageModel {
             try await configuration!.modelConfig
         }
     }
-    
+
     var tokenizerConfig: Config? {
         get async throws {
             try await configuration!.tokenizerConfig
         }
     }
-    
+
     var tokenizerData: Config {
         get async throws {
             try await configuration!.tokenizerData
         }
     }
-    
+
     var modelType: String? {
         get async throws {
             try await modelConfig.modelType?.stringValue
         }
     }
-    
+
     var textGenerationParameters: Config? {
         get async throws {
             try await modelConfig.taskSpecificParams?.textGeneration
         }
     }
-    
+
     var defaultDoSample: Bool {
         get async throws {
             try await textGenerationParameters?.doSample?.boolValue ?? true
@@ -181,14 +181,14 @@ public extension LanguageModel {
             return modelConfig.bosTokenId?.intValue
         }
     }
-    
+
     var eosTokenId: Int? {
         get async throws {
             let modelConfig = try await modelConfig
             return modelConfig.eosTokenId?.intValue
         }
     }
-    
+
     var tokenizer: Tokenizer {
         get async throws {
             guard _tokenizer == nil else { return _tokenizer! }

--- a/Sources/Models/LanguageModelTypes.swift
+++ b/Sources/Models/LanguageModelTypes.swift
@@ -15,9 +15,9 @@ public protocol LanguageModelProtocol {
 
     var tokenizer: Tokenizer { get async throws }
     var model: MLModel { get }
-    
+
     init(model: MLModel)
-    
+
     /// Make prediction callable (this works like __call__ in Python)
     func predictNextTokenScores(_ tokens: InputTokens, config: GenerationConfig) -> any MLShapedArrayProtocol
     func callAsFunction(_ tokens: InputTokens, config: GenerationConfig) -> any MLShapedArrayProtocol

--- a/Sources/TensorUtils/LogitsWarper/TemperatureLogitsWarper.swift
+++ b/Sources/TensorUtils/LogitsWarper/TemperatureLogitsWarper.swift
@@ -2,7 +2,7 @@ import Foundation
 
 public struct TemperatureLogitsWarper: LogitsWarper {
     public var temperature: Float
-    
+
     public init(temperature: Float) {
         self.temperature = temperature
     }

--- a/Sources/TensorUtils/LogitsWarper/TopKLogitsWarper.swift
+++ b/Sources/TensorUtils/LogitsWarper/TopKLogitsWarper.swift
@@ -7,7 +7,7 @@ import Foundation
 /// and their probabilities.
 public struct TopKLogitsWarper: LogitsWarper {
     public var k: Int
-    
+
     public init(k: Int) {
         self.k = k
     }

--- a/Sources/TensorUtils/MLMultiArray+Utils.swift
+++ b/Sources/TensorUtils/MLMultiArray+Utils.swift
@@ -25,7 +25,7 @@ public extension MLMultiArray {
         }
         return o
     }
-    
+
     /// All values will be stored in the last dimension of the MLMultiArray (default is dims=1)
     static func from(_ arr: [Double], dims: Int = 1) -> MLMultiArray {
         var shape = Array(repeating: 1, count: dims)
@@ -41,7 +41,7 @@ public extension MLMultiArray {
         }
         return o
     }
-    
+
     /// This will concatenate all dimensions into one one-dim array.
     static func toIntArray(_ o: MLMultiArray) -> [Int] {
         var arr = Array(repeating: 0, count: o.count)
@@ -51,9 +51,9 @@ public extension MLMultiArray {
         }
         return arr
     }
-    
+
     func toIntArray() -> [Int] { Self.toIntArray(self) }
-    
+
     /// This will concatenate all dimensions into one one-dim array.
     static func toDoubleArray(_ o: MLMultiArray) -> [Double] {
         var arr: [Double] = Array(repeating: 0, count: o.count)
@@ -63,9 +63,9 @@ public extension MLMultiArray {
         }
         return arr
     }
-    
+
     func toDoubleArray() -> [Double] { Self.toDoubleArray(self) }
-    
+
     /// Helper to construct a sequentially-indexed multi array,
     /// useful for debugging and unit tests
     /// Example in 3 dimensions:
@@ -93,7 +93,7 @@ public extension MLMultiArray {
         case select(Int)
         case slice
     }
-    
+
     /// Slice an array according to a list of `Indexing` enums.
     ///
     /// You must specify all dimensions.
@@ -117,7 +117,7 @@ public extension MLMultiArray {
             selectDims: selectDims
         )
     }
-    
+
     /// Slice an array according to a list, according to `sliceDim` (which dimension to slice on)
     /// and a dictionary of `dim` to `index`.
     ///
@@ -130,7 +130,7 @@ public extension MLMultiArray {
         shape[sliceDim] = o.shape[sliceDim]
         // print("About to slice ndarray of shape \(o.shape) into ndarray of shape \(shape)")
         let arr = try! MLMultiArray(shape: shape, dataType: .double)
-        
+
         // let srcPtr = UnsafeMutablePointer<Double>(OpaquePointer(o.dataPointer))
         // TODO: use srcPtr instead of array subscripting.
         let dstPtr = UnsafeMutablePointer<Double>(OpaquePointer(arr.dataPointer))
@@ -154,7 +154,7 @@ extension MLMultiArray {
     var debug: String {
         debug([])
     }
-    
+
     /// From https://twitter.com/mhollemans
     ///
     /// Slightly tweaked
@@ -163,11 +163,11 @@ extension MLMultiArray {
         func indent(_ x: Int) -> String {
             String(repeating: " ", count: x)
         }
-        
+
         // This function is called recursively for every dimension.
         // Add an entry for this dimension to the end of the array.
         var indices = indices + [0]
-        
+
         let d = indices.count - 1 // the current dimension
         let N = shape[d].intValue // how many elements in this dimension
         var s = "["

--- a/Sources/TensorUtils/MLShapedArray+Utils.swift
+++ b/Sources/TensorUtils/MLShapedArray+Utils.swift
@@ -14,7 +14,7 @@ public extension MLShapedArray<Float> {
             // If strides is not 1, we can write a Metal kernel to copy the values properly.
             return scalars
         }
-        
+
         // Fast path: memcpy
         let mlArray = MLMultiArray(self)
         return mlArray.floats ?? scalars
@@ -38,7 +38,7 @@ public extension MLShapedArraySlice<Float> {
 public extension MLMultiArray {
     var floats: [Float]? {
         guard dataType == .float32 else { return nil }
-        
+
         var result: [Float] = Array(repeating: 0, count: count)
         return withUnsafeBytes { ptr in
             guard let source = ptr.baseAddress else { return nil }

--- a/Sources/TensorUtils/Math.swift
+++ b/Sources/TensorUtils/Math.swift
@@ -18,7 +18,7 @@ import Foundation
 public struct Math {
     /**
      Returns the index and value of the largest element in the array.
-     
+
      - Parameters:
      - ptr: Pointer to the first element in memory.
      - count: How many elements to look at.
@@ -30,7 +30,7 @@ public struct Math {
         vDSP_maxvi(ptr, vDSP_Stride(stride), &maxValue, &maxIndex, vDSP_Length(count))
         return (Int(maxIndex), maxValue)
     }
-    
+
     /**
      Returns the index and value of the largest element in the array.
      - Parameters:
@@ -44,14 +44,14 @@ public struct Math {
         vDSP_maxviD(ptr, vDSP_Stride(stride), &maxValue, &maxIndex, vDSP_Length(count))
         return (Int(maxIndex), maxValue)
     }
-    
+
     public static func argmax32(_ ptr: UnsafePointer<Float>, count: Int, stride: Int = 1) -> (Int, Float) {
         var maxValue: Float = 0
         var maxIndex: vDSP_Length = 0
         vDSP_maxvi(ptr, vDSP_Stride(stride), &maxValue, &maxIndex, vDSP_Length(count))
         return (Int(maxIndex), maxValue)
     }
-    
+
     /// MLMultiArray helper.
     /// Works in our specific use case.
     public static func argmax(_ multiArray: MLMultiArray) -> (Int, Double) {
@@ -59,7 +59,7 @@ public struct Math {
         let ptr = UnsafeMutablePointer<Double>(OpaquePointer(multiArray.dataPointer))
         return Math.argmax(ptr, count: multiArray.count)
     }
-    
+
     /// MLMultiArray helper.
     /// Works in our specific use case.
     public static func argmax32(_ multiArray: MLMultiArray) -> (Int, Float) {
@@ -87,7 +87,7 @@ public struct Math {
         let i = randomNumber(probabilities: probs)
         return indexes[i]
     }
-    
+
     /**
      Computes the "softmax" function over an array.
      Based on code from https://github.com/nikolaypavlov/MLPNeuralNet/
@@ -102,31 +102,31 @@ public struct Math {
     public static func softmax(_ x: [Float]) -> [Float] {
         var x = x
         let len = vDSP_Length(x.count)
-        
+
         // Find the maximum value in the input array.
         var max: Float = 0
         vDSP_maxv(x, 1, &max, len)
-        
+
         // Subtract the maximum from all the elements in the array.
         // Now the highest value in the array is 0.
         max = -max
         vDSP_vsadd(x, 1, &max, &x, 1, len)
-        
+
         // Exponentiate all the elements in the array.
         var count = Int32(x.count)
         vvexpf(&x, x, &count)
-        
+
         // Compute the sum of all exponentiated values.
         var sum: Float = 0
         vDSP_sve(x, 1, &sum, len)
-        
+
         // Divide each element by the sum. This normalizes the array contents
         // so that they all add up to 1.
         vDSP_vsdiv(x, 1, &sum, &x, 1, len)
-        
+
         return x
     }
-    
+
     /// Multinomial sampling
     ///
     /// From https://stackoverflow.com/questions/30309556/generate-random-numbers-with-a-given-distribution
@@ -158,7 +158,7 @@ public extension Math {
             return Math.argmax32(ptr.baseAddress!, count: shapedArray.count, stride: strides.first!)
         }
     }
-    
+
     // TODO: handle Double, etc.
     static func argmax(_ shapedArray: some MLShapedArrayProtocol) -> (Int, Float) {
         shapedArray.withUnsafeShapedBufferPointer { ptr, shape, strides in

--- a/Sources/Tokenizers/BPETokenizer.swift
+++ b/Sources/Tokenizers/BPETokenizer.swift
@@ -21,7 +21,7 @@ struct BytePair: Hashable {
         a = tuple[0]
         b = tuple[1]
     }
-    
+
     static func == (lhs: BytePair, rhs: BytePair) -> Bool {
         lhs.a == rhs.a && lhs.b == rhs.b
     }
@@ -72,10 +72,10 @@ class BPETokenizer: PreTrainedTokenizerModel {
             bpeRanks[bp] = i
         }
         self.bpeRanks = bpeRanks
-        
+
         tokensToIds = vocab.merging(addedTokens as [NSString: Int]) { $1 }
         idsToTokens = Utils.invert(tokensToIds)
-        
+
         // Populate tokens
         if let unknownToken = TokenizerModel.unknownToken(from: tokenizerConfig) {
             self.unknownToken = unknownToken
@@ -97,7 +97,7 @@ class BPETokenizer: PreTrainedTokenizerModel {
     func convertTokenToId(_ token: String) -> Int? {
         tokensToIds[token as NSString] ?? unknownTokenId
     }
-    
+
     func convertIdToToken(_ id: Int) -> String? {
         idsToTokens[id] as String?
     }
@@ -109,7 +109,7 @@ class BPETokenizer: PreTrainedTokenizerModel {
             return Array(token.utf8).compactMap { byteEncoder[$0] }.joined()
         }
     }
-    
+
     func hexaEncode(text: String) -> [String] {
         let RE = #"'s|'t|'re|'ve|'m|'ll|'d| ?\p{L}+| ?\p{N}+| ?[^\s\p{L}\p{N}]+|\s+(?!\S)|\s+"#
         let tokens = text.ranges(of: RE).map { String(text[$0]) }
@@ -117,7 +117,7 @@ class BPETokenizer: PreTrainedTokenizerModel {
             return Array(token.utf8).map { String(format: "<0x%02X>", $0) }
         }
     }
-    
+
     private func getPairs(word: [String]) -> Set<BytePair> {
         var s = Set<BytePair>()
         for i in 0..<word.count - 1 {
@@ -129,15 +129,15 @@ class BPETokenizer: PreTrainedTokenizerModel {
         }
         return s
     }
-    
+
     func bpe(token: String) -> String {
         if token.count <= 1 {
             return token
         }
-        
+
         var word = Array(token).map { String($0) }
         var pairs = Array(getPairs(word: word))
-        
+
         while true {
             let bigrams = pairs.filter { bp -> Bool in bpeRanks[bp] != nil }
             if bigrams.count == 0 {
@@ -158,7 +158,7 @@ class BPETokenizer: PreTrainedTokenizerModel {
                     newWord.append(contentsOf: word[i..<word.count])
                     break
                 }
-                
+
                 if word[i] == first, i < word.count - 1, word[i + 1] == second {
                     newWord.append(first + second)
                     i += 2

--- a/Sources/Tokenizers/BertTokenizer.swift
+++ b/Sources/Tokenizers/BertTokenizer.swift
@@ -14,7 +14,7 @@ public class BertTokenizer {
     private let wordpieceTokenizer: WordpieceTokenizer
     private let maxLen = 512
     private let tokenizeChineseChars: Bool
-    
+
     private let vocab: [String: Int]
     private let ids_to_tokens: [Int: String]
 
@@ -44,7 +44,7 @@ public class BertTokenizer {
         eosTokenId = eosToken == nil ? nil : vocab[eosToken!]
         self.fuseUnknownTokens = fuseUnknownTokens
     }
-    
+
     public required convenience init(tokenizerConfig: Config, tokenizerData: Config, addedTokens: [String: Int]) throws {
         guard var vocab = tokenizerData.model?.vocab?.dictionary as? [String: Int] else { throw TokenizerError.missingVocab }
         if let addedTokens = tokenizerData.added_tokens?.dictionary["value"] as? [[String: Any]],
@@ -61,7 +61,7 @@ public class BertTokenizer {
         let doLowerCase = tokenizerConfig.doLowerCase?.boolValue ?? true
         self.init(vocab: vocab, merges: merges, tokenizeChineseChars: tokenizeChineseChars, bosToken: bosToken, eosToken: eosToken, fuseUnknownTokens: fuseUnknown, doLowerCase: doLowerCase)
     }
-    
+
     public func tokenize(text: String) -> [String] {
         let text = tokenizeChineseCharsIfNeed(text)
         var tokens: [String] = []
@@ -72,7 +72,7 @@ public class BertTokenizer {
         }
         return tokens
     }
-    
+
     private func convertTokensToIds(tokens: [String]) throws -> [Int] {
         if tokens.count > maxLen {
             throw TokenizerError.tooLong(
@@ -85,26 +85,26 @@ public class BertTokenizer {
         }
         return tokens.compactMap { vocab[$0] }
     }
-    
+
     /// Main entry point
     func tokenizeToIds(text: String) -> [Int] {
         try! convertTokensToIds(tokens: tokenize(text: text))
     }
-    
+
     func tokenToId(token: String) -> Int {
         vocab[token]!
     }
-    
+
     /// Un-tokenization: get tokens from tokenIds
     func unTokenize(tokens: [Int]) -> [String] {
         tokens.compactMap { ids_to_tokens[$0] }
     }
-    
+
     /// Un-tokenization:
     func convertWordpieceToBasicTokenList(_ wordpieceTokenList: [String]) -> String {
         var tokenList: [String] = []
         var individualToken = ""
-        
+
         for token in wordpieceTokenList {
             if token.starts(with: "##") {
                 individualToken += String(token.suffix(token.count - 2))
@@ -112,21 +112,21 @@ public class BertTokenizer {
                 if individualToken.count > 0 {
                     tokenList.append(individualToken)
                 }
-                
+
                 individualToken = token
             }
         }
-        
+
         tokenList.append(individualToken)
-        
+
         return tokenList.joined(separator: " ")
     }
-    
+
     private func tokenizeChineseCharsIfNeed(_ text: String) -> String {
         guard tokenizeChineseChars else {
             return text
         }
-        
+
         return text.map { c in
             if let scalar = c.unicodeScalars.first, Utils.isChineseChar(scalar) {
                 " \(c) "
@@ -142,16 +142,16 @@ extension BertTokenizer: PreTrainedTokenizerModel {
     public var unknownTokenId: Int? { vocab[unknownToken!] }
 
     func encode(text: String) -> [Int] { tokenizeToIds(text: text) }
-    
+
     func decode(tokens: [Int]) -> String {
         let tokens = unTokenize(tokens: tokens)
         return convertWordpieceToBasicTokenList(tokens)
     }
-    
+
     public func convertTokenToId(_ token: String) -> Int? {
         vocab[token] ?? unknownTokenId
     }
-    
+
     public func convertIdToToken(_ id: Int) -> String? {
         ids_to_tokens[id]
     }
@@ -227,11 +227,11 @@ class WordpieceTokenizer {
     let unkToken = "[UNK]"
     private let maxInputCharsPerWord = 100
     private let vocab: [String: Int]
-    
+
     init(vocab: [String: Int]) {
         self.vocab = vocab
     }
-    
+
     /// `word`: A single token.
     /// Warning: this differs from the `pytorch-transformers` implementation.
     /// This should have already been passed through `BasicTokenizer`.

--- a/Sources/Tokenizers/PostProcessor.swift
+++ b/Sources/Tokenizers/PostProcessor.swift
@@ -48,15 +48,15 @@ struct PostProcessorFactory {
 class TemplateProcessing: PostProcessor {
     let single: [Config]
     let pair: [Config]
-    
+
     public required init(config: Config) {
         guard let single = config.single?.arrayValue else { fatalError("Missing `single` processor configuration") }
         guard let pair = config.pair?.arrayValue else { fatalError("Missing `pair` processor configuration") }
-        
+
         self.single = single
         self.pair = pair
     }
-    
+
     func postProcess(tokens: [String], tokensPair: [String]? = nil, addSpecialTokens: Bool = true) -> [String] {
         let config = tokensPair == nil ? single : pair
 
@@ -99,7 +99,7 @@ class RobertaProcessing: PostProcessor {
         trimOffset = config.trimOffset?.boolValue ?? true
         addPrefixSpace = config.addPrefixSpace?.boolValue ?? true
     }
-    
+
     func postProcess(tokens: [String], tokensPair: [String]?, addSpecialTokens: Bool = true) -> [String] {
         var outTokens = tokens
         var tokensPair = tokensPair

--- a/Sources/Tokenizers/PreTokenizer.swift
+++ b/Sources/Tokenizers/PreTokenizer.swift
@@ -31,7 +31,7 @@ extension PreTokenizer {
     func callAsFunction(texts: [String], options: PreTokenizerOptions = [.firstSection]) -> [String] {
         preTokenize(texts: texts, options: options)
     }
-    
+
     func callAsFunction(text: String, options: PreTokenizerOptions = [.firstSection]) -> [String] {
         preTokenize(text: text, options: options)
     }
@@ -85,12 +85,12 @@ class BertPreTokenizer: PreTokenizer {
 
 class PreTokenizerSequence: PreTokenizer {
     let preTokenizers: [PreTokenizer]
-    
+
     required init(config: Config) {
         guard let configs = config.pretokenizers?.arrayValue else { fatalError("No pretokenizers in Sequence") }
         preTokenizers = configs.compactMap { PreTokenizerFactory.fromConfig(config: $0) }
     }
-    
+
     func preTokenize(text: String, options: PreTokenizerOptions = [.firstSection]) -> [String] {
         preTokenizers.reduce([text]) { current, preTokenizer in
             preTokenizer(texts: current, options: options)
@@ -114,40 +114,40 @@ class WhitespacePreTokenizer: PreTokenizer {
 class MetaspacePreTokenizer: PreTokenizer {
     /// Whether to add a prefix space to the first token
     let addPrefixSpace: Bool
-    
+
     /// Replacement character
     let replacement: String
-    
+
     /// Optional string representation of the replacement character.
     let stringReplacement: String
-    
+
     enum PrependScheme: String {
         case first
         case never
         case always
-        
+
         static var defaultScheme: PrependScheme { .always }
         static func from(rawValue value: String?) -> PrependScheme {
             guard let value else { return defaultScheme }
             return PrependScheme(rawValue: value) ?? defaultScheme
         }
     }
-    
+
     /// The metaspace prepend scheme, see https://github.com/huggingface/tokenizers/pull/1357
     let prependScheme: PrependScheme
-    
+
     required init(config: Config) {
         addPrefixSpace = config.addPrefixSpace?.boolValue ?? false
         replacement = config.replacement?.stringValue ?? " "
         stringReplacement = config.strRep?.stringValue ?? replacement
         prependScheme = PrependScheme.from(rawValue: config.prependScheme?.stringValue)
     }
-    
+
     /// https://github.com/huggingface/tokenizers/blob/accd0650b802f2180df40ef1def3bce32156688e/tokenizers/src/pre_tokenizers/metaspace.rs#L114
     /// https://github.com/xenova/transformers.js/blob/b07336d8f7ff57453cc164cc68aead2a79cbd57e/src/tokenizers.js#L2153
     func preTokenize(text: String, options: PreTokenizerOptions = [.firstSection]) -> [String] {
         let normalized = text.replacingOccurrences(of: " ", with: stringReplacement)
-        
+
         // We add a prefix space if:
         //  (1) The addPrefixSpace option is enabled and the normalized
         //      token does not already start with the replacement character.
@@ -165,7 +165,7 @@ class MetaspacePreTokenizer: PreTokenizer {
                 prepend = stringReplacement
             }
         }
-        
+
         // Split in `MergedWithNext` mode, although usually the input to this function is already pre-tokenized
         // https://github.com/huggingface/tokenizers/blob/accd0650b802f2180df40ef1def3bce32156688e/tokenizers/src/pre_tokenizers/metaspace.rs#L127
         return (prepend + normalized).split(by: replacement, behavior: .mergedWithNext)
@@ -177,13 +177,13 @@ class ByteLevelPreTokenizer: PreTokenizer {
     let trimOffsets: Bool
     let useRegex: Bool
     let RE = #"'s|'t|'re|'ve|'m|'ll|'d| ?\p{L}+| ?\p{N}+| ?[^\s\p{L}\p{N}]+|\s+(?!\S)|\s+"#
-    
+
     required init(config: Config) {
         addPrefixSpace = config.addPrefixSpace?.boolValue ?? false
         trimOffsets = config.trimOffsets?.boolValue ?? true
         useRegex = config.useRegex?.boolValue ?? true
     }
-    
+
     func preTokenize(text: String, options: PreTokenizerOptions = [.firstSection]) -> [String] {
         // Split on whitespace and punctuation
         let tokens = useRegex ? text.ranges(of: RE).map { String(text[$0]) } : [text]
@@ -277,7 +277,7 @@ public extension String {
         }
         return result
     }
-        
+
     func split(by string: String, options: CompareOptions = .regularExpression, includeSeparators: Bool = false, omittingEmptySubsequences: Bool = true) -> [String] {
         var result: [String] = []
         var start = startIndex
@@ -291,7 +291,7 @@ public extension String {
             }
             start = range.upperBound
         }
-        
+
         if omittingEmptySubsequences, start < endIndex {
             result.append(String(self[start...]))
         }
@@ -361,7 +361,7 @@ public extension String {
             }
             return merged
         }
-        
+
         func mergedWithPrevious(ranges: [Range<String.Index>]) -> [Range<String.Index>] {
             var merged: [Range<String.Index>] = []
             var currentStart = startIndex

--- a/Sources/Tokenizers/TokenLattice.swift
+++ b/Sources/Tokenizers/TokenLattice.swift
@@ -14,27 +14,27 @@ public struct TokenLattice {
     let sentence: String
     let bosTokenId: Int
     let eosTokenId: Int
-    
+
     var nodes: [TokenLatticeNode] = []
     var beginNodes: [[TokenLatticeNode]]
     var endNodes: [[TokenLatticeNode]]
-    
+
     var count: Int { sentence.count }
 
     init(sentence: String, bosTokenId: Int, eosTokenId: Int) {
         self.sentence = sentence
         self.bosTokenId = bosTokenId
         self.eosTokenId = eosTokenId
-        
+
         beginNodes = Array(repeating: [], count: sentence.count + 1)
         endNodes = Array(repeating: [], count: sentence.count + 1)
-        
+
         let bos = TokenLatticeNode(tokenId: bosTokenId, startOffset: 0, length: 0, score: 0)
         let eos = TokenLatticeNode(tokenId: eosTokenId, startOffset: sentence.count, length: 0, score: 0)
-        
+
         nodes.append(bos)
         nodes.append(eos)
-        
+
         beginNodes[sentence.count].append(eos)
         endNodes[0].append(bos)
     }
@@ -63,7 +63,7 @@ extension TokenLattice {
     func viterbi() -> [TokenLatticeNode] {
         for offset in 0...count {
             guard beginNodes[offset].count > 0 else { return [] }
-            
+
             for rnode in beginNodes[offset] {
                 rnode.prev = nil
                 var bestScore: Float = 0
@@ -75,14 +75,14 @@ extension TokenLattice {
                         bestScore = score
                     }
                 }
-                
+
                 if bestNode != nil {
                     rnode.prev = bestNode
                     rnode.backtraceScore = bestScore
                 }
             }
         }
-        
+
         let root = beginNodes[count][0]
         guard let prev = root.prev else { return [] }
 
@@ -95,7 +95,7 @@ extension TokenLattice {
         }
         return result.reversed()
     }
-    
+
     /// Returns the substring of the sentence to be tokenized associated to the specified node
     ///
     /// - Parameters:
@@ -113,7 +113,7 @@ public extension TokenLattice {
     var tokens: [String] {
         viterbi().map { String(piece($0)) }
     }
-    
+
     var tokenIds: [Int] {
         viterbi().map { $0.tokenId }
     }
@@ -124,10 +124,10 @@ class TokenLatticeNode {
     let startOffset: Int
     let length: Int
     let score: Float
-    
+
     var prev: TokenLatticeNode?
     var backtraceScore: Float = 0
-    
+
     init(tokenId: Int, startOffset: Int, length: Int, score: Float, prev: TokenLatticeNode? = nil, backtraceScore: Float = 0) {
         self.tokenId = tokenId
         self.startOffset = startOffset

--- a/Sources/Tokenizers/Trie.swift
+++ b/Sources/Tokenizers/Trie.swift
@@ -10,9 +10,9 @@ import Foundation
 
 public struct Trie<T: Hashable> {
     public typealias Node = TrieNode<T>
-    
+
     var root: Node
-    
+
     public init(root: Node? = nil) {
         self.root = root ?? Node()
     }
@@ -32,13 +32,13 @@ public extension Trie {
         }
         node.isLeaf = true
     }
-    
+
     func append(contentsOf container: any Sequence<any Sequence<T>>) {
         for t in container {
             insert(t)
         }
     }
-        
+
     /// Find all leaf nodes that share a common prefix with the input sequence (usually a text)
     /// Returns an array
     func commonPrefixSearch(_ text: any Sequence<T>) -> [[T]] {
@@ -55,7 +55,7 @@ public extension Trie {
         }
         return seqs
     }
-    
+
     /// Find all leaf nodes that share a common prefix with the input sequence (usually a text)
     /// Returns an iterator
     func commonPrefixSearchIterator(_ text: any Sequence<T>) -> LeavesWithCommonPrefixIterator<T> {
@@ -86,7 +86,7 @@ public struct LeavesWithCommonPrefixIterator<T: Hashable>: Sequence, IteratorPro
     var text: any Sequence<T>
     var seq: [T] = []
     lazy var iterator = text.makeIterator() as any IteratorProtocol<T>
-    
+
     public mutating func next() -> [T]? {
         while true {
             guard let item = iterator.next() else { return nil }

--- a/Sources/Tokenizers/UnigramTokenizer.swift
+++ b/Sources/Tokenizers/UnigramTokenizer.swift
@@ -16,13 +16,13 @@ class UnigramTokenizer: PreTrainedTokenizerModel {
     }
 
     let vocab: [SentencePieceToken]
-    
+
     let unknownPiece: SentencePieceToken
     var unknownTokenScore: Float { unknownPiece.score }
-    
+
     public let unknownTokenId: Int?
     public var unknownToken: String? { unknownPiece.token }
-    
+
     let minScore: Float
     let tokensToIds: [NSString: Int]
 
@@ -35,12 +35,12 @@ class UnigramTokenizer: PreTrainedTokenizerModel {
     let fuseUnknownTokens: Bool = true
 
     private let trie: Trie<Character>
-        
+
     required init(tokenizerConfig: Config, tokenizerData: Config, addedTokens: [String: Int]) throws {
         guard let configVocab = tokenizerData.model?.vocab?.value as? [[Any]] else {
             throw TokenizerError.missingVocab
         }
-        
+
         vocab = try configVocab.map { piece in
             guard let token = piece.first as? String,
                   let scoreValue = piece.last
@@ -56,18 +56,18 @@ class UnigramTokenizer: PreTrainedTokenizerModel {
             } else {
                 throw TokenizerError.malformedVocab
             }
-            
+
             return SentencePieceToken(token: token, score: score)
         }
-        
+
         minScore = vocab.reduce(999) { partial, token in
             min(partial, token.score)
         }
-        
+
         guard let unknownTokenId = tokenizerData.model?.unkId?.intValue else { throw TokenizerError.malformedVocab }
         self.unknownTokenId = unknownTokenId
         unknownPiece = SentencePieceToken(token: vocab[unknownTokenId].token, score: minScore - 10)
-        
+
         tokensToIds = Dictionary(uniqueKeysWithValues: vocab.map { $0.token as NSString }.enumerated().map { ($1, $0) })
         bosTokenId = tokensToIds[bosToken! as NSString] // May be nil
 
@@ -81,21 +81,21 @@ class UnigramTokenizer: PreTrainedTokenizerModel {
     func convertTokenToId(_ token: String) -> Int? {
         tokensToIds[token as NSString] ?? unknownTokenId
     }
-    
+
     func convertIdToToken(_ id: Int) -> String? {
         vocab[id].token
     }
-        
+
     func tokenize(text: String) -> [String] {
         var lattice = TokenLattice(sentence: text, bosTokenId: bosTokenId ?? 0, eosTokenId: eosTokenId ?? 0)
-        
+
         // Populate nodes
         let sentence = lattice.sentence
         var beginPos = 0
         while beginPos < sentence.count {
             let mblen = 1
             var hasSingleNode = false
-            
+
             let beginIndex = sentence.index(sentence.startIndex, offsetBy: beginPos)
             for token in trie.commonPrefixSearchIterator(sentence[beginIndex...]).map({ String($0) }) {
                 guard let tokenId = tokensToIds[token as NSString] else { fatalError("Token not in vocab: \(token)") }

--- a/Sources/Tokenizers/Utils.swift
+++ b/Sources/Tokenizers/Utils.swift
@@ -17,7 +17,7 @@ struct Utils {
         print("[\(label)] \(diff)ms")
         return result
     }
-    
+
     /// Time a block in seconds and return (output, time)
     static func time<T>(_ block: () -> T) -> (T, Double) {
         let startTime = CFAbsoluteTimeGetCurrent()
@@ -25,24 +25,24 @@ struct Utils {
         let diff = CFAbsoluteTimeGetCurrent() - startTime
         return (result, diff)
     }
-    
+
     /// Return unix timestamp in ms
     static func dateNow() -> Int64 {
         // Use `Int` when we don't support 32-bits devices/OSes anymore.
         // Int crashes on iPhone 5c.
         Int64(Date().timeIntervalSince1970 * 1000)
     }
-    
+
     /// Clamp a val to [min, max]
     static func clamp<T: Comparable>(_ val: T, _ vmin: T, _ vmax: T) -> T {
         min(max(vmin, val), vmax)
     }
-    
+
     /// Fake func that can throw.
     static func fakeThrowable<T>(_ input: T) throws -> T {
         input
     }
-    
+
     /// Substring
     static func substr(_ s: String, _ r: Range<Int>) -> String? {
         let stringCount = s.count
@@ -53,7 +53,7 @@ struct Utils {
         let endIndex = s.index(startIndex, offsetBy: r.upperBound - r.lowerBound)
         return String(s[startIndex..<endIndex])
     }
-    
+
     /// Invert a (k, v) dictionary
     static func invert<K, V>(_ dict: [K: V]) -> [V: K] {
         var inverted: [V: K] = [:]

--- a/Sources/TransformersCLI/main.swift
+++ b/Sources/TransformersCLI/main.swift
@@ -23,7 +23,7 @@ struct TransformersCLI: ParsableCommand {
 
     @Option(help: "Compute units to load model with {all,cpuOnly,cpuAndGPU,cpuAndNeuralEngine}")
     var computeUnits: ComputeUnits = .cpuAndGPU
-    
+
     func generate(model: LanguageModel, config: GenerationConfig, prompt: String, printOutput: Bool = true) {
         let semaphore = DispatchSemaphore(value: 0)
         Task.init { [config] in
@@ -69,15 +69,15 @@ struct TransformersCLI: ParsableCommand {
         let compiledURL = try compile(at: url)
         print("Loading model \(compiledURL)")
         let model = try LanguageModel.loadCompiled(url: compiledURL, computeUnits: computeUnits.asMLComputeUnits)
-        
+
         // Using greedy generation for now
         var config = model.defaultGenerationConfig
         config.doSample = false
         config.maxNewTokens = maxLength
-        
+
         print("Warming up...")
         generate(model: model, config: config, prompt: prompt, printOutput: false)
-        
+
         print("Generating")
         generate(model: model, config: config, prompt: prompt)
     }

--- a/Tests/HubTests/DownloaderTests.swift
+++ b/Tests/HubTests/DownloaderTests.swift
@@ -32,20 +32,20 @@ private extension Downloader {
 
 final class DownloaderTests: XCTestCase {
     var tempDir: URL!
-    
+
     override func setUp() {
         super.setUp()
         tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
         try? FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
     }
-    
+
     override func tearDown() {
         if let tempDir, FileManager.default.fileExists(atPath: tempDir.path) {
             try? FileManager.default.removeItem(at: tempDir)
         }
         super.tearDown()
     }
-    
+
     /// This test downloads a known config file, verifies the download completes, checks the content matches expected value
     func testSuccessfulDownload() async throws {
         // Create a test file
@@ -65,22 +65,22 @@ final class DownloaderTests: XCTestCase {
         }
 
         """
-        
+
         let cacheDir = tempDir.appendingPathComponent("cache")
         try? FileManager.default.createDirectory(at: cacheDir, withIntermediateDirectories: true)
 
         let incompleteDestination = cacheDir.appendingPathComponent("config.json.\(etag).incomplete")
         FileManager.default.createFile(atPath: incompleteDestination.path, contents: nil, attributes: nil)
-        
+
         let downloader = Downloader(
             from: url,
             to: destination,
             incompleteDestination: incompleteDestination
         )
-        
+
         // Store subscriber outside the continuation to maintain its lifecycle
         var subscriber: AnyCancellable?
-        
+
         try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
             subscriber = downloader.downloadState.sink { state in
                 switch state {
@@ -95,21 +95,21 @@ final class DownloaderTests: XCTestCase {
                 }
             }
         }
-        
+
         // Cancel subscription after continuation completes
         subscriber?.cancel()
-        
+
         // Verify download completed successfully
         XCTAssertTrue(FileManager.default.fileExists(atPath: destination.path))
         XCTAssertEqual(try String(contentsOf: destination, encoding: .utf8), fileContent)
     }
-    
+
     /// This test attempts to download with incorrect expected file, verifies the download fails, ensures no partial file is left behind
     func testDownloadFailsWithIncorrectSize() async throws {
         let url = URL(string: "https://huggingface.co/coreml-projects/Llama-2-7b-chat-coreml/resolve/main/config.json")!
         let etag = try await Hub.getFileMetadata(fileURL: url).etag!
         let destination = tempDir.appendingPathComponent("config.json")
-        
+
         let cacheDir = tempDir.appendingPathComponent("cache")
         try? FileManager.default.createDirectory(at: cacheDir, withIntermediateDirectories: true)
 
@@ -123,27 +123,27 @@ final class DownloaderTests: XCTestCase {
             incompleteDestination: incompleteDestination,
             expectedSize: 999999 // Incorrect size
         )
-        
+
         do {
             try downloader.waitUntilDone()
             XCTFail("Download should have failed due to size mismatch")
         } catch { }
-        
+
         // Verify no file was created at destination
         XCTAssertFalse(FileManager.default.fileExists(atPath: destination.path))
     }
-    
+
     /// This test downloads an LFS file, interrupts the download at 50% and 75% progress,
     /// verifies the download can resume and complete successfully, checks the final file exists and has content
     func testSuccessfulInterruptedDownload() async throws {
         let url = URL(string: "https://huggingface.co/coreml-projects/sam-2-studio/resolve/main/SAM%202%20Studio%201.1.zip")!
         let etag = try await Hub.getFileMetadata(fileURL: url).etag!
         let destination = tempDir.appendingPathComponent("SAM%202%20Studio%201.1.zip")
-        
+
         // Create parent directory if it doesn't exist
         try FileManager.default.createDirectory(at: destination.deletingLastPathComponent(),
                                                 withIntermediateDirectories: true)
-        
+
         let cacheDir = tempDir.appendingPathComponent("cache")
         try? FileManager.default.createDirectory(at: cacheDir, withIntermediateDirectories: true)
 
@@ -156,12 +156,12 @@ final class DownloaderTests: XCTestCase {
             incompleteDestination: incompleteDestination,
             expectedSize: 73194001 // Correct size for verification
         )
-        
+
         // First interruption point at 50%
         var threshold = 0.5
-        
+
         var subscriber: AnyCancellable?
-        
+
         do {
             // Monitor download progress and interrupt at thresholds to test if
             // download continues from where it left off
@@ -183,9 +183,9 @@ final class DownloaderTests: XCTestCase {
                     }
                 }
             }
-            
+
             subscriber?.cancel()
-            
+
             // Verify the file exists and is complete
             if FileManager.default.fileExists(atPath: destination.path) {
                 let attributes = try FileManager.default.attributesOfItem(atPath: destination.path)

--- a/Tests/HubTests/HubApiTests.swift
+++ b/Tests/HubTests/HubApiTests.swift
@@ -87,12 +87,12 @@ class HubApiTests: XCTestCase {
             XCTFail("\(error)")
         }
     }
-    
+
     func testGetFileMetadata() async throws {
         do {
             let url = URL(string: "https://huggingface.co/enterprise-explorers/Llama-2-7b-chat-coreml/resolve/main/config.json")
             let metadata = try await Hub.getFileMetadata(fileURL: url!)
-            
+
             XCTAssertNotNil(metadata.commitHash)
             XCTAssertNotNil(metadata.etag)
             XCTAssertEqual(metadata.location, url?.absoluteString)
@@ -101,12 +101,12 @@ class HubApiTests: XCTestCase {
             XCTFail("\(error)")
         }
     }
-    
+
     func testGetFileMetadataBlobPath() async throws {
         do {
             let url = URL(string: "https://huggingface.co/enterprise-explorers/Llama-2-7b-chat-coreml/resolve/main/config.json")
             let metadata = try await Hub.getFileMetadata(fileURL: url!)
-            
+
             XCTAssertNotNil(metadata.commitHash)
             XCTAssertTrue(metadata.etag != nil && metadata.etag!.hasPrefix("d6ceb9"))
             XCTAssertEqual(metadata.location, url?.absoluteString)
@@ -115,13 +115,13 @@ class HubApiTests: XCTestCase {
             XCTFail("\(error)")
         }
     }
-    
+
     func testGetFileMetadataWithRevision() async throws {
         do {
             let revision = "f2c752cfc5c0ab6f4bdec59acea69eefbee381c2"
             let url = URL(string: "https://huggingface.co/julien-c/dummy-unknown/resolve/\(revision)/config.json")
             let metadata = try await Hub.getFileMetadata(fileURL: url!)
-            
+
             XCTAssertEqual(metadata.commitHash, revision)
             XCTAssertNotNil(metadata.etag)
             XCTAssertGreaterThan(metadata.etag!.count, 0)
@@ -144,7 +144,7 @@ class HubApiTests: XCTestCase {
             XCTAssertGreaterThan(metadata.size!, 0)
         }
     }
-    
+
     /// Verify with `curl -I https://huggingface.co/coreml-projects/Llama-2-7b-chat-coreml/resolve/main/llama-2-7b-chat.mlpackage/Data/com.apple.CoreML/model.mlmodel`
     func testGetLargeFileMetadata() async throws {
         do {
@@ -152,10 +152,10 @@ class HubApiTests: XCTestCase {
             let etag = "fc329090bfbb2570382c9af997cffd5f4b78b39b8aeca62076db69534e020107"
             let location = "https://cdn-lfs.hf.co/repos/4a/4e/4a4e587f66a2979dcd75e1d7324df8ee9ef74be3582a05bea31c2c26d0d467d0/fc329090bfbb2570382c9af997cffd5f4b78b39b8aeca62076db69534e020107?response-content-disposition=inline%3B+filename*%3DUTF-8%27%27model.mlmodel%3B+filename%3D%22model.mlmodel"
             let size = 504766
-            
+
             let url = URL(string: "https://huggingface.co/coreml-projects/Llama-2-7b-chat-coreml/resolve/main/llama-2-7b-chat.mlpackage/Data/com.apple.CoreML/model.mlmodel")
             let metadata = try await Hub.getFileMetadata(fileURL: url!)
-                        
+
             XCTAssertEqual(metadata.commitHash, revision)
             XCTAssertNotNil(metadata.etag, etag)
             XCTAssertTrue(metadata.location.contains(location))
@@ -173,9 +173,9 @@ class SnapshotDownloadTests: XCTestCase {
         let base = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first!
         return base.appending(component: "huggingface-tests")
     }()
-    
+
     override func setUp() { }
-    
+
     override func tearDown() {
         do {
             try FileManager.default.removeItem(at: downloadDestination)
@@ -183,11 +183,11 @@ class SnapshotDownloadTests: XCTestCase {
             print("Can't remove test download destination \(downloadDestination), error: \(error)")
         }
     }
-    
+
     func getRelativeFiles(url: URL, repo: String) -> [String] {
         var filenames: [String] = []
         let prefix = downloadDestination.appending(path: "models/\(repo)").path.appending("/")
-        
+
         if let enumerator = FileManager.default.enumerator(at: url, includingPropertiesForKeys: [.isRegularFileKey], options: [.skipsHiddenFiles], errorHandler: nil) {
             for case let fileURL as URL in enumerator {
                 do {
@@ -202,31 +202,31 @@ class SnapshotDownloadTests: XCTestCase {
         }
         return filenames
     }
-    
+
     func testDownload() async throws {
         let hubApi = HubApi(downloadBase: downloadDestination)
         var lastProgress: Progress? = nil
-        
+
         // Add debug prints
         print("Download destination before: \(downloadDestination.path)")
-        
+
         let downloadedTo = try await hubApi.snapshot(from: repo, matching: "*.json") { progress in
             print("Total Progress: \(progress.fractionCompleted)")
             print("Files Completed: \(progress.completedUnitCount) of \(progress.totalUnitCount)")
             lastProgress = progress
         }
-        
+
         // Add more debug prints
         print("Downloaded to: \(downloadedTo.path)")
-        
+
         let downloadedFilenames = getRelativeFiles(url: downloadDestination, repo: repo)
         print("Downloaded filenames: \(downloadedFilenames)")
         print("Prefix used in getRelativeFiles: \(downloadDestination.appending(path: "models/\(repo)").path)")
-        
+
         XCTAssertEqual(lastProgress?.fractionCompleted, 1)
         XCTAssertEqual(lastProgress?.completedUnitCount, 6)
         XCTAssertEqual(downloadedTo, downloadDestination.appending(path: "models/\(repo)"))
-        
+
         XCTAssertEqual(
             Set(downloadedFilenames),
             Set([
@@ -237,7 +237,7 @@ class SnapshotDownloadTests: XCTestCase {
             ])
         )
     }
-    
+
     /// Background sessions get rate limited by the OS, see discussion here: https://github.com/huggingface/swift-transformers/issues/61
     /// Test only one file at a time
     func testDownloadInBackground() async throws {
@@ -251,7 +251,7 @@ class SnapshotDownloadTests: XCTestCase {
         XCTAssertEqual(lastProgress?.fractionCompleted, 1)
         XCTAssertEqual(lastProgress?.completedUnitCount, 1)
         XCTAssertEqual(downloadedTo, downloadDestination.appending(path: "models/\(repo)"))
-        
+
         let downloadedFilenames = getRelativeFiles(url: downloadDestination, repo: repo)
         XCTAssertEqual(
             Set(downloadedFilenames),
@@ -260,7 +260,7 @@ class SnapshotDownloadTests: XCTestCase {
             ])
         )
     }
-    
+
     func testCustomEndpointDownload() async throws {
         let hubApi = HubApi(downloadBase: downloadDestination, endpoint: "https://hf-mirror.com")
         var lastProgress: Progress? = nil
@@ -272,7 +272,7 @@ class SnapshotDownloadTests: XCTestCase {
         XCTAssertEqual(lastProgress?.fractionCompleted, 1)
         XCTAssertEqual(lastProgress?.completedUnitCount, 6)
         XCTAssertEqual(downloadedTo, downloadDestination.appending(path: "models/\(repo)"))
-        
+
         let downloadedFilenames = getRelativeFiles(url: downloadDestination, repo: repo)
         XCTAssertEqual(
             Set(downloadedFilenames),
@@ -284,7 +284,7 @@ class SnapshotDownloadTests: XCTestCase {
             ])
         )
     }
-    
+
     func testDownloadFileMetadata() async throws {
         let hubApi = HubApi(downloadBase: downloadDestination)
         var lastProgress: Progress? = nil
@@ -296,7 +296,7 @@ class SnapshotDownloadTests: XCTestCase {
         XCTAssertEqual(lastProgress?.fractionCompleted, 1)
         XCTAssertEqual(lastProgress?.completedUnitCount, 6)
         XCTAssertEqual(downloadedTo, downloadDestination.appending(path: "models/\(repo)"))
-        
+
         let downloadedFilenames = getRelativeFiles(url: downloadDestination, repo: repo)
         XCTAssertEqual(
             Set(downloadedFilenames),
@@ -307,7 +307,7 @@ class SnapshotDownloadTests: XCTestCase {
                 "llama-2-7b-chat.mlpackage/Data/com.apple.CoreML/Metadata.json",
             ])
         )
-        
+
         let metadataDestination = downloadedTo.appending(component: ".cache/huggingface/download")
         let downloadedMetadataFilenames = getRelativeFiles(url: metadataDestination, repo: repo)
         XCTAssertEqual(
@@ -322,21 +322,21 @@ class SnapshotDownloadTests: XCTestCase {
             ])
         )
     }
-    
+
     func testDownloadFileMetadataExists() async throws {
         let hubApi = HubApi(downloadBase: downloadDestination)
         var lastProgress: Progress? = nil
-        
+
         let downloadedTo = try await hubApi.snapshot(from: repo, matching: "*.json") { progress in
             print("Total Progress: \(progress.fractionCompleted)")
             print("Files Completed: \(progress.completedUnitCount) of \(progress.totalUnitCount)")
             lastProgress = progress
         }
-        
+
         XCTAssertEqual(lastProgress?.fractionCompleted, 1)
         XCTAssertEqual(lastProgress?.completedUnitCount, 6)
         XCTAssertEqual(downloadedTo, downloadDestination.appending(path: "models/\(repo)"))
-        
+
         let downloadedFilenames = getRelativeFiles(url: downloadDestination, repo: repo)
         XCTAssertEqual(
             Set(downloadedFilenames),
@@ -347,13 +347,13 @@ class SnapshotDownloadTests: XCTestCase {
                 "llama-2-7b-chat.mlpackage/Data/com.apple.CoreML/Metadata.json",
             ])
         )
-        
+
         let metadataDestination = downloadedTo.appending(component: ".cache/huggingface/download")
-        
+
         let configPath = downloadedTo.appending(path: "config.json")
         var attributes = try FileManager.default.attributesOfItem(atPath: configPath.path)
         let originalTimestamp = attributes[.modificationDate] as! Date
-        
+
         let downloadedMetadataFilenames = getRelativeFiles(url: metadataDestination, repo: repo)
         XCTAssertEqual(
             Set(downloadedMetadataFilenames),
@@ -366,41 +366,41 @@ class SnapshotDownloadTests: XCTestCase {
                 ".cache/huggingface/download/llama-2-7b-chat.mlpackage/Data/com.apple.CoreML/Metadata.json.metadata",
             ])
         )
-        
+
         let _ = try await hubApi.snapshot(from: repo, matching: "*.json") { progress in
             print("Total Progress: \(progress.fractionCompleted)")
             print("Files Completed: \(progress.completedUnitCount) of \(progress.totalUnitCount)")
             lastProgress = progress
         }
-        
+
         attributes = try FileManager.default.attributesOfItem(atPath: configPath.path)
         let secondDownloadTimestamp = attributes[.modificationDate] as! Date
-        
+
         // File will not be downloaded again thus last modified date will remain unchanged
         XCTAssertTrue(originalTimestamp == secondDownloadTimestamp)
     }
-    
+
     func testDownloadFileMetadataSame() async throws {
         let hubApi = HubApi(downloadBase: downloadDestination)
         var lastProgress: Progress? = nil
-        
+
         let downloadedTo = try await hubApi.snapshot(from: repo, matching: "tokenizer.json") { progress in
             print("Total Progress: \(progress.fractionCompleted)")
             print("Files Completed: \(progress.completedUnitCount) of \(progress.totalUnitCount)")
             lastProgress = progress
         }
-        
+
         XCTAssertEqual(lastProgress?.fractionCompleted, 1)
         XCTAssertEqual(lastProgress?.completedUnitCount, 1)
         XCTAssertEqual(downloadedTo, downloadDestination.appending(path: "models/\(repo)"))
-        
+
         let downloadedFilenames = getRelativeFiles(url: downloadDestination, repo: repo)
         XCTAssertEqual(Set(downloadedFilenames), Set(["tokenizer.json"]))
-        
+
         let metadataDestination = downloadedTo.appending(component: ".cache/huggingface/download")
-        
+
         let metadataPath = metadataDestination.appending(path: "tokenizer.json.metadata")
-        
+
         let downloadedMetadataFilenames = getRelativeFiles(url: metadataDestination, repo: repo)
         XCTAssertEqual(
             Set(downloadedMetadataFilenames),
@@ -408,39 +408,39 @@ class SnapshotDownloadTests: XCTestCase {
                 ".cache/huggingface/download/tokenizer.json.metadata",
             ])
         )
-        
+
         let originalMetadata = try String(contentsOf: metadataPath, encoding: .utf8)
-        
+
         let _ = try await hubApi.snapshot(from: repo, matching: "tokenizer.json") { progress in
             print("Total Progress: \(progress.fractionCompleted)")
             print("Files Completed: \(progress.completedUnitCount) of \(progress.totalUnitCount)")
             lastProgress = progress
         }
-        
+
         let secondDownloadMetadata = try String(contentsOf: metadataPath, encoding: .utf8)
-        
+
         // File hasn't changed so commit hash and etag will be identical
         let originalArr = originalMetadata.components(separatedBy: .newlines)
         let secondDownloadArr = secondDownloadMetadata.components(separatedBy: .newlines)
-        
+
         XCTAssertTrue(originalArr[0] == secondDownloadArr[0])
         XCTAssertTrue(originalArr[1] == secondDownloadArr[1])
     }
-    
+
     func testDownloadFileMetadataCorrupted() async throws {
         let hubApi = HubApi(downloadBase: downloadDestination)
         var lastProgress: Progress? = nil
-        
+
         let downloadedTo = try await hubApi.snapshot(from: repo, matching: "*.json") { progress in
             print("Total Progress: \(progress.fractionCompleted)")
             print("Files Completed: \(progress.completedUnitCount) of \(progress.totalUnitCount)")
             lastProgress = progress
         }
-        
+
         XCTAssertEqual(lastProgress?.fractionCompleted, 1)
         XCTAssertEqual(lastProgress?.completedUnitCount, 6)
         XCTAssertEqual(downloadedTo, downloadDestination.appending(path: "models/\(repo)"))
-        
+
         let downloadedFilenames = getRelativeFiles(url: downloadDestination, repo: repo)
         XCTAssertEqual(
             Set(downloadedFilenames),
@@ -451,13 +451,13 @@ class SnapshotDownloadTests: XCTestCase {
                 "llama-2-7b-chat.mlpackage/Data/com.apple.CoreML/Metadata.json",
             ])
         )
-        
+
         let metadataDestination = downloadedTo.appending(component: ".cache/huggingface/download")
-        
+
         let configPath = downloadedTo.appending(path: "config.json")
         var attributes = try FileManager.default.attributesOfItem(atPath: configPath.path)
         let originalTimestamp = attributes[.modificationDate] as! Date
-        
+
         let downloadedMetadataFilenames = getRelativeFiles(url: metadataDestination, repo: repo)
         XCTAssertEqual(
             Set(downloadedMetadataFilenames),
@@ -470,66 +470,66 @@ class SnapshotDownloadTests: XCTestCase {
                 ".cache/huggingface/download/llama-2-7b-chat.mlpackage/Data/com.apple.CoreML/Metadata.json.metadata",
             ])
         )
-        
+
         // Corrupt config.json.metadata
         print("Testing corrupted file.")
         try "a".write(to: metadataDestination.appendingPathComponent("config.json.metadata"), atomically: true, encoding: .utf8)
-        
+
         let _ = try await hubApi.snapshot(from: repo, matching: "*.json") { progress in
             print("Total Progress: \(progress.fractionCompleted)")
             print("Files Completed: \(progress.completedUnitCount) of \(progress.totalUnitCount)")
             lastProgress = progress
         }
-        
+
         attributes = try FileManager.default.attributesOfItem(atPath: configPath.path)
         let secondDownloadTimestamp = attributes[.modificationDate] as! Date
-        
+
         // File will be downloaded again thus last modified date will change
         XCTAssertTrue(originalTimestamp != secondDownloadTimestamp)
-        
+
         // Corrupt config.metadata again
         print("Testing corrupted timestamp.")
         try "a\nb\nc\n".write(to: metadataDestination.appendingPathComponent("config.json.metadata"), atomically: true, encoding: .utf8)
-        
+
         let _ = try await hubApi.snapshot(from: repo, matching: "*.json") { progress in
             print("Total Progress: \(progress.fractionCompleted)")
             print("Files Completed: \(progress.completedUnitCount) of \(progress.totalUnitCount)")
             lastProgress = progress
         }
-        
+
         attributes = try FileManager.default.attributesOfItem(atPath: configPath.path)
         let thirdDownloadTimestamp = attributes[.modificationDate] as! Date
-        
+
         // File will be downloaded again thus last modified date will change
         XCTAssertTrue(originalTimestamp != thirdDownloadTimestamp)
     }
-    
+
     func testDownloadLargeFileMetadataCorrupted() async throws {
         let hubApi = HubApi(downloadBase: downloadDestination)
         var lastProgress: Progress? = nil
-        
+
         let downloadedTo = try await hubApi.snapshot(from: repo, matching: "*.mlmodel") { progress in
             print("Total Progress: \(progress.fractionCompleted)")
             print("Files Completed: \(progress.completedUnitCount) of \(progress.totalUnitCount)")
             lastProgress = progress
         }
-        
+
         XCTAssertEqual(lastProgress?.fractionCompleted, 1)
         XCTAssertEqual(lastProgress?.completedUnitCount, 1)
         XCTAssertEqual(downloadedTo, downloadDestination.appending(path: "models/\(repo)"))
-        
+
         let downloadedFilenames = getRelativeFiles(url: downloadDestination, repo: repo)
         XCTAssertEqual(
             Set(downloadedFilenames),
             Set(["llama-2-7b-chat.mlpackage/Data/com.apple.CoreML/model.mlmodel"])
         )
-        
+
         let metadataDestination = downloadedTo.appending(component: ".cache/huggingface/download")
-        
+
         let modelPath = downloadedTo.appending(path: "llama-2-7b-chat.mlpackage/Data/com.apple.CoreML/model.mlmodel")
         var attributes = try FileManager.default.attributesOfItem(atPath: modelPath.path)
         let originalTimestamp = attributes[.modificationDate] as! Date
-        
+
         let downloadedMetadataFilenames = getRelativeFiles(url: metadataDestination, repo: repo)
         XCTAssertEqual(
             Set(downloadedMetadataFilenames),
@@ -537,34 +537,34 @@ class SnapshotDownloadTests: XCTestCase {
                 ".cache/huggingface/download/llama-2-7b-chat.mlpackage/Data/com.apple.CoreML/model.mlmodel.metadata",
             ])
         )
-        
+
         // Corrupt model.metadata etag
         print("Testing corrupted etag.")
         let corruptedMetadataString = "a\nfc329090bfbb2570382c9af997cffd5f4b78b39b8aeca62076db69534e020108\n0\n"
         let metadataFile = metadataDestination.appendingPathComponent("llama-2-7b-chat.mlpackage/Data/com.apple.CoreML/model.mlmodel.metadata")
         try corruptedMetadataString.write(to: metadataFile, atomically: true, encoding: .utf8)
-        
+
         let _ = try await hubApi.snapshot(from: repo, matching: "*.mlmodel") { progress in
             print("Total Progress: \(progress.fractionCompleted)")
             print("Files Completed: \(progress.completedUnitCount) of \(progress.totalUnitCount)")
             lastProgress = progress
         }
-        
+
         attributes = try FileManager.default.attributesOfItem(atPath: modelPath.path)
         let thirdDownloadTimestamp = attributes[.modificationDate] as! Date
-        
+
         // File will not be downloaded again because this is an LFS file.
         // While downloading LFS files, we first check if local file ETag is the same as remote ETag.
         // If that's the case we just update the metadata and keep the local file.
         XCTAssertEqual(originalTimestamp, thirdDownloadTimestamp)
-        
+
         let metadataString = try String(contentsOfFile: metadataFile.path)
-        
+
         // Updated metadata file needs to have the correct commit hash, etag and timestamp.
         // This is being updated because the local etag (SHA256 checksum) matches the remote etag
         XCTAssertNotEqual(metadataString, corruptedMetadataString)
     }
-    
+
     func testDownloadLargeFile() async throws {
         let hubApi = HubApi(downloadBase: downloadDestination)
         var lastProgress: Progress? = nil
@@ -573,28 +573,28 @@ class SnapshotDownloadTests: XCTestCase {
             print("Files Completed: \(progress.completedUnitCount) of \(progress.totalUnitCount)")
             lastProgress = progress
         }
-        
+
         XCTAssertEqual(lastProgress?.fractionCompleted, 1)
         XCTAssertEqual(lastProgress?.completedUnitCount, 1)
         XCTAssertEqual(downloadedTo, downloadDestination.appending(path: "models/\(repo)"))
-        
+
         let downloadedFilenames = getRelativeFiles(url: downloadDestination, repo: repo)
         XCTAssertEqual(Set(downloadedFilenames), Set(["llama-2-7b-chat.mlpackage/Data/com.apple.CoreML/model.mlmodel"]))
-        
+
         let metadataDestination = downloadedTo.appending(component: ".cache/huggingface/download")
         let downloadedMetadataFilenames = getRelativeFiles(url: metadataDestination, repo: repo)
         XCTAssertEqual(
             Set(downloadedMetadataFilenames),
             Set([".cache/huggingface/download/llama-2-7b-chat.mlpackage/Data/com.apple.CoreML/model.mlmodel.metadata"])
         )
-        
+
         let metadataFile = metadataDestination.appendingPathComponent("llama-2-7b-chat.mlpackage/Data/com.apple.CoreML/model.mlmodel.metadata")
         let metadataString = try String(contentsOfFile: metadataFile.path)
-        
+
         let expected = "eaf97358a37d03fd48e5a87d15aff2e8423c1afb\nfc329090bfbb2570382c9af997cffd5f4b78b39b8aeca62076db69534e020107"
         XCTAssertTrue(metadataString.contains(expected))
     }
-    
+
     func testDownloadSmolLargeFile() async throws {
         let hubApi = HubApi(downloadBase: downloadDestination)
         var lastProgress: Progress? = nil
@@ -603,28 +603,28 @@ class SnapshotDownloadTests: XCTestCase {
             print("Files Completed: \(progress.completedUnitCount) of \(progress.totalUnitCount)")
             lastProgress = progress
         }
-        
+
         XCTAssertEqual(lastProgress?.fractionCompleted, 1)
         XCTAssertEqual(lastProgress?.completedUnitCount, 1)
         XCTAssertEqual(downloadedTo, downloadDestination.appending(path: "models/\(lfsRepo)"))
-        
+
         let downloadedFilenames = getRelativeFiles(url: downloadDestination, repo: lfsRepo)
         XCTAssertEqual(Set(downloadedFilenames), Set(["x.bin"]))
-        
+
         let metadataDestination = downloadedTo.appending(component: ".cache/huggingface/download")
         let downloadedMetadataFilenames = getRelativeFiles(url: metadataDestination, repo: lfsRepo)
         XCTAssertEqual(
             Set(downloadedMetadataFilenames),
             Set([".cache/huggingface/download/x.bin.metadata"])
         )
-        
+
         let metadataFile = metadataDestination.appendingPathComponent("x.bin.metadata")
         let metadataString = try String(contentsOfFile: metadataFile.path)
-        
+
         let expected = "77b984598d90af6143d73d5a2d6214b23eba7e27\n98ea6e4f216f2fb4b69fff9b3a44842c38686ca685f3f55dc48c5d3fb1107be4"
         XCTAssertTrue(metadataString.contains(expected))
     }
-    
+
     func testRegexValidation() async throws {
         let hubApi = HubApi(downloadBase: downloadDestination)
         var lastProgress: Progress? = nil
@@ -633,219 +633,219 @@ class SnapshotDownloadTests: XCTestCase {
             print("Files Completed: \(progress.completedUnitCount) of \(progress.totalUnitCount)")
             lastProgress = progress
         }
-        
+
         XCTAssertEqual(lastProgress?.fractionCompleted, 1)
         XCTAssertEqual(lastProgress?.completedUnitCount, 1)
         XCTAssertEqual(downloadedTo, downloadDestination.appending(path: "models/\(lfsRepo)"))
-        
+
         let downloadedFilenames = getRelativeFiles(url: downloadDestination, repo: lfsRepo)
         XCTAssertEqual(Set(downloadedFilenames), Set(["x.bin"]))
-        
+
         let metadataDestination = downloadedTo.appending(component: ".cache/huggingface/download")
         let downloadedMetadataFilenames = getRelativeFiles(url: metadataDestination, repo: lfsRepo)
         XCTAssertEqual(
             Set(downloadedMetadataFilenames),
             Set([".cache/huggingface/download/x.bin.metadata"])
         )
-        
+
         let metadataFile = metadataDestination.appendingPathComponent("x.bin.metadata")
         let metadataString = try String(contentsOfFile: metadataFile.path)
         let metadataArr = metadataString.components(separatedBy: .newlines)
-        
+
         let commitHash = metadataArr[0]
         let etag = metadataArr[1]
-        
+
         XCTAssertTrue(hubApi.isValidHash(hash: commitHash, pattern: hubApi.commitHashPattern))
         XCTAssertTrue(hubApi.isValidHash(hash: etag, pattern: hubApi.sha256Pattern))
-        
+
         XCTAssertFalse(hubApi.isValidHash(hash: "\(commitHash)a", pattern: hubApi.commitHashPattern))
         XCTAssertFalse(hubApi.isValidHash(hash: "\(etag)a", pattern: hubApi.sha256Pattern))
     }
-    
+
     func testLFSFileNoMetadata() async throws {
         let hubApi = HubApi(downloadBase: downloadDestination)
         var lastProgress: Progress? = nil
-        
+
         let downloadedTo = try await hubApi.snapshot(from: lfsRepo, matching: "x.bin") { progress in
             print("Total Progress: \(progress.fractionCompleted)")
             print("Files Completed: \(progress.completedUnitCount) of \(progress.totalUnitCount)")
             lastProgress = progress
         }
-        
+
         XCTAssertEqual(lastProgress?.fractionCompleted, 1)
         XCTAssertEqual(lastProgress?.completedUnitCount, 1)
         XCTAssertEqual(downloadedTo, downloadDestination.appending(path: "models/\(lfsRepo)"))
-        
+
         let downloadedFilenames = getRelativeFiles(url: downloadDestination, repo: lfsRepo)
         XCTAssertEqual(Set(downloadedFilenames), Set(["x.bin"]))
-        
+
         let metadataDestination = downloadedTo.appending(component: ".cache/huggingface/download")
-        
+
         let filePath = downloadedTo.appending(path: "x.bin")
         var attributes = try FileManager.default.attributesOfItem(atPath: filePath.path)
         let originalTimestamp = attributes[.modificationDate] as! Date
-        
+
         let downloadedMetadataFilenames = getRelativeFiles(url: metadataDestination, repo: lfsRepo)
         XCTAssertEqual(
             Set(downloadedMetadataFilenames),
             Set([".cache/huggingface/download/x.bin.metadata"])
         )
-        
+
         let metadataFile = metadataDestination.appendingPathComponent("x.bin.metadata")
         try FileManager.default.removeItem(atPath: metadataFile.path)
-        
+
         let _ = try await hubApi.snapshot(from: lfsRepo, matching: "x.bin") { progress in
             print("Total Progress: \(progress.fractionCompleted)")
             print("Files Completed: \(progress.completedUnitCount) of \(progress.totalUnitCount)")
             lastProgress = progress
         }
-        
+
         attributes = try FileManager.default.attributesOfItem(atPath: filePath.path)
         let secondDownloadTimestamp = attributes[.modificationDate] as! Date
-        
+
         // File will not be downloaded again thus last modified date will remain unchanged
         XCTAssertTrue(originalTimestamp == secondDownloadTimestamp)
         XCTAssertTrue(FileManager.default.fileExists(atPath: metadataDestination.path))
-        
+
         let metadataString = try String(contentsOfFile: metadataFile.path)
         let expected = "77b984598d90af6143d73d5a2d6214b23eba7e27\n98ea6e4f216f2fb4b69fff9b3a44842c38686ca685f3f55dc48c5d3fb1107be4"
-        
+
         XCTAssertTrue(metadataString.contains(expected))
     }
-    
+
     func testLFSFileCorruptedMetadata() async throws {
         let hubApi = HubApi(downloadBase: downloadDestination)
         var lastProgress: Progress? = nil
-        
+
         let downloadedTo = try await hubApi.snapshot(from: lfsRepo, matching: "x.bin") { progress in
             print("Total Progress: \(progress.fractionCompleted)")
             print("Files Completed: \(progress.completedUnitCount) of \(progress.totalUnitCount)")
             lastProgress = progress
         }
-        
+
         XCTAssertEqual(lastProgress?.fractionCompleted, 1)
         XCTAssertEqual(lastProgress?.completedUnitCount, 1)
         XCTAssertEqual(downloadedTo, downloadDestination.appending(path: "models/\(lfsRepo)"))
-        
+
         let downloadedFilenames = getRelativeFiles(url: downloadDestination, repo: lfsRepo)
         XCTAssertEqual(Set(downloadedFilenames), Set(["x.bin"]))
-        
+
         let metadataDestination = downloadedTo.appending(component: ".cache/huggingface/download")
-        
+
         let filePath = downloadedTo.appending(path: "x.bin")
         var attributes = try FileManager.default.attributesOfItem(atPath: filePath.path)
         let originalTimestamp = attributes[.modificationDate] as! Date
-        
+
         let downloadedMetadataFilenames = getRelativeFiles(url: metadataDestination, repo: lfsRepo)
         XCTAssertEqual(
             Set(downloadedMetadataFilenames),
             Set([".cache/huggingface/download/x.bin.metadata"])
         )
-        
+
         let metadataFile = metadataDestination.appendingPathComponent("x.bin.metadata")
         try "a".write(to: metadataFile, atomically: true, encoding: .utf8)
-        
+
         let _ = try await hubApi.snapshot(from: lfsRepo, matching: "x.bin") { progress in
             print("Total Progress: \(progress.fractionCompleted)")
             print("Files Completed: \(progress.completedUnitCount) of \(progress.totalUnitCount)")
             lastProgress = progress
         }
-        
+
         attributes = try FileManager.default.attributesOfItem(atPath: filePath.path)
         let secondDownloadTimestamp = attributes[.modificationDate] as! Date
-        
+
         // File will not be downloaded again thus last modified date will remain unchanged
         XCTAssertTrue(originalTimestamp == secondDownloadTimestamp)
         XCTAssertTrue(FileManager.default.fileExists(atPath: metadataDestination.path))
-        
+
         let metadataString = try String(contentsOfFile: metadataFile.path)
         let expected = "77b984598d90af6143d73d5a2d6214b23eba7e27\n98ea6e4f216f2fb4b69fff9b3a44842c38686ca685f3f55dc48c5d3fb1107be4"
-        
+
         XCTAssertTrue(metadataString.contains(expected))
     }
-    
+
     func testNonLFSFileRedownload() async throws {
         let hubApi = HubApi(downloadBase: downloadDestination)
         var lastProgress: Progress? = nil
-        
+
         let downloadedTo = try await hubApi.snapshot(from: repo, matching: "config.json") { progress in
             print("Total Progress: \(progress.fractionCompleted)")
             print("Files Completed: \(progress.completedUnitCount) of \(progress.totalUnitCount)")
             lastProgress = progress
         }
-        
+
         XCTAssertEqual(lastProgress?.fractionCompleted, 1)
         XCTAssertEqual(lastProgress?.completedUnitCount, 1)
         XCTAssertEqual(downloadedTo, downloadDestination.appending(path: "models/\(repo)"))
-        
+
         let downloadedFilenames = getRelativeFiles(url: downloadDestination, repo: repo)
         XCTAssertEqual(Set(downloadedFilenames), Set(["config.json"]))
-        
+
         let metadataDestination = downloadedTo.appending(component: ".cache/huggingface/download")
-        
+
         let filePath = downloadedTo.appending(path: "config.json")
         var attributes = try FileManager.default.attributesOfItem(atPath: filePath.path)
         let originalTimestamp = attributes[.modificationDate] as! Date
-        
+
         let downloadedMetadataFilenames = getRelativeFiles(url: metadataDestination, repo: repo)
         XCTAssertEqual(
             Set(downloadedMetadataFilenames),
             Set([".cache/huggingface/download/config.json.metadata"])
         )
-        
+
         let metadataFile = metadataDestination.appendingPathComponent("config.json.metadata")
         try FileManager.default.removeItem(atPath: metadataFile.path)
-        
+
         let _ = try await hubApi.snapshot(from: repo, matching: "config.json") { progress in
             print("Total Progress: \(progress.fractionCompleted)")
             print("Files Completed: \(progress.completedUnitCount) of \(progress.totalUnitCount)")
             lastProgress = progress
         }
-        
+
         attributes = try FileManager.default.attributesOfItem(atPath: filePath.path)
         let secondDownloadTimestamp = attributes[.modificationDate] as! Date
-        
+
         // File will be downloaded again thus last modified date will change
         XCTAssertTrue(originalTimestamp != secondDownloadTimestamp)
         XCTAssertTrue(FileManager.default.fileExists(atPath: metadataDestination.path))
-        
+
         let metadataString = try String(contentsOfFile: metadataFile.path)
         let expected = "eaf97358a37d03fd48e5a87d15aff2e8423c1afb\nd6ceb92ce9e3c83ab146dc8e92a93517ac1cc66f"
-        
+
         XCTAssertTrue(metadataString.contains(expected))
     }
-    
+
     func testOfflineModeReturnsDestination() async throws {
         var hubApi = HubApi(downloadBase: downloadDestination)
         var lastProgress: Progress? = nil
-        
+
         var downloadedTo = try await hubApi.snapshot(from: repo, matching: "*.json") { progress in
             print("Total Progress: \(progress.fractionCompleted)")
             print("Files Completed: \(progress.completedUnitCount) of \(progress.totalUnitCount)")
-            
+
             lastProgress = progress
         }
-        
+
         XCTAssertEqual(lastProgress?.fractionCompleted, 1)
         XCTAssertEqual(lastProgress?.completedUnitCount, 6)
         XCTAssertEqual(downloadedTo, downloadDestination.appending(path: "models/\(repo)"))
-        
+
         hubApi = HubApi(downloadBase: downloadDestination, useOfflineMode: true)
-        
+
         downloadedTo = try await hubApi.snapshot(from: repo, matching: "*.json") { progress in
             print("Total Progress: \(progress.fractionCompleted)")
             print("Files Completed: \(progress.completedUnitCount) of \(progress.totalUnitCount)")
             lastProgress = progress
         }
-        
+
         XCTAssertEqual(lastProgress?.fractionCompleted, 1)
         XCTAssertEqual(lastProgress?.completedUnitCount, 6)
         XCTAssertEqual(downloadedTo, downloadDestination.appending(path: "models/\(repo)"))
     }
-    
+
     func testOfflineModeThrowsError() async throws {
         let hubApi = HubApi(downloadBase: downloadDestination, useOfflineMode: true)
-        
+
         do {
             try await hubApi.snapshot(from: repo, matching: "*.json")
             XCTFail("Expected an error to be thrown")
@@ -860,29 +860,29 @@ class SnapshotDownloadTests: XCTestCase {
             XCTFail("Unexpected error: \(error)")
         }
     }
-    
+
     func testOfflineModeWithoutMetadata() async throws {
         var hubApi = HubApi(downloadBase: downloadDestination)
         var lastProgress: Progress? = nil
-        
+
         let downloadedTo = try await hubApi.snapshot(from: lfsRepo, matching: "*") { progress in
             print("Total Progress: \(progress.fractionCompleted)")
             print("Files Completed: \(progress.completedUnitCount) of \(progress.totalUnitCount)")
-            
+
             lastProgress = progress
         }
-        
+
         XCTAssertEqual(lastProgress?.fractionCompleted, 1)
         XCTAssertEqual(lastProgress?.completedUnitCount, 2)
         XCTAssertEqual(downloadedTo, downloadDestination.appending(path: "models/\(lfsRepo)"))
-        
+
         let metadataDestination = downloadedTo.appending(component: ".cache/huggingface/download")
-        
+
         let metadataFile = metadataDestination.appendingPathComponent("x.bin.metadata")
         try FileManager.default.removeItem(atPath: metadataFile.path)
-        
+
         hubApi = HubApi(downloadBase: downloadDestination, useOfflineMode: true)
-        
+
         do {
             try await hubApi.snapshot(from: lfsRepo, matching: "*")
             XCTFail("Expected an error to be thrown")
@@ -897,28 +897,28 @@ class SnapshotDownloadTests: XCTestCase {
             XCTFail("Unexpected error: \(error)")
         }
     }
-    
+
     func testOfflineModeWithCorruptedLFSMetadata() async throws {
         var hubApi = HubApi(downloadBase: downloadDestination)
         var lastProgress: Progress? = nil
-        
+
         let downloadedTo = try await hubApi.snapshot(from: lfsRepo, matching: "*") { progress in
             print("Total Progress: \(progress.fractionCompleted)")
             print("Files Completed: \(progress.completedUnitCount) of \(progress.totalUnitCount)")
-            
+
             lastProgress = progress
         }
-        
+
         XCTAssertEqual(lastProgress?.fractionCompleted, 1)
         XCTAssertEqual(lastProgress?.completedUnitCount, 2)
         XCTAssertEqual(downloadedTo, downloadDestination.appending(path: "models/\(lfsRepo)"))
-        
+
         let metadataDestination = downloadedTo.appendingPathComponent(".cache/huggingface/download").appendingPathComponent("x.bin.metadata")
-        
+
         try "77b984598d90af6143d73d5a2d6214b23eba7e27\n98ea6e4f216f2ab4b69fff9b3a44842c38686ca685f3f55dc48c5d3fb1107be4\n0\n".write(to: metadataDestination, atomically: true, encoding: .utf8)
-        
+
         hubApi = HubApi(downloadBase: downloadDestination, useOfflineMode: true)
-        
+
         do {
             try await hubApi.snapshot(from: lfsRepo, matching: "*")
             XCTFail("Expected an error to be thrown")
@@ -933,27 +933,27 @@ class SnapshotDownloadTests: XCTestCase {
             XCTFail("Unexpected error: \(error)")
         }
     }
-    
+
     func testOfflineModeWithNoFiles() async throws {
         var hubApi = HubApi(downloadBase: downloadDestination)
         var lastProgress: Progress? = nil
-        
+
         let downloadedTo = try await hubApi.snapshot(from: lfsRepo, matching: "x.bin") { progress in
             print("Total Progress: \(progress.fractionCompleted)")
             print("Files Completed: \(progress.completedUnitCount) of \(progress.totalUnitCount)")
-            
+
             lastProgress = progress
         }
-        
+
         XCTAssertEqual(lastProgress?.fractionCompleted, 1)
         XCTAssertEqual(lastProgress?.completedUnitCount, 1)
         XCTAssertEqual(downloadedTo, downloadDestination.appending(path: "models/\(lfsRepo)"))
-        
+
         let fileDestination = downloadedTo.appendingPathComponent("x.bin")
         try FileManager.default.removeItem(at: fileDestination)
-        
+
         hubApi = HubApi(downloadBase: downloadDestination, useOfflineMode: true)
-        
+
         do {
             try await hubApi.snapshot(from: lfsRepo, matching: "x.bin")
             XCTFail("Expected an error to be thrown")
@@ -968,17 +968,17 @@ class SnapshotDownloadTests: XCTestCase {
             XCTFail("Unexpected error: \(error)")
         }
     }
-    
+
     func testResumeDownloadFromEmptyIncomplete() async throws {
         let hubApi = HubApi(downloadBase: downloadDestination)
         var lastProgress: Progress? = nil
         var downloadedTo = FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent("Library/Caches/huggingface-tests/models/coreml-projects/Llama-2-7b-chat-coreml")
-        
+
         let metadataDestination = downloadedTo.appending(component: ".cache/huggingface/download")
-        
+
         let url = URL(string: "https://huggingface.co/coreml-projects/Llama-2-7b-chat-coreml/resolve/main/config.json")!
         let etag = try await Hub.getFileMetadata(fileURL: url).etag!
-        
+
         try FileManager.default.createDirectory(at: metadataDestination, withIntermediateDirectories: true, attributes: nil)
         try "".write(to: metadataDestination.appendingPathComponent("config.json.\(etag).incomplete"), atomically: true, encoding: .utf8)
         downloadedTo = try await hubApi.snapshot(from: repo, matching: "config.json") { progress in
@@ -991,7 +991,7 @@ class SnapshotDownloadTests: XCTestCase {
         XCTAssertEqual(downloadedTo, downloadDestination.appending(path: "models/\(repo)"))
 
         let fileContents = try String(contentsOfFile: downloadedTo.appendingPathComponent("config.json").path)
-                
+
         let expected = """
         {
           "architectures": [
@@ -1006,18 +1006,18 @@ class SnapshotDownloadTests: XCTestCase {
         """
         XCTAssertTrue(fileContents.contains(expected))
     }
-    
+
     func testResumeDownloadFromNonEmptyIncomplete() async throws {
         let hubApi = HubApi(downloadBase: downloadDestination)
         var lastProgress: Progress? = nil
         var downloadedTo = FileManager.default.homeDirectoryForCurrentUser
             .appendingPathComponent("Library/Caches/huggingface-tests/models/coreml-projects/Llama-2-7b-chat-coreml")
-        
+
         let metadataDestination = downloadedTo.appending(component: ".cache/huggingface/download")
-        
+
         let url = URL(string: "https://huggingface.co/coreml-projects/Llama-2-7b-chat-coreml/resolve/main/config.json")!
         let etag = try await Hub.getFileMetadata(fileURL: url).etag!
-        
+
         try FileManager.default.createDirectory(at: metadataDestination, withIntermediateDirectories: true, attributes: nil)
         try "X".write(to: metadataDestination.appendingPathComponent("config.json.\(etag).incomplete"), atomically: true, encoding: .utf8)
         downloadedTo = try await hubApi.snapshot(from: repo, matching: "config.json") { progress in
@@ -1028,9 +1028,9 @@ class SnapshotDownloadTests: XCTestCase {
         XCTAssertEqual(lastProgress?.fractionCompleted, 1)
         XCTAssertEqual(lastProgress?.completedUnitCount, 1)
         XCTAssertEqual(downloadedTo, downloadDestination.appending(path: "models/\(repo)"))
-        
+
         let fileContents = try String(contentsOfFile: downloadedTo.appendingPathComponent("config.json").path)
-        
+
         let expected = """
         X
           "architectures": [
@@ -1045,16 +1045,16 @@ class SnapshotDownloadTests: XCTestCase {
         """
         XCTAssertTrue(fileContents.contains(expected))
     }
-    
+
     func testRealDownloadInterruptionAndResumption() async throws {
         // Use the DepthPro model weights file
         let targetFile = "SAM 2 Studio 1.1.zip"
         let repo = "coreml-projects/sam-2-studio"
         let hubApi = HubApi(downloadBase: downloadDestination)
-        
+
         // Create expectation for first progress update
         let progressExpectation = expectation(description: "First progress update received")
-        
+
         // Create a task for the download
         let downloadTask = Task {
             try await hubApi.snapshot(from: repo, matching: targetFile) { progress in
@@ -1064,19 +1064,19 @@ class SnapshotDownloadTests: XCTestCase {
                 }
             }
         }
-        
+
         // Wait for the first progress update
         await fulfillment(of: [progressExpectation], timeout: 30.0)
-        
+
         // Cancel the download once we've seen progress
         downloadTask.cancel()
         try await Task.sleep(nanoseconds: 5_000_000_000)
-        
+
         // Resume download with a new task
         let downloadedTo = try await hubApi.snapshot(from: repo, matching: targetFile) { progress in
             print("Progress reached 2 \(progress.fractionCompleted * 100)%")
         }
-        
+
         let filePath = downloadedTo.appendingPathComponent(targetFile)
         XCTAssertTrue(FileManager.default.fileExists(atPath: filePath.path),
                       "Downloaded file should exist at \(filePath.path)")

--- a/Tests/HubTests/HubTests.swift
+++ b/Tests/HubTests/HubTests.swift
@@ -29,28 +29,28 @@ class HubTests: XCTestCase {
         do {
             let configLoader = LanguageModelConfigurationFromHub(modelName: "t5-base", hubApi: hubApi)
             let config = try await configLoader.modelConfig
-            
+
             // Test leaf value (Int)
             guard let eos = config.eos_token_id?.intValue else {
                 XCTFail("nil leaf value (Int)")
                 return
             }
             XCTAssertEqual(eos, 1)
-            
+
             // Test leaf value (String)
             guard let modelType = config.model_type?.stringValue else {
                 XCTFail("nil leaf value (String)")
                 return
             }
             XCTAssertEqual(modelType, "t5")
-            
+
             // Test leaf value (Array)
             guard let architectures = config.architectures?.value as? [String] else {
                 XCTFail("nil array")
                 return
             }
             XCTAssertEqual(architectures, ["T5ForConditionalGeneration"])
-            
+
             // Test nested wrapper
             guard let taskParams = config.task_specific_params else {
                 XCTFail("nil nested wrapper")
@@ -67,7 +67,7 @@ class HubTests: XCTestCase {
             XCTFail("Cannot download test configuration from the Hub: \(error)")
         }
     }
-    
+
     func testConfigCamelCase() async {
         do {
             let configLoader = LanguageModelConfigurationFromHub(modelName: "t5-base", hubApi: hubApi)
@@ -79,14 +79,14 @@ class HubTests: XCTestCase {
                 return
             }
             XCTAssertEqual(eos, 1)
-            
+
             // Test leaf value (String)
             guard let modelType = config.modelType?.stringValue else {
                 XCTFail("nil leaf value (String)")
                 return
             }
             XCTAssertEqual(modelType, "t5")
-                        
+
             guard let summarizationMaxLength = config.taskSpecificParams?.summarization?.maxLength?.intValue else {
                 XCTFail("cannot traverse nested containers")
                 return

--- a/Tests/PreTokenizerTests/PreTokenizerTests.swift
+++ b/Tests/PreTokenizerTests/PreTokenizerTests.swift
@@ -150,7 +150,7 @@ class PreTokenizerTests: XCTestCase {
             ["Hey", " friend", "!", "    ", " How", " are", " you", "?!?"]
         )
     }
-    
+
     /// https://github.com/huggingface/tokenizers/pull/1357
     func testMetaspacePreTokenizer() {
         // Prepend "always"
@@ -159,7 +159,7 @@ class PreTokenizerTests: XCTestCase {
             "replacement": "▁",
             "prepend_scheme": "always",
         ]))
-        
+
         // TODO: different sections on <s>
         let text = "Hey my friend <s>how▁are you"
         let tokens = text

--- a/Tests/TensorUtilsTests/LogitsWarperTests.swift
+++ b/Tests/TensorUtilsTests/LogitsWarperTests.swift
@@ -99,11 +99,11 @@ final class LogitsWarperTests: XCTestCase {
         XCTAssertEqual(result2.indices, indices)
         let logits2 = indices.map { Float($0) / 3.75 }
         XCTAssertEqual(result2.logits, logits2, accuracy: accuracy)
-        
+
         let result3 = RepetitionPenaltyWarper(penalty: 0.75)([0, 1, 2], [0.8108, 0.9954, 0.0119])
         XCTAssertEqual(result3.indices, [0, 1, 2])
         XCTAssertEqual(result3.logits, [1.0811, 1.3272, 0.0158], accuracy: 1e-4)
-        
+
         let result4 = RepetitionPenaltyWarper(penalty: 1.11)([2, 3, 4], [0.5029, 0.8694, 0.4765, 0.9967, 0.4190, 0.9158])
         XCTAssertEqual(result4.indices, [2, 3, 4])
         XCTAssertEqual(result4.logits, [0.5029, 0.8694, 0.4293, 0.8980, 0.3775, 0.9158], accuracy: 1e-4)
@@ -111,7 +111,7 @@ final class LogitsWarperTests: XCTestCase {
         let result5 = RepetitionPenaltyWarper(penalty: 0.9)([0, 1, 2], [-0.7433, -0.4738, -0.2966])
         XCTAssertEqual(result5.indices, [0, 1, 2])
         XCTAssertEqual(result5.logits, [-0.6690, -0.4264, -0.2669], accuracy: 1e-4)
-        
+
         let result6 = RepetitionPenaltyWarper(penalty: 1.125)([3, 1, 2], [0.1674, 0.6431, 0.6780, 0.2755])
         XCTAssertEqual(result6.indices, [3, 1, 2])
         XCTAssertEqual(result6.logits, [0.1674, 0.5716, 0.6026, 0.2449], accuracy: 1e-4)

--- a/Tests/TensorUtilsTests/TensorUtilsTests.swift
+++ b/Tests/TensorUtilsTests/TensorUtilsTests.swift
@@ -45,7 +45,7 @@ final class TensorUtilsTests: XCTestCase {
 
     func testSoftmax() {
         XCTAssertEqual(Math.softmax([]), [])
-        
+
         let result1 = Math.softmax([3.0, 4.0, 1.0, 2.0])
         XCTAssertEqual(result1, [0.23688284, 0.6439143, 0.032058604, 0.08714432], accuracy: accuracy)
         XCTAssertEqual(result1.reduce(0, +), 1.0, accuracy: accuracy)

--- a/Tests/TokenizersTests/BertTokenizerTests.swift
+++ b/Tests/TokenizersTests/BertTokenizerTests.swift
@@ -18,7 +18,7 @@ class BertTokenizerTests: XCTestCase {
     override func tearDown() {
         // Put teardown code here. This method is called after the invocation of each test method in the class.
     }
-    
+
     lazy var bertTokenizer: BertTokenizer = {
         let vocab = {
             let url = Bundle.module.url(forResource: "bert-vocab", withExtension: "txt")!
@@ -30,93 +30,93 @@ class BertTokenizerTests: XCTestCase {
             }
             return vocab
         }()
-        
+
         return BertTokenizer(vocab: vocab, merges: nil)
     }()
 
     func testBasicTokenizer() {
         let basicTokenizer = BasicTokenizer()
-        
+
         let text = "Brave gaillard, d'où [UNK] êtes vous?"
         let tokens = ["brave", "gaillard", ",", "d", "\'", "ou", "[UNK]", "etes", "vous", "?"]
-        
+
         XCTAssertEqual(
             basicTokenizer.tokenize(text: text), tokens
         )
         // Verify that `XCTAssertEqual` does what deep equality checks on arrays of strings.
         XCTAssertEqual(["foo", "bar"], ["foo", "bar"])
     }
-    
+
     /// For each Squad question tokenized by python, check that we get the same output through the `BasicTokenizer`
     func testFullBasicTokenizer() {
         let url = Bundle.module.url(forResource: "basic_tokenized_questions", withExtension: "json")!
         let json = try! Data(contentsOf: url)
         let decoder = JSONDecoder()
         let sampleTokens = try! decoder.decode([[String]].self, from: json)
-        
+
         let basicTokenizer = BasicTokenizer()
-        
+
         XCTAssertEqual(sampleTokens.count, Squad.examples.count)
-        
+
         for (i, example) in Squad.examples.enumerated() {
             let output = basicTokenizer.tokenize(text: example.question)
             XCTAssertEqual(output, sampleTokens[i])
         }
     }
-    
+
     /// For each Squad question tokenized by python, check that we get the same output through the whole `BertTokenizer`
     func testFullBertTokenizer() {
         let url = Bundle.module.url(forResource: "tokenized_questions", withExtension: "json")!
         let json = try! Data(contentsOf: url)
         let decoder = JSONDecoder()
         let sampleTokens = try! decoder.decode([[Int]].self, from: json)
-        
+
         let tokenizer = bertTokenizer
-        
+
         XCTAssertEqual(sampleTokens.count, Squad.examples.count)
-        
+
         for (i, example) in Squad.examples.enumerated() {
             let output = tokenizer.tokenizeToIds(text: example.question)
             XCTAssertEqual(output, sampleTokens[i])
         }
     }
-    
+
     func testMixedChineseEnglishTokenization() {
         let tokenizer = bertTokenizer
         let text = "你好，世界！Hello, world!"
         let expectedTokens = ["[UNK]", "[UNK]", "，", "世", "[UNK]", "！", "hello", ",", "world", "!"]
         let tokens = tokenizer.tokenize(text: text)
-        
+
         XCTAssertEqual(tokens, expectedTokens)
     }
-    
+
     func testPureChineseTokenization() {
         let tokenizer = bertTokenizer
         let text = "明日，大家上山看日出。"
         let expectedTokens = ["明", "日", "，", "大", "家", "上", "山", "[UNK]", "日", "出", "。"]
         let tokens = tokenizer.tokenize(text: text)
-        
+
         XCTAssertEqual(tokens, expectedTokens)
     }
-    
+
     func testChineseWithNumeralsTokenization() {
         let tokenizer = bertTokenizer
         let text = "2020年奥运会在东京举行。"
         let expectedTokens = ["2020", "年", "[UNK]", "[UNK]", "会", "[UNK]", "[UNK]", "京", "[UNK]", "行", "。"]
         let tokens = tokenizer.tokenize(text: text)
-        
+
         XCTAssertEqual(tokens, expectedTokens)
     }
-    
+
     func testChineseWithSpecialTokens() {
         let tokenizer = bertTokenizer
         let text = "[CLS] 机器学习是未来。 [SEP]"
         let expectedTokens = ["[CLS]", "[UNK]", "[UNK]", "学", "[UNK]", "[UNK]", "[UNK]", "[UNK]", "。", "[SEP]"]
         let tokens = tokenizer.tokenize(text: text)
-        
+
         XCTAssertEqual(tokens, expectedTokens)
     }
-    
+
     func testPerformanceExample() {
         let tokenizer = bertTokenizer
 
@@ -126,25 +126,25 @@ class BertTokenizerTests: XCTestCase {
             _ = tokenizer.tokenizeToIds(text: "Brave gaillard, d'où [UNK] êtes vous?")
         }
     }
-    
+
     func testWordpieceDetokenizer() {
         struct QuestionTokens: Codable {
             let original: String
             let basic: [String]
             let wordpiece: [String]
         }
-        
+
         let url = Bundle.module.url(forResource: "question_tokens", withExtension: "json")!
         let json = try! Data(contentsOf: url)
         let decoder = JSONDecoder()
         let questionTokens = try! decoder.decode([QuestionTokens].self, from: json)
         let tokenizer = bertTokenizer
-        
+
         for question in questionTokens {
             XCTAssertEqual(question.basic.joined(separator: " "), tokenizer.convertWordpieceToBasicTokenList(question.wordpiece))
         }
     }
-    
+
     func testEncoderDecoder() {
         let text = """
         Wake up (Wake up)
@@ -156,7 +156,7 @@ class BertTokenizerTests: XCTestCase {
         Hide the scars to fade away the shakeup, you wanted to
         Why'd you leave the keys upon the table? You wanted to
         """
-        
+
         // Not sure if there's a way to achieve a non-destructive round-trip
         let decoded = """
         wake up ( wake up )
@@ -168,7 +168,7 @@ class BertTokenizerTests: XCTestCase {
         hide the scars to fade away the shakeup , you wanted to
         why \' d you leave the keys upon the table ? you wanted to
         """
-        
+
         let tokenizer = bertTokenizer
         for (line, expected) in zip(text.split(separator: "\n"), decoded.split(separator: "\n")) {
             let encoded = tokenizer.encode(text: String(line))

--- a/Tests/TokenizersTests/DecoderTests.swift
+++ b/Tests/TokenizersTests/DecoderTests.swift
@@ -15,7 +15,7 @@ class DecoderTests: XCTestCase {
             "add_prefix_space": true,
             "replacement": "▁",
         ]))
-        
+
         let tokens = ["▁Hey", "▁my", "▁friend", "▁", "▁<s>", "▁how", "▁are", "▁you"]
         let decoded = decoder.decode(tokens: tokens)
 
@@ -24,7 +24,7 @@ class DecoderTests: XCTestCase {
             ["Hey", " my", " friend", " ", " <s>", " how", " are", " you"]
         )
     }
-    
+
     func testWordPieceDecoder() {
         let config = Config(["prefix": "##", "cleanup": true])
         let decoder = WordPieceDecoder(config: config)

--- a/Tests/TokenizersTests/FactoryTests.swift
+++ b/Tests/TokenizersTests/FactoryTests.swift
@@ -36,28 +36,28 @@ class FactoryTests: TestWithCustomHubDownloadLocation {
         let inputIds = tokenizer("Today she took a train to the West")
         XCTAssertEqual(inputIds, [1, 20628, 1183, 3614, 263, 7945, 304, 278, 3122])
     }
-    
+
     func testWhisper() async throws {
         let tokenizer = try await AutoTokenizer.from(pretrained: "openai/whisper-large-v2", hubApi: hubApi)
         let inputIds = tokenizer("Today she took a train to the West")
         XCTAssertEqual(inputIds, [50258, 50363, 27676, 750, 1890, 257, 3847, 281, 264, 4055, 50257])
     }
-    
+
     func testFromModelFolder() async throws {
         let filesToDownload = ["config.json", "tokenizer_config.json", "tokenizer.json"]
         let repo = Hub.Repo(id: "coreml-projects/Llama-2-7b-chat-coreml")
         let localModelFolder = try await hubApi.snapshot(from: repo, matching: filesToDownload)
-        
+
         let tokenizer = try await AutoTokenizer.from(modelFolder: localModelFolder, hubApi: hubApi)
         let inputIds = tokenizer("Today she took a train to the West")
         XCTAssertEqual(inputIds, [1, 20628, 1183, 3614, 263, 7945, 304, 278, 3122])
     }
-    
+
     func testWhisperFromModelFolder() async throws {
         let filesToDownload = ["config.json", "tokenizer_config.json", "tokenizer.json"]
         let repo = Hub.Repo(id: "openai/whisper-large-v2")
         let localModelFolder = try await hubApi.snapshot(from: repo, matching: filesToDownload)
-        
+
         let tokenizer = try await AutoTokenizer.from(modelFolder: localModelFolder, hubApi: hubApi)
         let inputIds = tokenizer("Today she took a train to the West")
         XCTAssertEqual(inputIds, [50258, 50363, 27676, 750, 1890, 257, 3847, 281, 264, 4055, 50257])

--- a/Tests/TokenizersTests/SplitTests.swift
+++ b/Tests/TokenizersTests/SplitTests.swift
@@ -14,56 +14,56 @@ class SplitTests: XCTestCase {
             "the-final--countdown".split(by: "-", options: .caseInsensitive, behavior: .mergedWithPrevious),
             ["the-", "final-", "-", "countdown"]
         )
-        
+
         XCTAssertEqual(
             "the-final--countdown-".split(by: "-", options: .caseInsensitive, behavior: .mergedWithPrevious),
             ["the-", "final-", "-", "countdown-"]
         )
-        
+
         XCTAssertEqual(
             "the-final--countdown--".split(by: "-", options: .caseInsensitive, behavior: .mergedWithPrevious),
             ["the-", "final-", "-", "countdown-", "-"]
         )
-        
+
         XCTAssertEqual(
             "-the-final--countdown--".split(by: "-", options: .caseInsensitive, behavior: .mergedWithPrevious),
             ["-", "the-", "final-", "-", "countdown-", "-"]
         )
-        
+
         XCTAssertEqual(
             "--the-final--countdown--".split(by: "-", options: .caseInsensitive, behavior: .mergedWithPrevious),
             ["-", "-", "the-", "final-", "-", "countdown-", "-"]
         )
     }
-    
+
     func testSplitBehaviorMergedWithNext() {
         XCTAssertEqual(
             "the-final--countdown".split(by: "-", options: .caseInsensitive, behavior: .mergedWithNext),
             ["the", "-final", "-", "-countdown"]
         )
-        
+
         XCTAssertEqual(
             "-the-final--countdown".split(by: "-", options: .caseInsensitive, behavior: .mergedWithNext),
             ["-the", "-final", "-", "-countdown"]
         )
-        
+
         XCTAssertEqual(
             "--the-final--countdown".split(by: "-", options: .caseInsensitive, behavior: .mergedWithNext),
             ["-", "-the", "-final", "-", "-countdown"]
         )
-        
+
         XCTAssertEqual(
             "--the-final--countdown-".split(by: "-", options: .caseInsensitive, behavior: .mergedWithNext),
             ["-", "-the", "-final", "-", "-countdown", "-"]
         )
     }
-    
+
     func testSplitBehaviorOther() {
         XCTAssertEqual(
             "the-final--countdown".split(by: "-", options: .caseInsensitive, behavior: .isolated),
             ["the", "-", "final", "-", "-", "countdown"]
         )
-        
+
         XCTAssertEqual(
             "the-final--countdown".split(by: "-", options: .caseInsensitive, behavior: .removed),
             ["the", "final", "countdown"]

--- a/Tests/TokenizersTests/SquadDataset.swift
+++ b/Tests/TokenizersTests/SquadDataset.swift
@@ -52,7 +52,7 @@ struct Squad {
         let json = try! Data(contentsOf: url)
         let decoder = JSONDecoder()
         let squadDataset = try! decoder.decode(SquadDataset.self, from: json)
-        
+
         var examples: [SquadExample] = []
         for datum in squadDataset.data {
             for paragraph in datum.paragraphs {

--- a/Tests/TokenizersTests/TrieTests.swift
+++ b/Tests/TokenizersTests/TrieTests.swift
@@ -16,23 +16,23 @@ class TrieTests: XCTestCase {
         trie.insert("carp")
         trie.insert("car")
         XCTAssertEqual(trie.root.children.count, 1)
-        
+
         let c = trie.get("c")
         XCTAssertNotNil(c)
         XCTAssertEqual(c!.children.count, 1) // "a"
-        
+
         let ca = trie.get("ca")
         XCTAssertNotNil(ca)
         XCTAssertEqual(ca!.children.count, 2) // "r", "t"
-        
+
         let car = trie.get("car")
         XCTAssertNotNil(car)
         XCTAssertTrue(car!.isLeaf)
         XCTAssertFalse(ca!.isLeaf)
-        
+
         XCTAssertNil(trie.get("card"))
     }
-    
+
     func testTrieCommonPrefixSearch() {
         // https://guillaume-be.github.io/2020-05-30/sentence_piece
         let trie = Trie<Character>()
@@ -44,7 +44,7 @@ class TrieTests: XCTestCase {
         let leaves = trie.commonPrefixSearch("carpooling").map { String($0) }
         XCTAssertEqual(leaves, ["car", "carp"])
     }
-    
+
     func testTrieCommonPrefixSearchIterator() {
         // https://guillaume-be.github.io/2020-05-30/sentence_piece
         let trie = Trie<Character>()


### PR DESCRIPTION
A bunch of extra whitespace on empty lines was added in the last commit. This fixes the issue throughout the repo by using `--trimwhitespace always` instead of `--trimwhitespace nonblank-lines`.