### PR TITLE
Add a `comment` field to the shim for the `String(localized:` init

### DIFF
--- a/Sources/Hub/Hub.swift
+++ b/Sources/Hub/Hub.swift
@@ -372,7 +372,7 @@ public final class LanguageModelConfigurationFromHub: Sendable {
 
 #if !canImport(Darwin)
 extension String {
-    init(localized key: String) {
+    init(localized key: String, comment: String? = nil) {
         self = key
     }
 }

--- a/Sources/Tokenizers/Tokenizer.swift
+++ b/Sources/Tokenizers/Tokenizer.swift
@@ -1014,7 +1014,7 @@ class LlamaPreTrainedTokenizer: PreTrainedTokenizer, @unchecked Sendable {
 
 #if !canImport(Darwin)
 fileprivate extension String {
-    init(localized key: String) {
+    init(localized key: String, comment: String? = nil) {
         self = key
     }
 }


### PR DESCRIPTION
We ignore them on Linux, but I saw some comments were added in other PRs