### PR TITLE
Fix repo file update

### DIFF
--- a/Sources/Hub/Downloader.swift
+++ b/Sources/Hub/Downloader.swift
@@ -347,7 +347,7 @@ extension Downloader: URLSessionDownloadDelegate {
 
 extension FileManager {
     func moveDownloadedFile(from srcURL: URL, to dstURL: URL) throws {
-        if fileExists(atPath: dstURL.path()) {
+        if fileExists(atPath: dstURL.path(percentEncoded: false)) {
             try removeItem(at: dstURL)
         }
 


### PR DESCRIPTION
# What
Currently, if you update any file in a repo after the initial download and then try to update local files, it fails with an error:

```
Error Domain=NSCocoaErrorDomain Code=516 "{file}.incomplete" couldn't be moved to "{destination}" because an item with the same name already exists.
```

The problem is in how the check for an existing local file is done:

```swift
fileExists(atPath: dstURL.path()) // false
fileExists(atPath: dstURL.path(percentEncoded: false)) // true
```