### PR TITLE
Fix build on x86_64

### DIFF
--- a/Sources/Models/LanguageModel.swift
+++ b/Sources/Models/LanguageModel.swift
@@ -471,7 +471,7 @@ public class LanguageModelWithStatefulKVCache: LanguageModel {
             Keys.inputIds: inputIds
         ]
         if isRequiringAttentionMask {
-            #if !((os(macOS) || (macCatalyst)) && arch(x86_64))
+            #if !((os(macOS) || targetEnvironment(macCatalyst)) && arch(x86_64))
             // TODO: Infer scalar type from cache or model I/O descriptors
             let attentionMask = MLTensor(zeros: [1, 1, 1, tokenCount + 1], scalarType: Float16.self)
             inputDictionary[Keys.attentionMask] = attentionMask


### PR DESCRIPTION
This pull request makes a targeted fix to the conditional compilation logic for attention mask handling in the `LanguageModelWithStatefulKVCache` class. The change ensures that the correct environment check is used for macOS and Mac Catalyst on x86_64 architecture.

* Compilation condition update: Replaced the incorrect use of `macCatalyst` with the proper `targetEnvironment(macCatalyst)` in the `#if` directive, ensuring accurate platform detection for attention mask logic in `LanguageModelWithStatefulKVCache`.