### PR TITLE
Add mixed-attention Core ML mask support for stateful generation

### DIFF
--- a/Sources/Models/LanguageModel.swift
+++ b/Sources/Models/LanguageModel.swift
@@ -139,6 +139,8 @@ extension LanguageModel {
         static let inputIds = "inputIds"
         static let attentionMask = "attentionMask"
         static let causalMask = "causalMask"
+        static let fullAttentionMask = "fullAttentionMask"
+        static let slidingAttentionMask = "slidingAttentionMask"
         static let keyCache = "keyCache"
         static let valueCache = "valueCache"
         // Output keys
@@ -260,6 +262,16 @@ public extension LanguageModel {
     /// Whether the model requires a causal attention mask.
     var isRequiringCausalMask: Bool {
         modelDescription.inputDescriptionsByName[Keys.causalMask] != nil
+    }
+
+    /// Whether the model requires a full-attention mask.
+    var isRequiringFullAttentionMask: Bool {
+        modelDescription.inputDescriptionsByName[Keys.fullAttentionMask] != nil
+    }
+
+    /// Whether the model requires a sliding-window attention mask.
+    var isRequiringSlidingAttentionMask: Bool {
+        modelDescription.inputDescriptionsByName[Keys.slidingAttentionMask] != nil
     }
 
     /// Determines the type of KV Cache available for the model, if any.
@@ -412,6 +424,27 @@ public extension LanguageModel {
         }
     }
 
+    /// Sliding window size for mixed-attention models, if present.
+    var slidingWindowSize: Int? {
+        get async throws {
+            if let userFields = metadata[MLModelMetadataKey.creatorDefinedKey] as? [String: String],
+                let value = userFields["co.huggingface.exporters.sliding_window"],
+                let parsed = Int(value)
+            {
+                return parsed
+            }
+
+            let modelConfig = try await modelConfig
+            if let direct = modelConfig?.slidingWindow.integer() {
+                return direct
+            }
+            if let nested = modelConfig?.textConfig.slidingWindow.integer() {
+                return nested
+            }
+            return nil
+        }
+    }
+
     /// The tokenizer associated with this model.
     ///
     /// Lazily loads and caches the tokenizer on first access.
@@ -454,6 +487,36 @@ extension LanguageModel: TextGenerationModel {
 
 @available(macOS 15.0, iOS 18.0, tvOS 18.0, visionOS 2.0, watchOS 11.0, *)
 extension LanguageModel {
+    static func additiveAttentionMask(
+        queryLength: Int,
+        totalLength: Int,
+        slidingWindow: Int? = nil
+    ) -> MLTensor {
+        precondition(queryLength > 0)
+        precondition(totalLength >= queryLength)
+
+        let negativeValue = -Float16.greatestFiniteMagnitude
+        let zeroValue: Float16 = 0
+        let pastLength = totalLength - queryLength
+        var scalars = [Float16]()
+        scalars.reserveCapacity(queryLength * totalLength)
+
+        for queryIndex in 0..<queryLength {
+            let queryPosition = pastLength + queryIndex
+            for keyIndex in 0..<totalLength {
+                let isCausal = keyIndex <= queryPosition
+                let isInsideWindow = slidingWindow == nil || keyIndex > (queryPosition - slidingWindow!)
+                scalars.append(isCausal && isInsideWindow ? zeroValue : negativeValue)
+            }
+        }
+
+        return MLTensor(
+            shape: [1, 1, queryLength, totalLength],
+            scalars: scalars,
+            scalarType: Float16.self
+        )
+    }
+
     /// Generates tokens from input tokens.
     ///
     /// - Parameters:
@@ -531,6 +594,7 @@ public class LanguageModelWithStatefulKVCache: LanguageModel {
         var inputDictionary = [
             Keys.inputIds: inputIds
         ]
+        let queryLength = inputIds.shape[1]
         if isRequiringAttentionMask {
             #if !((os(macOS) || targetEnvironment(macCatalyst)) && arch(x86_64))
             // TODO: Infer scalar type from cache or model I/O descriptors
@@ -548,6 +612,29 @@ public class LanguageModelWithStatefulKVCache: LanguageModel {
             #else
             fatalError()
             #endif
+        }
+        if isRequiringFullAttentionMask {
+            let fullAttentionMask = Self.additiveAttentionMask(
+                queryLength: queryLength,
+                totalLength: tokenCount
+            )
+            inputDictionary[Keys.fullAttentionMask] = fullAttentionMask
+        }
+        if isRequiringSlidingAttentionMask {
+            guard let slidingWindow = try? await slidingWindowSize, let slidingWindow else {
+                fatalError(
+                    """
+                    Encountered a model requiring `slidingAttentionMask` but no sliding window \
+                    size was available in metadata or config.
+                    """
+                )
+            }
+            let slidingAttentionMask = Self.additiveAttentionMask(
+                queryLength: queryLength,
+                totalLength: tokenCount,
+                slidingWindow: slidingWindow
+            )
+            inputDictionary[Keys.slidingAttentionMask] = slidingAttentionMask
         }
         let outputs = try! await model.prediction(from: inputDictionary, using: state)
 

--- a/Sources/Models/LanguageModel.swift
+++ b/Sources/Models/LanguageModel.swift
@@ -621,7 +621,7 @@ public class LanguageModelWithStatefulKVCache: LanguageModel {
             inputDictionary[Keys.fullAttentionMask] = fullAttentionMask
         }
         if isRequiringSlidingAttentionMask {
-            guard let slidingWindow = try? await slidingWindowSize, let slidingWindow else {
+            guard let slidingWindow = try? await slidingWindowSize else {
                 fatalError(
                     """
                     Encountered a model requiring `slidingAttentionMask` but no sliding window \

--- a/Sources/Models/LanguageModel.swift
+++ b/Sources/Models/LanguageModel.swift
@@ -517,6 +517,57 @@ extension LanguageModel {
         )
     }
 
+    static func statefulGenerationInputs(
+        inputIds: MLTensor,
+        tokenCount: Int,
+        includeAttentionMask: Bool,
+        includeCausalMask: Bool,
+        includeFullAttentionMask: Bool,
+        includeSlidingAttentionMask: Bool,
+        slidingWindow: Int? = nil
+    ) -> [String: MLTensor] {
+        var inputDictionary = [
+            Keys.inputIds: inputIds
+        ]
+        let queryLength = inputIds.shape[1]
+
+        if includeAttentionMask {
+            inputDictionary[Keys.attentionMask] = MLTensor(
+                zeros: [1, 1, 1, tokenCount + 1],
+                scalarType: Float16.self
+            )
+        }
+        if includeCausalMask {
+            inputDictionary[Keys.causalMask] = MLTensor(
+                zeros: [1, 1, 1, tokenCount + 1],
+                scalarType: Float16.self
+            )
+        }
+        if includeFullAttentionMask {
+            inputDictionary[Keys.fullAttentionMask] = Self.additiveAttentionMask(
+                queryLength: queryLength,
+                totalLength: tokenCount
+            )
+        }
+        if includeSlidingAttentionMask {
+            guard let slidingWindow else {
+                fatalError(
+                    """
+                    Encountered a model requiring `slidingAttentionMask` but no sliding window \
+                    size was available in metadata or config.
+                    """
+                )
+            }
+            inputDictionary[Keys.slidingAttentionMask] = Self.additiveAttentionMask(
+                queryLength: queryLength,
+                totalLength: tokenCount,
+                slidingWindow: slidingWindow
+            )
+        }
+
+        return inputDictionary
+    }
+
     /// Generates tokens from input tokens.
     ///
     /// - Parameters:
@@ -591,51 +642,20 @@ public class LanguageModelWithStatefulKVCache: LanguageModel {
             }
         mode = .extending
 
-        var inputDictionary = [
-            Keys.inputIds: inputIds
-        ]
-        let queryLength = inputIds.shape[1]
-        if isRequiringAttentionMask {
-            #if !((os(macOS) || targetEnvironment(macCatalyst)) && arch(x86_64))
-            // TODO: Infer scalar type from cache or model I/O descriptors
-            let attentionMask = MLTensor(zeros: [1, 1, 1, tokenCount + 1], scalarType: Float16.self)
-            inputDictionary[Keys.attentionMask] = attentionMask
-            #else
-            fatalError()
-            #endif
+        let slidingWindow: Int? = if isRequiringSlidingAttentionMask {
+            try? await slidingWindowSize
+        } else {
+            nil
         }
-        if isRequiringCausalMask {
-            #if !((os(macOS) || targetEnvironment(macCatalyst)) && arch(x86_64))
-            // TODO: Infer scalar type from cache or model I/O descriptors
-            let causalMask = MLTensor(zeros: [1, 1, 1, tokenCount + 1], scalarType: Float16.self)
-            inputDictionary[Keys.causalMask] = causalMask
-            #else
-            fatalError()
-            #endif
-        }
-        if isRequiringFullAttentionMask {
-            let fullAttentionMask = Self.additiveAttentionMask(
-                queryLength: queryLength,
-                totalLength: tokenCount
-            )
-            inputDictionary[Keys.fullAttentionMask] = fullAttentionMask
-        }
-        if isRequiringSlidingAttentionMask {
-            guard let slidingWindow = try? await slidingWindowSize else {
-                fatalError(
-                    """
-                    Encountered a model requiring `slidingAttentionMask` but no sliding window \
-                    size was available in metadata or config.
-                    """
-                )
-            }
-            let slidingAttentionMask = Self.additiveAttentionMask(
-                queryLength: queryLength,
-                totalLength: tokenCount,
-                slidingWindow: slidingWindow
-            )
-            inputDictionary[Keys.slidingAttentionMask] = slidingAttentionMask
-        }
+        let inputDictionary = Self.statefulGenerationInputs(
+            inputIds: inputIds,
+            tokenCount: tokenCount,
+            includeAttentionMask: isRequiringAttentionMask,
+            includeCausalMask: isRequiringCausalMask,
+            includeFullAttentionMask: isRequiringFullAttentionMask,
+            includeSlidingAttentionMask: isRequiringSlidingAttentionMask,
+            slidingWindow: slidingWindow
+        )
         let outputs = try! await model.prediction(from: inputDictionary, using: state)
 
         assert(outputs.keys.contains(Keys.logits))

--- a/Tests/ModelsTests/LanguageModelCoreMLMaskTests.swift
+++ b/Tests/ModelsTests/LanguageModelCoreMLMaskTests.swift
@@ -10,6 +10,9 @@ import CoreML
 struct LanguageModelCoreMLMaskTests {
     @Test("Build full attention mask for prefill")
     func buildFullAttentionMaskForPrefill() async {
+        guard #available(macOS 15.0, iOS 18.0, tvOS 18.0, visionOS 2.0, watchOS 11.0, *) else {
+            return
+        }
         let mask = LanguageModel.additiveAttentionMask(queryLength: 3, totalLength: 3)
         let values = await mask.shapedArray(of: Float16.self).scalars
         let blocked = -Float16.greatestFiniteMagnitude
@@ -23,6 +26,9 @@ struct LanguageModelCoreMLMaskTests {
 
     @Test("Build sliding attention mask for decode")
     func buildSlidingAttentionMaskForDecode() async {
+        guard #available(macOS 15.0, iOS 18.0, tvOS 18.0, visionOS 2.0, watchOS 11.0, *) else {
+            return
+        }
         let mask = LanguageModel.additiveAttentionMask(queryLength: 1, totalLength: 6, slidingWindow: 4)
         let values = await mask.shapedArray(of: Float16.self).scalars
         let blocked = -Float16.greatestFiniteMagnitude
@@ -34,6 +40,9 @@ struct LanguageModelCoreMLMaskTests {
 
     @Test("Build sliding attention mask for prefill with past offset")
     func buildSlidingAttentionMaskForPrefillWithPastOffset() async {
+        guard #available(macOS 15.0, iOS 18.0, tvOS 18.0, visionOS 2.0, watchOS 11.0, *) else {
+            return
+        }
         let mask = LanguageModel.additiveAttentionMask(queryLength: 2, totalLength: 5, slidingWindow: 2)
         let values = await mask.shapedArray(of: Float16.self).scalars
         let blocked = -Float16.greatestFiniteMagnitude

--- a/Tests/ModelsTests/LanguageModelCoreMLMaskTests.swift
+++ b/Tests/ModelsTests/LanguageModelCoreMLMaskTests.swift
@@ -52,5 +52,46 @@ struct LanguageModelCoreMLMaskTests {
             blocked, blocked, blocked, 0, 0,
         ])
     }
+
+    @Test("Build stateful mixed-attention model inputs")
+    func buildStatefulMixedAttentionInputs() async {
+        guard #available(macOS 15.0, iOS 18.0, tvOS 18.0, visionOS 2.0, watchOS 11.0, *) else {
+            return
+        }
+        let inputIds = MLTensor(shape: [1, 2], scalars: [Int32(10), Int32(20)], scalarType: Int32.self)
+        let inputs = LanguageModel.statefulGenerationInputs(
+            inputIds: inputIds,
+            tokenCount: 5,
+            includeAttentionMask: false,
+            includeCausalMask: false,
+            includeFullAttentionMask: true,
+            includeSlidingAttentionMask: true,
+            slidingWindow: 2
+        )
+
+        #expect(inputs.keys.contains(LanguageModel.Keys.inputIds))
+        #expect(inputs.keys.contains(LanguageModel.Keys.fullAttentionMask))
+        #expect(inputs.keys.contains(LanguageModel.Keys.slidingAttentionMask))
+        #expect(!inputs.keys.contains(LanguageModel.Keys.causalMask))
+        #expect(!inputs.keys.contains(LanguageModel.Keys.attentionMask))
+
+        let fullMask = inputs[LanguageModel.Keys.fullAttentionMask]!
+        let slidingMask = inputs[LanguageModel.Keys.slidingAttentionMask]!
+        #expect(fullMask.shape == [1, 1, 2, 5])
+        #expect(slidingMask.shape == [1, 1, 2, 5])
+
+        let blocked = -Float16.greatestFiniteMagnitude
+        let fullValues = await fullMask.shapedArray(of: Float16.self).scalars
+        let slidingValues = await slidingMask.shapedArray(of: Float16.self).scalars
+
+        #expect(fullValues == [
+            0, 0, 0, 0, blocked,
+            0, 0, 0, 0, 0,
+        ])
+        #expect(slidingValues == [
+            blocked, blocked, 0, 0, blocked,
+            blocked, blocked, blocked, 0, 0,
+        ])
+    }
 }
 #endif // canImport(CoreML)

--- a/Tests/ModelsTests/LanguageModelCoreMLMaskTests.swift
+++ b/Tests/ModelsTests/LanguageModelCoreMLMaskTests.swift
@@ -1,0 +1,47 @@
+import Foundation
+import Testing
+
+@testable import Models
+
+#if canImport(CoreML)
+import CoreML
+
+@Suite("LanguageModel Core ML Mask Tests")
+struct LanguageModelCoreMLMaskTests {
+    @Test("Build full attention mask for prefill")
+    func buildFullAttentionMaskForPrefill() async {
+        let mask = LanguageModel.additiveAttentionMask(queryLength: 3, totalLength: 3)
+        let values = await mask.shapedArray(of: Float16.self).scalars
+        let blocked = -Float16.greatestFiniteMagnitude
+
+        #expect(values == [
+            0, blocked, blocked,
+            0, 0, blocked,
+            0, 0, 0,
+        ])
+    }
+
+    @Test("Build sliding attention mask for decode")
+    func buildSlidingAttentionMaskForDecode() async {
+        let mask = LanguageModel.additiveAttentionMask(queryLength: 1, totalLength: 6, slidingWindow: 4)
+        let values = await mask.shapedArray(of: Float16.self).scalars
+        let blocked = -Float16.greatestFiniteMagnitude
+
+        #expect(values == [
+            blocked, blocked, 0, 0, 0, 0,
+        ])
+    }
+
+    @Test("Build sliding attention mask for prefill with past offset")
+    func buildSlidingAttentionMaskForPrefillWithPastOffset() async {
+        let mask = LanguageModel.additiveAttentionMask(queryLength: 2, totalLength: 5, slidingWindow: 2)
+        let values = await mask.shapedArray(of: Float16.self).scalars
+        let blocked = -Float16.greatestFiniteMagnitude
+
+        #expect(values == [
+            blocked, blocked, 0, 0, blocked,
+            blocked, blocked, blocked, 0, 0,
+        ])
+    }
+}
+#endif // canImport(CoreML)


### PR DESCRIPTION
What

Add support for stateful Core ML language models that require multiple attention masks during generation.

Why

The current runtime only handles attentionMask / causalMask, which is not sufficient for mixed-attention Core ML exports that need separate masks for different layer types.

This change allows the stateful generation path to populate:
- fullAttentionMask
- slidingAttentionMask

when those inputs are present in the Core ML model description.

Implementation

- add fullAttentionMask and slidingAttentionMask keys to LanguageModel.Keys
- detect those inputs from modelDescription
- build additive full-attention and sliding-window masks in the stateful generation path
- resolve the sliding window size from Core ML metadata first, and fall back to Hugging Face config when needed
- factor stateful generation input assembly into a reusable helper for test coverage
- keep existing single-mask models working unchanged

Tests

- add regression tests for additive full-attention mask construction
- add regression tests for sliding-window mask construction
- add an integration-style test that verifies the full input dictionary for a mixed-attention model contract
- verify with:
  swift test --filter LanguageModelCoreMLMaskTests

Scope clarification

This PR is intended to support explicit multi-mask Core ML generation contracts in the runtime.

It does not attempt to fix exporter-side approaches that reconstruct multiple masks inside a Core ML graph from a single causalMask input.

Additional context

Closes #330

Example converted Core ML repo using the explicit multi-mask contract:
https://huggingface.co/Skyline23/translategemma-4b-it-coreml
