### PR TITLE
Add explicit dependency on `swift-collections` package

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -17,11 +17,22 @@ let package = Package(
         .library(name: "Transformers", targets: ["Tokenizers", "Generation", "Models"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/huggingface/swift-jinja.git", from: "2.0.0")
+        .package(url: "https://github.com/huggingface/swift-jinja.git", from: "2.0.0"),
+        .package(url: "https://github.com/apple/swift-collections.git", from: "1.0.0"),
     ],
     targets: [
         .target(name: "Generation", dependencies: ["Tokenizers"]),
-        .target(name: "Hub", dependencies: [.product(name: "Jinja", package: "swift-jinja")], resources: [.process("Resources")], swiftSettings: swiftSettings),
+        .target(
+            name: "Hub",
+            dependencies: [
+                .product(name: "Jinja", package: "swift-jinja"),
+                .product(name: "OrderedCollections", package: "swift-collections"),
+            ],
+            resources: [
+                .process("Resources")
+            ],
+            swiftSettings: swiftSettings
+        ),
         .target(name: "Models", dependencies: ["Tokenizers", "Generation"]),
         .target(name: "Tokenizers", dependencies: ["Hub", .product(name: "Jinja", package: "swift-jinja")]),
         .testTarget(name: "GenerationTests", dependencies: ["Generation"]),


### PR DESCRIPTION
Resolves #290
Resolves #284 

As correctly pointed out by @beshkenadze in https://github.com/huggingface/swift-transformers/issues/290#issuecomment-3627278625, we're missing an explicit dependency on `swift-collections` / `OrderedCollections` in `swift-transformers` as we're calling an  `OrderedDictionary` initializer here:

https://github.com/huggingface/swift-transformers/blob/296c0e901c6b37164af82c57bbdcc0d69190f5ce/Sources/Hub/Config.swift#L446