### PR TITLE
Skip networking test targets on Linux CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,12 @@ jobs:
               env:
                   CI_DISABLE_NETWORK_MONITOR: "1"
                   HF_TOKEN: ${{ secrets.HF_HUB_READ_TOKEN }}
-              run: swift test
+              # Skip test targets that use URLSession on Linux:
+              # FoundationNetworking has a race condition where curl EasyHandles
+              # can be freed while still in use during URLSession teardown,
+              # causing a crash (libcurl error 43). These tests run on macOS.
+              # See: https://github.com/swiftlang/swift-corelibs-foundation/issues/3675
+              run: swift test --skip HubTests --skip TokenizersTests --skip Benchmarks
 
     lint:
         name: Lint


### PR DESCRIPTION
## Summary

- Skip `HubTests`, `TokenizersTests`, and `Benchmarks` test targets on Linux CI using `swift test --skip`
- The `swift build` step still compiles all targets, catching compilation errors

## Context

FoundationNetworking has a race condition where curl EasyHandles can be freed while still in use during URLSession teardown, causing a crash in `curl_easy_setopt` (libcurl error 43). This is a known upstream issue with no fix available in Swift 6.2.3.

The crash is triggered during process teardown after any test that creates a URLSession instance completes. Since it affects multiple test targets, we skip them on Linux and rely on macOS CI for these tests.

**Upstream issue:** https://github.com/swiftlang/swift-corelibs-foundation/issues/3675