### PR TITLE
Update lint CI job to checkout PR merge ref

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,21 +20,30 @@ jobs:
         secrets: inherit
 
     lint:
-      name: Lint
-      runs-on: macos-latest
+        name: Lint
+        runs-on: macos-latest
 
-      steps:
-        - uses: actions/checkout@v4
+        steps:
+            - name: Checkout PR merge ref if called from PR
+              if: ${{ github.event.pull_request.number }}
+              uses: actions/checkout@v4
+              with:
+                  ref: refs/pull/${{ github.event.pull_request.number }}/merge
+                  fetch-depth: 0
 
-        - run: |
-            swift format lint --strict --recursive .
+            - name: Checkout fallback
+              if: ${{ !github.event.pull_request.number }}
+              uses: actions/checkout@v4
 
-        - name: Suggest fixes (if check fails)
-          if: failure()
-          run: |
-            echo "### Here's how to fix the formatting locally:" >> $GITHUB_STEP_SUMMARY
-            echo "" >> $GITHUB_STEP_SUMMARY
-            echo '```bash' >> $GITHUB_STEP_SUMMARY
-            echo "# Format all Swift files" >> $GITHUB_STEP_SUMMARY
-            echo 'swift format -i --recursive .' >> $GITHUB_STEP_SUMMARY
-            echo '```' >> $GITHUB_STEP_SUMMARY
+            - run: |
+                  swift format lint --strict --recursive .
+
+            - name: Suggest fixes (if check fails)
+              if: failure()
+              run: |
+                  echo "### Here's how to fix the formatting locally:" >> $GITHUB_STEP_SUMMARY
+                  echo "" >> $GITHUB_STEP_SUMMARY
+                  echo '```bash' >> $GITHUB_STEP_SUMMARY
+                  echo "# Format all Swift files" >> $GITHUB_STEP_SUMMARY
+                  echo 'swift format -i --recursive .' >> $GITHUB_STEP_SUMMARY
+                  echo '```' >> $GITHUB_STEP_SUMMARY

--- a/Sources/Models/LanguageModel.swift
+++ b/Sources/Models/LanguageModel.swift
@@ -129,6 +129,7 @@ extension LanguageModel {
         static let valueCache = "valueCache"
         // Output keys
         static let logits = "logits"
+        // swift-format-ignore: DontRepeatTypeInStaticProperties
         static let presentKeys = "presentKeys"
         static let presentValues = "presentValues"
     }


### PR DESCRIPTION
CI has been failing on recent PRs, like in [this run](https://github.com/huggingface/swift-transformers/actions/runs/18093479110/job/51479308080?pr=276). 

> Sources/Models/LanguageModel.swift:132:20: warning: [DontRepeatTypeInStaticProperties] remove the suffix 'Keys' from the name of the variable 'presentKeys'

However, this linting failure can't be resolved by any changes in the PR branch, including fixing the issue and disabling the check outright.

I noticed in the logs for `action/checkout`, that it's fetching `origin/main`, which is currently a2e184dddb4757bc943e77fbe99ac6786c53f0b2.

```
Fetching the repository
  /opt/homebrew/bin/git -c protocol.version=2 fetch --no-tags --prune --no-recurse-submodules --depth=1 origin +a2e184dddb4757bc943e77fbe99ac6786c53f0b2:refs/remotes/origin/main
  From https://github.com/huggingface/swift-transformers
   * [new ref]         a2e184dddb4757bc943e77fbe99ac6786c53f0b2 -> origin/main
```

This PR updates the lint job to use the same checkout pattern as the shared workflow for testing.