### PR TITLE
Catch JinjaError during chat template compilation

### DIFF
--- a/Sources/Tokenizers/Tokenizer.swift
+++ b/Sources/Tokenizers/Tokenizer.swift
@@ -545,7 +545,12 @@ public class PreTrainedTokenizer: @unchecked Sendable, Tokenizer {
         cacheLock.unlock()
 
         // Compile template outside of lock to avoid holding lock during expensive operation
-        let compiled = try Template(templateString, with: .init(lstripBlocks: true, trimBlocks: true))
+        let compiled: Template
+        do {
+            compiled = try Template(templateString, with: .init(lstripBlocks: true, trimBlocks: true))
+        } catch let jinjaError as JinjaError {
+            throw TokenizerError.chatTemplate("Failed to compile chat template: \(jinjaError)")
+        }
 
         // Insert into cache under lock (using double-checked locking pattern)
         cacheLock.lock()


### PR DESCRIPTION
## Summary

Some models use Jinja2 features not yet supported by the Swift [Jinja](https://github.com/johnmai-dev/Jinja) library. The most common example is namespace dot-notation assignment used in Gemma4's `chat_template.jinja`:

```jinja
{%- set ns = namespace(found_first=false) -%}
...
{%- set ns.found_first = true -%}
```

Previously, `Template.init()` threw a `JinjaError` that propagated uncaught through `compiledTemplate(for:)` and `applyChatTemplate(...)`, producing a fatal crash at the call site:

```
Fatal error: Error raised at top level:
Jinja.JinjaError.syntax("Unexpected token: multiplicativeBinaryOperator")
```

## Change

Wrap the `Template.init()` call in `compiledTemplate(for:)` so that any `JinjaError` is caught and rethrown as `TokenizerError.chatTemplate(message)`. This gives callers a recoverable, typed error instead of a process-terminating one.

Callers that want a graceful fallback when the template is unusable can now catch `TokenizerError.chatTemplate` alongside `TokenizerError.missingChatTemplate`.

## Test plan

- [ ] Existing test suite passes (one pre-existing unrelated failure in `ConfigTests` — `Equatable: string, integer, float, boolean, token, dictionary` — exists on `main` before this change)
- [ ] Manually verified: loading a Gemma4 tokenizer via `AutoTokenizer.from(modelFolder:)` no longer crashes; callers receive `TokenizerError.chatTemplate` instead