### PR TITLE
Add cache step to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,11 @@ jobs:
     test-linux:
         name: Test (Linux)
         runs-on: ubuntu-latest
-        container: swift:6.2.3
+        strategy:
+            matrix:
+                swift-version:
+                    - "6.2.3"
+        container: swift:${{ matrix.swift-version }}
         steps:
             - name: Checkout PR merge ref if called from PR
               if: ${{ github.event.pull_request.number }}
@@ -39,13 +43,17 @@ jobs:
               if: ${{ !github.event.pull_request.number }}
               uses: actions/checkout@v6
 
-            - name: Cache SwiftPM build artifacts
+            - name: Cache Swift Package Manager Build Artifacts
               uses: actions/cache@v5
               with:
-                  path: .build
-                  key: ${{ runner.os }}-swiftpm-${{ hashFiles('Package.swift', 'Package.resolved') }}
+                  path: |
+                      .build/artifacts
+                      .build/checkouts
+                      .build/debug
+                      .build/repositories
+                  key: ${{ runner.os }}-swiftpm-swift-${{ matrix.swift-version }}-${{ hashFiles('Package.swift') }}
                   restore-keys: |
-                      ${{ runner.os }}-swiftpm-
+                      ${{ runner.os }}-swiftpm-swift-${{ matrix.swift-version }}-
 
             - name: Build
               run: swift build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,14 @@ jobs:
               if: ${{ !github.event.pull_request.number }}
               uses: actions/checkout@v6
 
+            - name: Cache SwiftPM build artifacts
+              uses: actions/cache@v5
+              with:
+                  path: .build
+                  key: ${{ runner.os }}-swiftpm-${{ hashFiles('Package.swift', 'Package.resolved') }}
+                  restore-keys: |
+                      ${{ runner.os }}-swiftpm-
+
             - name: Build
               run: swift build
 


### PR DESCRIPTION
Didn't notice until just now that we're not caching intermediate build output between CI runs. Especially since we brought in SwiftNIO / AsyncHTTPClient as a transitive dependency for Xet downloads, this adds an extra minute or two to each run.