### PR TITLE
Add Dependabot configuration for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
## Summary

Add a Dependabot configuration file to automatically keep GitHub Actions dependencies up to date.

Closes #301

## Changes

Adds `.github/dependabot.yml` configured to:
- Monitor the `github-actions` package ecosystem
- Check for updates weekly

## Why?

As noted in #301, keeping GitHub Actions up to date manually can lead to outdated versions going unnoticed. Dependabot automates this by opening PRs when new versions are available, and also supports pinning actions by commit SHA for improved security.