### PR TITLE
Reduce high CPU usage during downloads

### DIFF
--- a/Sources/Hub/Downloader.swift
+++ b/Sources/Hub/Downloader.swift
@@ -265,15 +265,14 @@ final class Downloader: NSObject, Sendable, ObservableObject {
         do {
             // Batch collect bytes to reduce Data.append() overhead
             // Use ContiguousArray for better performance (no NSArray bridging overhead)
-            // Larger batch size = fewer Data.append calls
-            let batchSize = 16384 // 16KB batches
+            let batchSize = 16384 // 16 kB
             var byteBatch = ContiguousArray<UInt8>()
             byteBatch.reserveCapacity(batchSize)
 
             for try await byte in asyncBytes {
                 byteBatch.append(byte)
 
-                // When we've collected a batch, append to main buffer
+                // Append batch to main buffer
                 if byteBatch.count >= batchSize {
                     buffer.append(contentsOf: byteBatch)
                     byteBatch.removeAll(keepingCapacity: true)
@@ -466,7 +465,6 @@ actor Broadcaster<E: Sendable> {
 
     func broadcast(state: E) async {
         latestState = state
-        // continuation.yield() is already async-safe, no need to wrap in Tasks
         for continuation in continuations.values {
             continuation.yield(state)
         }


### PR DESCRIPTION
I noticed that CPU usage in my app was above 300% during 4 concurrent model downloads. I made some changes that appear to reduce the CPU usage by about half:

- Bytes are appended to the buffer in batches of 16 kB instead of individually.
- `ContiguousArray<UInt8>` is used for collecting batches instead of `Array<UInt8>`.
- The unnecessary creation of a `TaskGroup` on each update was removed.

The use of `URLSession.bytes(for:)` is inherently expensive due to the processing of bytes one at a time in an `AsyncSequence`, but I'm not sure if there's a better alternative that allows for resumable downloads.