### PR TITLE
Add Swift 6.1 manifest to forward Xet trait to `swift-huggingface` dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,9 +24,15 @@ jobs:
             HF_HUB_READ_TOKEN: ${{ secrets.HF_HUB_READ_TOKEN }}
 
     test-linux:
-        name: Test (Linux)
+        name: Test (Linux)${{ matrix.traits != '' && format(' with --traits {0}', matrix.traits) || '' }}
         runs-on: ubuntu-latest
         container: swift:6.2.3
+        strategy:
+            fail-fast: false
+            matrix:
+                include:
+                    - traits: ""
+                    - traits: "Xet"
         steps:
             - name: Checkout PR merge ref if called from PR
               if: ${{ github.event.pull_request.number }}
@@ -40,7 +46,7 @@ jobs:
               uses: actions/checkout@v6
 
             - name: Build
-              run: swift build
+              run: swift build${{ matrix.traits != '' && format(' --traits {0}', matrix.traits) || '' }}
 
             - name: Run tests
               env:
@@ -49,7 +55,7 @@ jobs:
               # FoundationNetworking race condition that crashes during teardown.
               # See: https://github.com/swiftlang/swift-corelibs-foundation/issues/3675
               run: |
-                  swift test --skip HubTests --skip TokenizersTests
+                  swift test --skip HubTests --skip TokenizersTests${{ matrix.traits != '' && format(' --traits {0}', matrix.traits) || '' }}
     lint:
         name: Lint
         runs-on: macos-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
               uses: actions/cache@v5
               with:
                   path: ~/.cache/org.swift.swiftpm
-                  key: ${{ runner.os }}-swift-${{ matrix.swift }}-${{ matrix.traits == '' && 'xet-off' || 'xet-on' }}-spm-${{ hashFiles('Package*.swift') }}-${{ hashFiles('**/Package.resolved') }}
+                  key: ${{ runner.os }}-swift-${{ matrix.swift }}-${{ matrix.traits == '' && 'xet-off' || 'xet-on' }}-spm-${{ hashFiles('Package*.swift') }}-${{ hashFiles('Package.resolved') }}
                   restore-keys: |
                       ${{ runner.os }}-swift-${{ matrix.swift }}-${{ matrix.traits == '' && 'xet-off' || 'xet-on' }}-spm-
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
               uses: actions/cache@v5
               with:
                   path: ~/.cache/org.swift.swiftpm
-                  key: ${{ runner.os }}-swift-${{ matrix.swift }}-${{ matrix.traits == '' && 'xet-off' || 'xet-on' }}-spm-${{ hashFiles('Package.swift', 'Package@swift-6.1.swift', '**/Package.resolved') }}
+                  key: ${{ runner.os }}-swift-${{ matrix.swift }}-${{ matrix.traits == '' && 'xet-off' || 'xet-on' }}-spm-${{ hashFiles('Package*.swift') }}-${{ hashFiles('**/Package.resolved') }}
                   restore-keys: |
                       ${{ runner.os }}-swift-${{ matrix.swift }}-${{ matrix.traits == '' && 'xet-off' || 'xet-on' }}-spm-
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,13 +26,15 @@ jobs:
     test-linux:
         name: Test (Linux)${{ matrix.traits != '' && format(' with --traits {0}', matrix.traits) || '' }}
         runs-on: ubuntu-latest
-        container: swift:6.2.3
+        container: swift:${{ matrix.swift }}
         strategy:
             fail-fast: false
             matrix:
                 include:
-                    - traits: ""
-                    - traits: "Xet"
+                    - swift: "6.2.3"
+                      traits: ""
+                    - swift: "6.2.3"
+                      traits: "Xet"
         steps:
             - name: Checkout PR merge ref if called from PR
               if: ${{ github.event.pull_request.number }}
@@ -44,6 +46,14 @@ jobs:
             - name: Checkout fallback
               if: ${{ !github.event.pull_request.number }}
               uses: actions/checkout@v6
+
+            - name: Cache Swift Package Manager dependencies
+              uses: actions/cache@v5
+              with:
+                  path: ~/.cache/org.swift.swiftpm
+                  key: ${{ runner.os }}-swift-${{ matrix.swift }}-${{ matrix.traits == '' && 'xet-off' || 'xet-on' }}-spm-${{ hashFiles('Package.swift', 'Package@swift-6.1.swift', '**/Package.resolved') }}
+                  restore-keys: |
+                      ${{ runner.os }}-swift-${{ matrix.swift }}-${{ matrix.traits == '' && 'xet-off' || 'xet-on' }}-spm-
 
             - name: Build
               run: swift build${{ matrix.traits != '' && format(' --traits {0}', matrix.traits) || '' }}

--- a/Package@swift-6.1.swift
+++ b/Package@swift-6.1.swift
@@ -45,6 +45,7 @@ let package = Package(
             dependencies: [
                 .product(name: "Jinja", package: "swift-jinja"),
                 .product(name: "HuggingFace", package: "swift-huggingface"),
+                .product(name: "Xet", package: "swift-xet", condition: .when(traits: ["Xet"])),
                 .product(name: "OrderedCollections", package: "swift-collections"),
                 .product(name: "Crypto", package: "swift-crypto"),
                 .product(name: "yyjson", package: "yyjson"),

--- a/Package@swift-6.1.swift
+++ b/Package@swift-6.1.swift
@@ -24,9 +24,11 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/huggingface/swift-jinja.git", from: "2.0.0"),
+        // Work around SwiftPM trait resolution issue for transitive Xet dependency.
+        .package(url: "https://github.com/huggingface/swift-xet.git", from: "0.2.0"),
         .package(
             url: "https://github.com/huggingface/swift-huggingface.git",
-            from: "0.8.1",
+            from: "0.9.0",
             traits: [
                 .defaults,
                 .trait(name: "Xet", condition: .when(traits: ["Xet"])),

--- a/Package@swift-6.1.swift
+++ b/Package@swift-6.1.swift
@@ -28,7 +28,8 @@ let package = Package(
             url: "https://github.com/huggingface/swift-huggingface.git",
             from: "0.8.1",
             traits: [
-                .trait(name: "Xet", condition: .when(traits: ["Xet"]))
+                .defaults,
+                .trait(name: "Xet", condition: .when(traits: ["Xet"])),
             ]
         ),
         .package(url: "https://github.com/apple/swift-collections.git", from: "1.0.0"),

--- a/Package@swift-6.1.swift
+++ b/Package@swift-6.1.swift
@@ -59,5 +59,6 @@ let package = Package(
         .testTarget(name: "HubTests", dependencies: ["Hub", .product(name: "Jinja", package: "swift-jinja")], swiftSettings: swiftSettings),
         .testTarget(name: "ModelsTests", dependencies: ["Models", "Hub"], resources: [.process("Resources")]),
         .testTarget(name: "TokenizersTests", dependencies: ["Tokenizers", "Models", "Hub"], resources: [.process("Resources")]),
-    ]
+    ],
+    swiftLanguageModes: [.v5]
 )

--- a/Package@swift-6.1.swift
+++ b/Package@swift-6.1.swift
@@ -1,0 +1,62 @@
+// swift-tools-version: 6.1
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+/// Define the strict concurrency settings to be applied to all targets.
+let swiftSettings: [SwiftSetting] = [
+    .enableExperimentalFeature("StrictConcurrency")
+]
+
+let package = Package(
+    name: "swift-transformers",
+    platforms: [.iOS(.v16), .macOS(.v13)],
+    products: [
+        .library(name: "Hub", targets: ["Hub"]),
+        .library(name: "Tokenizers", targets: ["Tokenizers"]),
+        .library(name: "Transformers", targets: ["Tokenizers", "Generation", "Models"]),
+    ],
+    traits: [
+        .trait(
+            name: "Xet",
+            description: "Enable Xet transport support in swift-huggingface."
+        )
+    ],
+    dependencies: [
+        .package(url: "https://github.com/huggingface/swift-jinja.git", from: "2.0.0"),
+        .package(
+            url: "https://github.com/huggingface/swift-huggingface.git",
+            from: "0.8.1",
+            traits: [
+                .trait(name: "Xet", condition: .when(traits: ["Xet"]))
+            ]
+        ),
+        .package(url: "https://github.com/apple/swift-collections.git", from: "1.0.0"),
+        .package(url: "https://github.com/apple/swift-crypto.git", "3.0.0"..<"5.0.0"),
+        .package(url: "https://github.com/ibireme/yyjson.git", exact: "0.12.0"),
+    ],
+    targets: [
+        .target(name: "Generation", dependencies: ["Tokenizers"]),
+        .target(
+            name: "Hub",
+            dependencies: [
+                .product(name: "Jinja", package: "swift-jinja"),
+                .product(name: "HuggingFace", package: "swift-huggingface"),
+                .product(name: "OrderedCollections", package: "swift-collections"),
+                .product(name: "Crypto", package: "swift-crypto"),
+                .product(name: "yyjson", package: "yyjson"),
+            ],
+            resources: [
+                .process("Resources")
+            ],
+            swiftSettings: swiftSettings
+        ),
+        .target(name: "Models", dependencies: ["Tokenizers", "Generation"]),
+        .target(name: "Tokenizers", dependencies: ["Hub", .product(name: "Jinja", package: "swift-jinja")]),
+        .testTarget(name: "Benchmarks", dependencies: ["Hub", "Tokenizers", .product(name: "yyjson", package: "yyjson")]),
+        .testTarget(name: "GenerationTests", dependencies: ["Generation"]),
+        .testTarget(name: "HubTests", dependencies: ["Hub", .product(name: "Jinja", package: "swift-jinja")], swiftSettings: swiftSettings),
+        .testTarget(name: "ModelsTests", dependencies: ["Models", "Hub"], resources: [.process("Resources")]),
+        .testTarget(name: "TokenizersTests", dependencies: ["Tokenizers", "Models", "Hub"], resources: [.process("Resources")]),
+    ]
+)

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ To use `swift-transformers` with SwiftPM, you can add this to your `Package.swif
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/huggingface/swift-transformers", from: "0.1.17")
+    .package(url: "https://github.com/huggingface/swift-transformers", from: "1.3.0")
 ]
 ```
 
@@ -140,6 +140,46 @@ targets: [
     )
 ]
 ```
+
+### Optional Xet trait
+
+`swift-transformers` includes an `Xet` [package trait](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0450-swiftpm-package-traits.md)
+that enables fast, parallel downloads from the Hugging Face Hub
+via [swift-xet](https://github.com/huggingface/swift-xet).
+Because Xet introduces additional transitive dependencies
+(including [AsyncHTTPClient](https://github.com/swift-server/async-http-client)),
+it is opt-in.
+
+On Swift 6.1+, enable it in your `Package.swift`:
+
+```swift
+dependencies: [
+    .package(
+        url: "https://github.com/huggingface/swift-transformers",
+        from: "1.3.0",
+        traits: ["Xet"]
+    )
+]
+```
+
+Or from the command line:
+
+```bash
+swift build --traits Xet
+swift test --traits Xet
+```
+
+When the trait is not enabled,
+Hub downloads use the default `URLSession`-based transport.
+
+On Swift versions earlier than 6.1,
+package traits are unavailable and Xet transport cannot be enabled.
+
+> [!NOTE]
+> Xcode doesn't yet provide a built-in way to declare package dependencies with traits.
+> As a workaround, you can create an internal Swift package
+> that re-exports `swift-transformers` with the `Xet` trait enabled,
+> then add that package as a local dependency in your Xcode project.
 
 ## Projects that use swift-transformers ❤️ 
 


### PR DESCRIPTION
Follow up to #315 

[swift-xet](https://github.com/huggingface/swift-xet) depends on [async-http-client](https://github.com/swift-server/async-http-client) for fast, parallel downloads. Unfortunately, `AsyncHTTPClient` has a bunch of transitive dependences, which some package consumers find unacceptable.

https://github.com/huggingface/swift-huggingface/pull/46 adds a new opt-in `"Xet"` trait to conditionalize this dependency. This PR adds the plumbing required for consumers of the swift-transformers package to opt-in to that feature as well.