### PR TITLE
Add VSCode settings and recommended extensions

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,6 @@
+{
+    "recommendations": [
+        "swiftlang.swift-vscode",
+        "vknabel.vscode-swiftformat"
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,38 @@
+{
+    // SwiftFormat configuration to match CI
+    "swiftformat.configSearchPaths": [
+        ".swiftformat"
+    ],
+    // Swift language settings
+    "swift.path": "/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin",
+    "swift.buildPath": ".build",
+    // Editor settings for Swift development
+    "editor.tabSize": 4,
+    "editor.insertSpaces": true,
+    "editor.detectIndentation": false,
+    "editor.rulers": [],
+    "editor.wordWrap": "off",
+    "editor.trimAutoWhitespace": true,
+    // File associations
+    "files.associations": {
+        "*.swift": "swift"
+    },
+    // Format on save for Swift files
+    "[swift]": {
+        "editor.formatOnSave": true,
+        "editor.defaultFormatter": "vknabel.vscode-swiftformat"
+    },
+    // Exclude build artifacts from search
+    "search.exclude": {
+        "**/.build": true,
+        "**/Package.resolved": true
+    },
+    // Files to exclude from file watching
+    "files.watcherExclude": {
+        "**/.build/**": true,
+        "**/Package.resolved": true
+    },
+    "swift.swiftEnvironmentVariables": {
+        "DEVELOPER_DIR": "/Applications/Xcode.app"
+    }
+}


### PR DESCRIPTION
In working on #168, I found that my editor's configured format-on-save behavior was causing churn and [CI failures](https://github.com/huggingface/swift-transformers/actions/runs/17126880235/job/48580616211?pr=168#step:4:528) (sorry about that!)

This PR adds a `.vscode` directory to configure VSCode (plus derivatives like Cursor) to do the following:

- Recommend the installation of the [official Swift extension (`swiftlang.swift-vscode`)](https://marketplace.visualstudio.com/items?itemName=swiftlang.swift-vscode) and [`vknabel.vscode-swiftformat`](https://marketplace.visualstudio.com/items?itemName=vknabel.vscode-swiftformat)
- Configures format-on-save using SwiftFormat using the project's `.swiftformat` file

These settings should reduce the number of failed CI jobs due to formatting issues, and provide a nice baseline experience for developers using VSCode, et al.