### PR TITLE
updating Jinja to 1.2.0 as it correctly supports Granite model template

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-argument-parser.git", .upToNextMinor(from: "1.4.0")),
-        .package(url: "https://github.com/johnmai-dev/Jinja", .upToNextMinor(from: "1.1.0")),
+        .package(url: "https://github.com/johnmai-dev/Jinja", .upToNextMinor(from: "1.2.0")),
     ],
     targets: [
         .executableTarget(


### PR DESCRIPTION
Updating the version to correctly handle Granite model templates. 
