### PR TITLE
Change `AutoTokenizer` from struct to enum

### DIFF
--- a/Sources/Tokenizers/Tokenizer.swift
+++ b/Sources/Tokenizers/Tokenizer.swift
@@ -595,9 +595,9 @@ public class PreTrainedTokenizer: Tokenizer {
 
 // MARK: - Building
 
-public struct AutoTokenizer {}
+public enum AutoTokenizer {}
 
-struct PreTrainedTokenizerClasses {
+enum PreTrainedTokenizerClasses {
     /// Class overrides for custom behaviour
     /// Not to be confused with the TokenizerModel classes defined in TokenizerModel
     static let tokenizerClasses: [String: PreTrainedTokenizer.Type] = [


### PR DESCRIPTION
`AutoTokenizer` is used purely as a namespace, and shouldn't be initialized. Therefore, an enumeration is a more appropriate type for it.