### PR TITLE
Add Hub and Tokenizers as library products

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -12,7 +12,9 @@ let package = Package(
     name: "swift-transformers",
     platforms: [.iOS(.v16), .macOS(.v13)],
     products: [
-        .library(name: "Transformers", targets: ["Tokenizers", "Generation", "Models"])
+        .library(name: "Hub", targets: ["Hub"]),
+        .library(name: "Tokenizers", targets: ["Tokenizers"]),
+        .library(name: "Transformers", targets: ["Tokenizers", "Generation", "Models"]),
     ],
     dependencies: [
         .package(url: "https://github.com/huggingface/swift-jinja.git", from: "2.0.0")


### PR DESCRIPTION
This PR takes a subset of changes from #168 — specifically, the decision to export `Hub` and `Tokenizers` modules as library products of the package, so they can be used independently of `Transformers`.