### PR TITLE
Fix doc for `callAsFunction` that got out of sync

### DIFF
--- a/Sources/Models/LanguageModelTypes.swift
+++ b/Sources/Models/LanguageModelTypes.swift
@@ -57,9 +57,9 @@ public extension LanguageModelProtocol {
     /// This provides a more convenient syntax for calling `predictNextTokenScores`.
     ///
     /// - Parameters:
-    ///   - tokens: The input token sequence
-    ///   - config: The generation configuration containing model parameters
-    /// - Returns: A shaped array containing the logits for the next token prediction
+    ///   - input: The input sequence tensor.
+    ///   - config: The generation configuration containing model parameters.
+    /// - Returns: MLTensor with the raw scores of the next token.
     func callAsFunction(_ input: MLTensor, config: GenerationConfig) async -> MLTensor {
         await predictNextTokenScores(input, config: config)
     }


### PR DESCRIPTION
I saw this during the lint run for #270, but tests passed when I merged #257 🤷 