### PR TITLE
Change `Hub` from struct to enum

### DIFF
--- a/Sources/Hub/Hub.swift
+++ b/Sources/Hub/Hub.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public struct Hub: Sendable {}
+public enum Hub: Sendable {}
 
 public extension Hub {
     enum HubClientError: LocalizedError {


### PR DESCRIPTION
Same as #266. `Hub` is used as a namespace and shouldn't be initialized, so an enumeration is more appropriate.