### PR TITLE
Harden legacy `Downloader` background behavior and progress reporting

### DIFF
--- a/Sources/Hub/Downloader.swift
+++ b/Sources/Hub/Downloader.swift
@@ -433,10 +433,6 @@ extension Downloader: URLSessionDownloadDelegate {
             Task {
                 await self.broadcaster.broadcast(state: .failed(error))
             }
-            //        } else if let response = task.response as? HTTPURLResponse {
-            //            print("HTTP response status code: \(response.statusCode)")
-            //            let headers = response.allHeaderFields
-            //            print("HTTP response headers: \(headers)")
         }
     }
 }


### PR DESCRIPTION
Most of the changes in #305 were superseded by our migration to [swift-huggingface](https://github.com/huggingface/swift-huggingface) in #315. However, there were some useful changes there that are worth pulling in, even if `Downloader` is only kept around for backward compatibility — specifically:

- Keeping background session identifiers collision-safe
- Guarding progress with unknown content-length
- Preserving temp files safely before move