### PR TITLE
Fix typo in URL of v1.0 release post

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Those familiar with the [`transformers`](https://github.com/huggingface/transfor
 
 ## Rationale & Overview
 
-Check out [our v1.0 release post](https://huggingfce.co/blog/swift-transformers) and our [original announcement](https://huggingface.co/blog/swift-coreml-llm) for more context on why we built this library.
+Check out [our v1.0 release post](https://huggingface.co/blog/swift-transformers) and our [original announcement](https://huggingface.co/blog/swift-coreml-llm) for more context on why we built this library.
 
 ## Examples
 


### PR DESCRIPTION
This fixes a typo in URL of v1.0 release post in the README.md file.