### PR TITLE
Update HubApi tests to account for resolve-cache URLs

### DIFF
--- a/Tests/HubTests/HubApiTests.swift
+++ b/Tests/HubTests/HubApiTests.swift
@@ -95,7 +95,7 @@ class HubApiTests: XCTestCase {
 
             XCTAssertNotNil(metadata.commitHash)
             XCTAssertNotNil(metadata.etag)
-            XCTAssertEqual(metadata.location, url?.absoluteString)
+            XCTAssertEqual(URL(string: metadata.location)?.path, "/api/resolve-cache/models\(url!.path.replacingOccurrences(of: "resolve/main", with: metadata.commitHash!))")
             XCTAssertEqual(metadata.size, 163)
         } catch {
             XCTFail("\(error)")
@@ -109,7 +109,7 @@ class HubApiTests: XCTestCase {
 
             XCTAssertNotNil(metadata.commitHash)
             XCTAssertTrue(metadata.etag != nil && metadata.etag!.hasPrefix("d6ceb9"))
-            XCTAssertEqual(metadata.location, url?.absoluteString)
+            XCTAssertEqual(URL(string: metadata.location)?.path, "/api/resolve-cache/models\(url!.path.replacingOccurrences(of: "resolve/main", with: metadata.commitHash!))")
             XCTAssertEqual(metadata.size, 163)
         } catch {
             XCTFail("\(error)")
@@ -125,7 +125,7 @@ class HubApiTests: XCTestCase {
             XCTAssertEqual(metadata.commitHash, revision)
             XCTAssertNotNil(metadata.etag)
             XCTAssertGreaterThan(metadata.etag!.count, 0)
-//            XCTAssertEqual(metadata.location, url?.absoluteString) // TODO: does not pass on main, is it even relevant?
+            XCTAssertEqual(URL(string: metadata.location)?.path, "/api/resolve-cache/models\(url!.path.replacingOccurrences(of: "resolve/\(revision)", with: metadata.commitHash!))")
             XCTAssertEqual(metadata.size, 851)
         } catch {
             XCTFail("\(error)")
@@ -134,13 +134,11 @@ class HubApiTests: XCTestCase {
 
     func testGetFileMetadataWithBlobSearch() async throws {
         let repo = "coreml-projects/Llama-2-7b-chat-coreml"
-        let metadataFromBlob = try await Hub.getFileMetadata(from: repo, matching: "*.json").sorted { $0.location < $1.location }
-        let files = try await Hub.getFilenames(from: repo, matching: "*.json").sorted()
-        for (metadata, file) in zip(metadataFromBlob, files) {
+        let metadataFromBlob = try await Hub.getFileMetadata(from: repo, matching: "*.json")
+        for metadata in metadataFromBlob {
             XCTAssertNotNil(metadata.commitHash)
             XCTAssertNotNil(metadata.etag)
             XCTAssertGreaterThan(metadata.etag!.count, 0)
-            XCTAssertTrue(metadata.location.contains(file))
             XCTAssertGreaterThan(metadata.size!, 0)
         }
     }


### PR DESCRIPTION
The api endpoints may now return a `resolve-cache` URL:

```bash
curl -I "https://huggingface.co/enterprise-explorers/Llama-2-7b-chat-coreml/resolve/main/config.json"
```

```
...
location: /api/resolve-cache/models/enterprise-explorers/Llama-2-7b-chat-coreml/eaf97358a37d03fd48e5a87d15aff2e8423c1afb/config.json?%2Fenterprise-explorers%2FLlama-2-7b-chat-coreml%2Fresolve%2Fmain%2Fconfig.json=&etag=%22d6ceb92ce9e3c83ab146dc8e92a93517ac1cc66f%22
...
```