### PR TITLE
Invoke `swiftformat` via Swift Package Manager plugin 

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -5,9 +5,6 @@ on:
       - '**.swift'
   workflow_dispatch:
 
-env:
-  SWIFTFORMAT_VERSION: "0.54.6"
-
 jobs:
   swift-format:
     name: Check Swift Formatting
@@ -15,44 +12,15 @@ jobs:
     
     steps:
       - uses: actions/checkout@v4
-      
-      - name: Install SwiftFormat
-        run: |
-          curl -L https://github.com/nicklockwood/SwiftFormat/releases/download/${{ env.SWIFTFORMAT_VERSION }}/swiftformat.zip -o swiftformat.zip
-          unzip swiftformat.zip
-          sudo mv swiftformat /usr/local/bin/
-          chmod +x /usr/local/bin/swiftformat
-          swiftformat --version
         
       - name: Check formatting
-        run: |
-          found_issues=false
-          files_with_issues=()
-          
-          while IFS= read -r file; do
-            if ! swiftformat --config .swiftformat --lint "$file"; then
-              found_issues=true
-              files_with_issues+=("$file")
-              echo "❌ Formatting issues found in: $file"
-            fi
-          done < <(find . -name "*.swift" -type f)
-          
-          if [ "$found_issues" = true ]; then
-            echo "❌ The following files need formatting:"
-            printf '%s\n' "${files_with_issues[@]}"
-            exit 1
-          else
-            echo "✅ All Swift files are properly formatted!"
-          fi
+        run: swift package plugin --allow-writing-to-package-directory swiftformat --lint --config .swiftformat .
 
       - name: Suggest fixes (if check fails)
         if: failure()
         run: |
           echo "### Here's how to fix the formatting locally:" >> $GITHUB_STEP_SUMMARY
           echo '```bash' >> $GITHUB_STEP_SUMMARY
-          echo "# Install SwiftFormat version ${{ env.SWIFTFORMAT_VERSION }}" >> $GITHUB_STEP_SUMMARY
-          echo "brew install swiftformat@${{ env.SWIFTFORMAT_VERSION }}" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "# Format all Swift files" >> $GITHUB_STEP_SUMMARY
-          echo 'swiftformat --config .swiftformat .' >> $GITHUB_STEP_SUMMARY
+          echo "# Format all Swift files using SPM plugin" >> $GITHUB_STEP_SUMMARY
+          echo 'swift package plugin --allow-writing-to-package-directory swiftformat --config .swiftformat .' >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY

--- a/Package.swift
+++ b/Package.swift
@@ -19,6 +19,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/apple/swift-argument-parser.git", .upToNextMinor(from: "1.4.0")),
         .package(url: "https://github.com/johnmai-dev/Jinja", .upToNextMinor(from: "1.2.1")),
+        .package(url: "https://github.com/nicklockwood/SwiftFormat", from: "0.54.0"),
     ],
     targets: [
         .executableTarget(

--- a/Package.swift
+++ b/Package.swift
@@ -19,7 +19,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/apple/swift-argument-parser.git", .upToNextMinor(from: "1.4.0")),
         .package(url: "https://github.com/johnmai-dev/Jinja", .upToNextMinor(from: "1.2.1")),
-        .package(url: "https://github.com/nicklockwood/SwiftFormat", from: "0.54.0"),
+        .package(url: "https://github.com/nicklockwood/SwiftFormat", from: "0.57.0"),
     ],
     targets: [
         .executableTarget(


### PR DESCRIPTION
The [`format` workflow](https://github.com/huggingface/swift-transformers/blob/ed54f3c9589d6cdc6fc2bb810e4809b0735fee01/.github/workflows/format.yml) currently defines the current SwiftFormat version as an environment variable:

https://github.com/huggingface/swift-transformers/blob/ed54f3c9589d6cdc6fc2bb810e4809b0735fee01/.github/workflows/format.yml#L8-L9

As we see in #223, defining a constant here creates drift over time. 

This PR proposes to declare SwiftFormat as a package dependency and call it as a [Swift Package Manager plugin](https://docs.swift.org/swiftpm/documentation/packagemanagerdocs/plugins). This approach defines a single source of truth for managing the development dependency, and provide developers and CI a unified way to apply and lint project standards.

**Before**

```bash
brew install swiftformat # or curl && unzip && etc.
swiftformat --config .swiftformat .
```

**After**

```bash
swift package plugin --allow-writing-to-package-directory swiftformat --config .swiftformat .
```