### PR TITLE
Conditionally import CoreML and Accelerate frameworks

### DIFF
--- a/Sources/Generation/Generation.swift
+++ b/Sources/Generation/Generation.swift
@@ -5,7 +5,9 @@
 //  Created by Pedro Cuenca on 7/5/23.
 //
 
+#if canImport(CoreML)
 import CoreML
+
 import Tokenizers
 
 public enum GenerationMode {
@@ -106,3 +108,4 @@ public extension Generation {
         return logitsWarpers
     }
 }
+#endif // canImport(CoreML)

--- a/Sources/Generation/LogitsWarper/TopKLogitsWarper.swift
+++ b/Sources/Generation/LogitsWarper/TopKLogitsWarper.swift
@@ -1,3 +1,4 @@
+#if canImport(Accelerate)
 import Accelerate
 import Foundation
 
@@ -56,3 +57,4 @@ public struct TopKLogitsWarper: LogitsWarper {
         return (indices: topkIndices.map { indices[Int($0)] }, logits: topkLogits)
     }
 }
+#endif // canImport(Accelerate)

--- a/Sources/Generation/MLMultiArray+Utils.swift
+++ b/Sources/Generation/MLMultiArray+Utils.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2019 Hugging Face. All rights reserved.
 //
 
+#if canImport(CoreML)
 import CoreML
 import Foundation
 
@@ -196,3 +197,4 @@ extension MLMultiArray {
         return s + "]"
     }
 }
+#endif // canImport(CoreML)

--- a/Sources/Generation/MLShapedArray+Utils.swift
+++ b/Sources/Generation/MLShapedArray+Utils.swift
@@ -5,6 +5,7 @@
 //  Created by Pedro Cuenca on 13/5/23.
 //
 
+#if canImport(CoreML)
 import CoreML
 
 public extension MLShapedArray<Float> {
@@ -50,3 +51,4 @@ public extension MLMultiArray {
         }
     }
 }
+#endif // canImport(CoreML)

--- a/Sources/Generation/Math.swift
+++ b/Sources/Generation/Math.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2019 Hugging Face. All rights reserved.
 //
 
+#if canImport(CoreML) && canImport(Accelerate)
 import Accelerate
 import CoreML
 import Foundation
@@ -168,3 +169,4 @@ public extension Math {
         }
     }
 }
+#endif // canImport(CoreML) && canImport(Accelerate)

--- a/Sources/Models/LanguageModel.swift
+++ b/Sources/Models/LanguageModel.swift
@@ -5,7 +5,9 @@
 //  Created by Pedro Cuenca on 7/5/23.
 //
 
+#if canImport(CoreML)
 import CoreML
+
 import Generation
 import Hub
 import Tokenizers
@@ -226,3 +228,5 @@ public enum TokenizerError: LocalizedError {
         }
     }
 }
+
+#endif // canImport(CoreML)

--- a/Sources/Models/LanguageModelTypes.swift
+++ b/Sources/Models/LanguageModelTypes.swift
@@ -5,7 +5,9 @@
 //  Created by Pedro Cuenca on 8/5/23.
 //
 
+#if canImport(CoreML)
 import CoreML
+
 import Generation
 import Tokenizers
 
@@ -40,3 +42,4 @@ public extension TextGenerationModel {
         try await generate(config: config, prompt: prompt, model: callAsFunction, tokenizer: tokenizer, callback: callback)
     }
 }
+#endif // canImport(CoreML)

--- a/Sources/Models/Weights.swift
+++ b/Sources/Models/Weights.swift
@@ -1,3 +1,4 @@
+#if canImport(CoreML)
 import CoreML
 
 public struct Weights {
@@ -91,3 +92,4 @@ struct Safetensor {
         return Weights(dict)
     }
 }
+#endif // canImport(CoreML)

--- a/Sources/TransformersCLI/main.swift
+++ b/Sources/TransformersCLI/main.swift
@@ -1,3 +1,4 @@
+#if canImport(CoreML)
 import ArgumentParser
 import CoreML
 import Foundation
@@ -107,3 +108,4 @@ extension Double {
         String(format: "\(format)", self)
     }
 }
+#endif // canImport(CoreML)

--- a/Tests/GenerationTests/LogitsWarperTests.swift
+++ b/Tests/GenerationTests/LogitsWarperTests.swift
@@ -4,9 +4,11 @@
 //  Created by Jan Krukowski on 09/12/2023.
 //
 
+#if canImport(CoreML)
 import CoreML
-@testable import Generation
 import XCTest
+
+@testable import Generation
 
 final class LogitsWarperTests: XCTestCase {
     private let accuracy: Float = 0.00001
@@ -150,3 +152,4 @@ final class LogitsWarperTests: XCTestCase {
         XCTAssertEqual(result5.logits, [4.5, 3.0, 2.0, 1.0], accuracy: accuracy)
     }
 }
+#endif // canImport(CoreML)

--- a/Tests/GenerationTests/MathTests.swift
+++ b/Tests/GenerationTests/MathTests.swift
@@ -4,9 +4,11 @@
 //  Created by Jan Krukowski on 25/11/2023.
 //
 
+#if canImport(CoreML)
 import CoreML
-@testable import Generation
 import XCTest
+
+@testable import Generation
 
 final class MathTests: XCTestCase {
     private let accuracy: Float = 0.00001
@@ -51,3 +53,4 @@ final class MathTests: XCTestCase {
         XCTAssertEqual(result1.reduce(0, +), 1.0, accuracy: accuracy)
     }
 }
+#endif // canImport(CoreML)


### PR DESCRIPTION
Related to https://github.com/huggingface/swift-transformers/issues/176

The `Hub` module and other products of the `swift-transformers` package could theoretically be used on Linux, Window, Wasm, or other platforms. As a prerequisite, this PR conditionalizes imports of `CoreML` and `Accelerate`, which are specific to macOS and iOS.