### PR TITLE
Update documentation targets for Swift Package Index configuration

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -1,4 +1,4 @@
 version: 1
 builder:
   configs:
-    - documentation_targets: [Hub, Tokenizers, TensorUtils, Generation, Models]
+    - documentation_targets: [Hub, Tokenizers, Generation, Models]


### PR DESCRIPTION
Follow-up to #244 

`TensorUtils` is no longer a module in this package. This PR updates the Swift Package Index config's list of targets for which to generate documentation.