### PR TITLE
Optimistic default connectivity, respect useOfflineMode if set

### DIFF
--- a/Sources/Hub/HubApi.swift
+++ b/Sources/Hub/HubApi.swift
@@ -575,7 +575,7 @@ public extension HubApi {
             .appendingPathComponent(".cache")
             .appendingPathComponent("huggingface")
             .appendingPathComponent("download")
-        
+
         let shouldUseOfflineMode = await NetworkMonitor.shared.state.shouldUseOfflineMode()
 
         if useOfflineMode ?? shouldUseOfflineMode {


### PR DESCRIPTION
There are a few PR's relating to this issue already #281 #260, but this PR simply reverts the [change](https://github.com/huggingface/swift-transformers/commit/b9209b98077a1f8acd6db735c3e97e4f6fb4c659#diff-d008547ca96c12875517345e1c3ddd2cdae19582c8f414b275e8b29f10bf801fR477) that ignores explicitly setting `useOfflineMode` in constrained or expensive network conditions to its previous logic (noted here https://github.com/huggingface/swift-transformers/issues/280#issuecomment-3396036390). Now if `useOfflineMode` is set it will always be respected, and only if nil will check the monitor for the proper fallback behavior.

In addition to that, it relaxes the default connectivity to assume true until updated by the monitor. This will match the other defaults that were optimistic already:
```swift
/// Assume best case connection until updated by the monitor
public var isConnected: Bool = true <- updated from false
public var isExpensive: Bool = false
public var isConstrained: Bool = false
```

There is still the case where we need a faster initial update, which I believe #259 covers well.

Regarding `isExpensive` and `isConstrained`, I think they are less relevant to this library and would be better off left to the developer since both cases would still be able to download a model, only `isConnected` will require a different code path to potentially succeed - developers can make the decision with their own monitor and UI that would warn the user, e.g. give them the option to continue if they're ok with either case. Future work here could be surfacing that to developers without throwing when there technically is connectivity.