### PR TITLE
Add some backwards-compatible getters

### DIFF
--- a/Sources/Hub/Config.swift
+++ b/Sources/Hub/Config.swift
@@ -616,6 +616,24 @@ public struct Config: Hashable, Sendable,
     }
 }
 
+// Old style, deprecated getters
+extension Config {
+    @available(*, deprecated, message: "Use string() instead")
+    public var stringValue: String? { string() }
+
+    @available(*, deprecated, message: "Use integer() instead")
+    public var intValue: Int? { integer() }
+
+    @available(*, deprecated, message: "Use boolean() instead")
+    public var boolValue: Bool? { boolean() }
+
+    @available(*, deprecated, message: "Use array() instead")
+    public var arrayValue: [Config]? { array() }
+
+    @available(*, deprecated, message: "Use token() instead")
+    public var tokenValue: (UInt, String)? { token() }
+}
+
 extension Config: Codable {
     public init(from decoder: any Decoder) throws {
         // Try decoding as a single value first (for scalars and null)


### PR DESCRIPTION
Unfortunately, we can't provide a `dictionary` var because the symbol has been replaced with `dictionary()` now :(

Even so, I think this could be useful for many downstream users, I don't think the use of `dictionary` is too frequent.

What are your thoughts @FL33TW00D, @DePasqualeOrg?