### PR TITLE
Fix yyjson parity with JSONSerialization

### DIFF
--- a/Sources/Hub/YYJSONParser.swift
+++ b/Sources/Hub/YYJSONParser.swift
@@ -52,12 +52,10 @@ enum YYJSONParser {
             //  - Inf/NaN literals in numeric fields
             //  - Trailing commas after the last element in objects/arrays
             //  - UTF-8 BOM prefix from files served over the network
-            //  - C-style single-line (//) and block (/* */) comments
             let flags: yyjson_read_flag =
                 YYJSON_READ_ALLOW_INF_AND_NAN
                 | YYJSON_READ_ALLOW_TRAILING_COMMAS
                 | YYJSON_READ_ALLOW_BOM
-                | YYJSON_READ_ALLOW_COMMENTS
             let doc = yyjson_read_opts(
                 UnsafeMutableRawPointer(mutating: baseAddress).assumingMemoryBound(to: CChar.self),
                 buffer.count,

--- a/Tests/TokenizersTests/YYJSONParserTests.swift
+++ b/Tests/TokenizersTests/YYJSONParserTests.swift
@@ -139,54 +139,6 @@ struct YYJSONParserTests {
         let array = config["b"].array()
         #expect(array?.count == 2)
     }
-
-    @Test
-    func allowsSingleLineComments() throws {
-        let json = """
-            {
-                // this is a comment
-                "key": "value",
-                "number": 42
-            }
-            """
-        let config = try YYJSONParser.parseToConfig(Data(json.utf8))
-
-        #expect(config["key"].string() == "value")
-        #expect(config["number"].integer() == 42)
-    }
-
-    @Test
-    func allowsMultiLineComments() throws {
-        let json = """
-            {
-                /* block comment
-                   spanning multiple lines */
-                "key": "value"
-            }
-            """
-        let config = try YYJSONParser.parseToConfig(Data(json.utf8))
-
-        #expect(config["key"].string() == "value")
-    }
-
-    @Test
-    func allowsCommentsWithTrailingCommas() throws {
-        let json = """
-            {
-                "a": 1, // inline comment
-                "b": [
-                    2, /* another comment */
-                    3,
-                ],
-            }
-            """
-        let config = try YYJSONParser.parseToConfig(Data(json.utf8))
-
-        #expect(config["a"].integer() == 1)
-        let array = config["b"].array()
-        #expect(array?.count == 2)
-        #expect(array?[1].integer() == 3)
-    }
 }
 
 // MARK: - Foundation / YYJSONParser comparison tests


### PR DESCRIPTION
We noticed a breaking change from #304  with one of our tokenizers that had trailing commas in it. 

`yyjson read failed (code 7) at position 118: trailing comma is not allowed.`

Luckily yyjson has a flag for this (expanding on @ronaldmannak's work in https://github.com/huggingface/swift-transformers/pull/324) so it can be brought back into parity with the previous JSONSerialization, but it requires a new release because protocolization was decided against.

This PR adds flags to reduce the validation error checks down to a level that JSONSerialization was allowing before.

Along with this, added some comprehensive tests to make sure we stay in parity with JSONSerialization in the future. 
Through writing these tests, I also found another breaking change regarding NUL characters where `String(cString: "before\u0000after")` would stop parsing after the NUL part, returning `before` only instead of `beforeafter`, but this was on the swift side not related to yyjson.