### PR TITLE
Honor `prepend_scheme` in MetaspaceDecoder

### DIFF
--- a/Sources/Tokenizers/Decoder.swift
+++ b/Sources/Tokenizers/Decoder.swift
@@ -237,23 +237,13 @@ class MetaspaceDecoder: Decoder {
     let replacement: String
 
     required init(config: Config) {
-        // `prepend_scheme` supersedes `add_prefix_space` per huggingface/tokenizers#1357.
-        // Newer python tokenizer.json files emitted by transformers ≥ 5 (e.g. T5 saved
-        // via `save_pretrained`) drop `add_prefix_space` and only set `prepend_scheme`.
-        // The Rust reference implementation uses the same `Metaspace` struct for both
-        // pre-tokenize and decode, so its defaults are symmetric by construction. Since
-        // Swift has separate types we mirror `MetaspacePreTokenizer`'s resolution here
-        // so encode and decode agree even when the config sets neither key (in that
-        // case both default to `.always`).
+        // See MetaspacePreTokenizer.init
         let scheme: MetaspacePreTokenizer.PrependScheme
         if let schemeStr = config.prependScheme.string() {
             scheme = MetaspacePreTokenizer.PrependScheme(rawValue: schemeStr) ?? .always
         } else {
             scheme = config.addPrefixSpace.boolean(or: true) ? .always : .never
         }
-        // For decode, both `.always` and `.first` mean a leading space was prepended
-        // at encode time and should be stripped from the first token; `.never` leaves
-        // the input untouched.
         addPrefixSpace = (scheme != .never)
         replacement = config.replacement.string(or: "_")
     }

--- a/Sources/Tokenizers/Decoder.swift
+++ b/Sources/Tokenizers/Decoder.swift
@@ -240,13 +240,21 @@ class MetaspaceDecoder: Decoder {
         // `prepend_scheme` supersedes `add_prefix_space` per huggingface/tokenizers#1357.
         // Newer python tokenizer.json files emitted by transformers ≥ 5 (e.g. T5 saved
         // via `save_pretrained`) drop `add_prefix_space` and only set `prepend_scheme`.
-        // Treat "always" / "first" as having prepended a leading space at encode time
-        // so the decoder strips it from the first token; "never" leaves it intact.
+        // The Rust reference implementation uses the same `Metaspace` struct for both
+        // pre-tokenize and decode, so its defaults are symmetric by construction. Since
+        // Swift has separate types we mirror `MetaspacePreTokenizer`'s resolution here
+        // so encode and decode agree even when the config sets neither key (in that
+        // case both default to `.always`).
+        let scheme: MetaspacePreTokenizer.PrependScheme
         if let schemeStr = config.prependScheme.string() {
-            addPrefixSpace = (schemeStr != "never")
+            scheme = MetaspacePreTokenizer.PrependScheme(rawValue: schemeStr) ?? .always
         } else {
-            addPrefixSpace = config.addPrefixSpace.boolean(or: false)
+            scheme = config.addPrefixSpace.boolean(or: true) ? .always : .never
         }
+        // For decode, both `.always` and `.first` mean a leading space was prepended
+        // at encode time and should be stripped from the first token; `.never` leaves
+        // the input untouched.
+        addPrefixSpace = (scheme != .never)
         replacement = config.replacement.string(or: "_")
     }
 

--- a/Sources/Tokenizers/Decoder.swift
+++ b/Sources/Tokenizers/Decoder.swift
@@ -237,7 +237,16 @@ class MetaspaceDecoder: Decoder {
     let replacement: String
 
     required init(config: Config) {
-        addPrefixSpace = config.addPrefixSpace.boolean(or: false)
+        // `prepend_scheme` supersedes `add_prefix_space` per huggingface/tokenizers#1357.
+        // Newer python tokenizer.json files emitted by transformers ≥ 5 (e.g. T5 saved
+        // via `save_pretrained`) drop `add_prefix_space` and only set `prepend_scheme`.
+        // Treat "always" / "first" as having prepended a leading space at encode time
+        // so the decoder strips it from the first token; "never" leaves it intact.
+        if let schemeStr = config.prependScheme.string() {
+            addPrefixSpace = (schemeStr != "never")
+        } else {
+            addPrefixSpace = config.addPrefixSpace.boolean(or: false)
+        }
         replacement = config.replacement.string(or: "_")
     }
 

--- a/Tests/TokenizersTests/DecoderTests.swift
+++ b/Tests/TokenizersTests/DecoderTests.swift
@@ -97,6 +97,23 @@ struct DecoderTests {
         #expect(decoded == [" How", " are"])
     }
 
+    /// When neither `prepend_scheme` nor `add_prefix_space` is in the config,
+    /// `MetaspacePreTokenizer` defaults to `.always` (prepend a space at encode
+    /// time). The decoder therefore has to strip the leading space from the
+    /// first token so encode/decode round-trip cleanly. Without the symmetric
+    /// default this asserted on `[" How", " are", " you", "?"]` instead.
+    @Test("Metaspace decoder default (neither key set) matches PreTokenizer")
+    func metaspaceDecoderDefaultMatchesPreTokenizer() {
+        let decoder = MetaspaceDecoder(
+            config: Config(["replacement": "▁"]))
+
+        let tokens = ["▁How", "▁are", "▁you", "?"]
+        let decoded = decoder.decode(tokens: tokens)
+
+        #expect(decoded == ["How", " are", " you", "?"])
+        #expect(decoded.joined() == "How are you?")
+    }
+
     @Test("WordPiece decoder with prefix and cleanup")
     func wordPieceDecoder() {
         let config = Config(["prefix": "##", "cleanup": true])

--- a/Tests/TokenizersTests/DecoderTests.swift
+++ b/Tests/TokenizersTests/DecoderTests.swift
@@ -29,6 +29,74 @@ struct DecoderTests {
         )
     }
 
+    /// Regression coverage for #329: newer tokenizer.json files written by
+    /// transformers ≥ 5 (e.g. `T5Tokenizer.save_pretrained`) drop the legacy
+    /// `add_prefix_space` field and only set `prepend_scheme`. The decoder
+    /// must derive the strip-leading-space behavior from `prepend_scheme`.
+    @Test("Metaspace decoder honors prepend_scheme = always (T5 fine-tune)")
+    func metaspaceDecoderPrependSchemeAlways() {
+        let decoder = MetaspaceDecoder(
+            config: Config([
+                "prepend_scheme": "always",
+                "replacement": "▁",
+                "split": true,
+            ]))
+
+        let tokens = ["▁How", "▁are", "▁you", "?"]
+        let decoded = decoder.decode(tokens: tokens)
+
+        #expect(decoded == ["How", " are", " you", "?"])
+        #expect(decoded.joined() == "How are you?")
+    }
+
+    @Test("Metaspace decoder honors prepend_scheme = never")
+    func metaspaceDecoderPrependSchemeNever() {
+        let decoder = MetaspaceDecoder(
+            config: Config([
+                "prepend_scheme": "never",
+                "replacement": "▁",
+            ]))
+
+        // With "never", no leading space was prepended at encode time, so the
+        // decoder must leave the leading replacement alone.
+        let tokens = ["▁How", "▁are", "▁you", "?"]
+        let decoded = decoder.decode(tokens: tokens)
+
+        #expect(decoded == [" How", " are", " you", "?"])
+    }
+
+    @Test("Metaspace decoder honors prepend_scheme = first")
+    func metaspaceDecoderPrependSchemeFirst() {
+        let decoder = MetaspaceDecoder(
+            config: Config([
+                "prepend_scheme": "first",
+                "replacement": "▁",
+            ]))
+
+        let tokens = ["▁How", "▁are", "▁you", "?"]
+        let decoded = decoder.decode(tokens: tokens)
+
+        // "first" prepended a leading space to the first piece only, so the
+        // decoder strips it from the first token.
+        #expect(decoded == ["How", " are", " you", "?"])
+    }
+
+    @Test("Metaspace decoder prepend_scheme supersedes add_prefix_space")
+    func metaspaceDecoderPrependSchemeSupersedesAddPrefixSpace() {
+        // When both keys are present, `prepend_scheme` wins per tokenizers PR #1357.
+        let decoder = MetaspaceDecoder(
+            config: Config([
+                "prepend_scheme": "never",
+                "add_prefix_space": true,
+                "replacement": "▁",
+            ]))
+
+        let tokens = ["▁How", "▁are"]
+        let decoded = decoder.decode(tokens: tokens)
+
+        #expect(decoded == [" How", " are"])
+    }
+
     @Test("WordPiece decoder with prefix and cleanup")
     func wordPieceDecoder() {
         let config = Config(["prefix": "##", "cleanup": true])


### PR DESCRIPTION
Closes #329.

## Problem

Newer python `tokenizer.json` files emitted by transformers ≥ 5 (e.g. T5 saved via `T5Tokenizer.save_pretrained`) drop the legacy `add_prefix_space` decoder field and only set `prepend_scheme`:

```diff
   "decoder": {
-    "add_prefix_space": true,
+    "prepend_scheme": "always",
     "replacement": "▁",
+    "split": true,
     "type": "Metaspace"
   }
```

The Swift `MetaspaceDecoder` was reading only `add_prefix_space`, so on a fine-tuned T5 it left the leading replacement unstripped:

```
tokens   ["▁How", "▁are", "▁you", "?"]
decoded  [" How", " are", " you", "?"]   // expected: ["How", " are", " you", "?"]
```

`MetaspacePreTokenizer` already migrated to `prepend_scheme` in #319; the decoder side was missed.

## Fix

In `MetaspaceDecoder.init`, prefer `prepend_scheme` when present and translate it to the existing strip-leading-space behavior:

| `prepend_scheme` | encode added a leading space? | decoder strips first leading space? |
|---|---|---|
| `always` | yes | yes |
| `first` | yes (first piece only) | yes |
| `never` | no | no |

When `prepend_scheme` is absent, fall back to the existing `add_prefix_space` reading so legacy `tokenizer.json` files keep working.

## Verification

Confirmed the regression and the fix with the new tests:

```
# pre-fix (HEAD~1, with new tests applied):
✘ Test "Metaspace decoder honors prepend_scheme = always (T5 fine-tune)"
  recorded an issue: Expectation failed:
    (decoded.joined() → " How are you?") == "How are you?"

# post-fix (HEAD):
✔ Test "Metaspace decoder with prefix space replacement" passed
✔ Test "Metaspace decoder honors prepend_scheme = always (T5 fine-tune)" passed
✔ Test "Metaspace decoder honors prepend_scheme = never" passed
✔ Test "Metaspace decoder honors prepend_scheme = first" passed
✔ Test "Metaspace decoder prepend_scheme supersedes add_prefix_space" passed
✔ Test run with 6 tests in 1 suite passed
```

Full TokenizersTests suite (111 tests) still passes locally on macOS.

The reproduction config in the new "= always (T5 fine-tune)" test mirrors the `tokenizer.json` snippet from #329 exactly.