### PR TITLE
Add integration test for MetaspacePreTokenizer fix

### DIFF
--- a/Tests/TokenizersTests/TokenizerTests.swift
+++ b/Tests/TokenizersTests/TokenizerTests.swift
@@ -236,6 +236,18 @@ struct TokenizerTests {
         #expect(ids == expected)
     }
 
+    /// https://github.com/huggingface/swift-transformers/issues/318
+    @Test
+    func kredorPunctuateAllTokenizer() async throws {
+        let tokenizerOpt = try await AutoTokenizer.from(pretrained: "kredor/punctuate-all") as? PreTrainedTokenizer
+        #expect(tokenizerOpt != nil)
+        let tokenizer = tokenizerOpt!
+
+        let ids = tokenizer.encode(text: "okay so lets get started")
+        let expected = [0, 68403, 221, 2633, 7, 2046, 26859, 2]
+        #expect(ids == expected)
+    }
+
     @Test
     func nllbTokenizer() async throws {
         do {


### PR DESCRIPTION
## Summary

- Adds integration test for the MetaspacePreTokenizer fix (#318, #319)
- Downloads `kredor/punctuate-all` tokenizer and verifies correct XLM-RoBERTa tokenization when `prepend_scheme` is used without `addPrefixSpace`

## Test plan

- [x] `swift test --filter kredorPunctuateAllTokenizer` passes
- [x] Follows existing test patterns in `TokenizerTests.swift`