### PR TITLE
Cache byte-level pre-tokenize regex and inline byte encoder lookup

### DIFF
--- a/Sources/Tokenizers/BPETokenizer.swift
+++ b/Sources/Tokenizers/BPETokenizer.swift
@@ -148,20 +148,38 @@ class BPETokenizer: PreTrainedTokenizerModel, @unchecked Sendable {
         idsToTokens[id] as String?
     }
 
+    /// Cached `<0x%02X>` byte fallback strings, indexed by byte value.
+    private static let hexaEncoderTable: [String] = (0..<256).map { String(format: "<0x%02X>", $0) }
+
     func byteEncode(text: String) -> [String] {
-        let RE = #"'s|'t|'re|'ve|'m|'ll|'d| ?\p{L}+| ?\p{N}+| ?[^\s\p{L}\p{N}]+|\s+(?!\S)|\s+"#
-        let tokens = text.ranges(of: RE).map { String(text[$0]) }
-        return tokens.map { token -> String in
-            return Array(token.utf8).compactMap { byteEncoder[$0] }.joined()
+        let nsText = text as NSString
+        let fullRange = NSRange(location: 0, length: nsText.length)
+        var result: [String] = []
+        byteLevelPreTokenizeRegex.enumerateMatches(in: text, range: fullRange) { match, _, _ in
+            guard let match else { return }
+            let token = nsText.substring(with: match.range)
+            var encoded = ""
+            encoded.reserveCapacity(token.utf8.count)
+            for byte in token.utf8 {
+                encoded.append(byteEncoderTable[Int(byte)])
+            }
+            result.append(encoded)
         }
+        return result
     }
 
     func hexaEncode(text: String) -> [String] {
-        let RE = #"'s|'t|'re|'ve|'m|'ll|'d| ?\p{L}+| ?\p{N}+| ?[^\s\p{L}\p{N}]+|\s+(?!\S)|\s+"#
-        let tokens = text.ranges(of: RE).map { String(text[$0]) }
-        return tokens.flatMap { token -> [String] in
-            return Array(token.utf8).map { String(format: "<0x%02X>", $0) }
+        let nsText = text as NSString
+        let fullRange = NSRange(location: 0, length: nsText.length)
+        var result: [String] = []
+        byteLevelPreTokenizeRegex.enumerateMatches(in: text, range: fullRange) { match, _, _ in
+            guard let match else { return }
+            let token = nsText.substring(with: match.range)
+            for byte in token.utf8 {
+                result.append(Self.hexaEncoderTable[Int(byte)])
+            }
         }
+        return result
     }
 
     private func getPairs(word: [String]) -> Set<BytePair> {

--- a/Sources/Tokenizers/BPETokenizer.swift
+++ b/Sources/Tokenizers/BPETokenizer.swift
@@ -152,12 +152,8 @@ class BPETokenizer: PreTrainedTokenizerModel, @unchecked Sendable {
     private static let hexaEncoderTable: [String] = (0..<256).map { String(format: "<0x%02X>", $0) }
 
     func byteEncode(text: String) -> [String] {
-        let nsText = text as NSString
-        let fullRange = NSRange(location: 0, length: nsText.length)
         var result: [String] = []
-        byteLevelPreTokenizeRegex.enumerateMatches(in: text, range: fullRange) { match, _, _ in
-            guard let match else { return }
-            let token = nsText.substring(with: match.range)
+        enumerateRegexTokens(in: text, with: byteLevelPreTokenizeRegex) { token in
             var encoded = ""
             encoded.reserveCapacity(token.utf8.count)
             for byte in token.utf8 {
@@ -169,12 +165,8 @@ class BPETokenizer: PreTrainedTokenizerModel, @unchecked Sendable {
     }
 
     func hexaEncode(text: String) -> [String] {
-        let nsText = text as NSString
-        let fullRange = NSRange(location: 0, length: nsText.length)
         var result: [String] = []
-        byteLevelPreTokenizeRegex.enumerateMatches(in: text, range: fullRange) { match, _, _ in
-            guard let match else { return }
-            let token = nsText.substring(with: match.range)
+        enumerateRegexTokens(in: text, with: byteLevelPreTokenizeRegex) { token in
             for byte in token.utf8 {
                 result.append(Self.hexaEncoderTable[Int(byte)])
             }

--- a/Sources/Tokenizers/ByteEncoder.swift
+++ b/Sources/Tokenizers/ByteEncoder.swift
@@ -284,19 +284,3 @@ let byteEncoderTable: [String] = {
     }
     return arr
 }()
-
-/// Pre-compiled GPT-2 / Llama / Qwen / Gemma byte-level pre-tokenization regex.
-///
-/// The same pattern is used by ``BPETokenizer/byteEncode(text:)``,
-/// ``BPETokenizer/hexaEncode(text:)`` and ``ByteLevelPreTokenizer/preTokenize(text:options:)``.
-/// Foundation's `String.range(of:options:.regularExpression)` re-parses the pattern on every
-/// call, so caching a single `NSRegularExpression` removes the dominant cost of
-/// short-input `encode` and lets us iterate matches via `enumerateMatches` without
-/// allocating an intermediate range array.
-let byteLevelPreTokenizeRegex: NSRegularExpression = {
-    let pattern = #"'s|'t|'re|'ve|'m|'ll|'d| ?\p{L}+| ?\p{N}+| ?[^\s\p{L}\p{N}]+|\s+(?!\S)|\s+"#
-    // The pattern is a compile-time constant and has been used in production for
-    // years; treating compilation failure as a programmer error matches every
-    // other in-tree regex.
-    return try! NSRegularExpression(pattern: pattern)
-}()

--- a/Sources/Tokenizers/ByteEncoder.swift
+++ b/Sources/Tokenizers/ByteEncoder.swift
@@ -270,3 +270,33 @@ let byteEncoder: [UTF8.CodeUnit: String] = [
 let byteDecoder = byteEncoder.reduce(into: [String: UTF8.CodeUnit]()) { result, element in
     result[element.value] = element.key
 }
+
+/// Fixed-size byte → unicode-character lookup, derived from ``byteEncoder``.
+///
+/// On the byte-level pre-tokenization hot path every input byte is encoded
+/// via this map, and a `[UInt8: String]` dictionary lookup costs roughly an
+/// order of magnitude more than indexing into a contiguous array. The byte
+/// alphabet covers the full 0...255 range, so a 256-element array is dense.
+let byteEncoderTable: [String] = {
+    var arr = [String](repeating: "", count: 256)
+    for (byte, str) in byteEncoder {
+        arr[Int(byte)] = str
+    }
+    return arr
+}()
+
+/// Pre-compiled GPT-2 / Llama / Qwen / Gemma byte-level pre-tokenization regex.
+///
+/// The same pattern is used by ``BPETokenizer/byteEncode(text:)``,
+/// ``BPETokenizer/hexaEncode(text:)`` and ``ByteLevelPreTokenizer/preTokenize(text:options:)``.
+/// Foundation's `String.range(of:options:.regularExpression)` re-parses the pattern on every
+/// call, so caching a single `NSRegularExpression` removes the dominant cost of
+/// short-input `encode` and lets us iterate matches via `enumerateMatches` without
+/// allocating an intermediate range array.
+let byteLevelPreTokenizeRegex: NSRegularExpression = {
+    let pattern = #"'s|'t|'re|'ve|'m|'ll|'d| ?\p{L}+| ?\p{N}+| ?[^\s\p{L}\p{N}]+|\s+(?!\S)|\s+"#
+    // The pattern is a compile-time constant and has been used in production for
+    // years; treating compilation failure as a programmer error matches every
+    // other in-tree regex.
+    return try! NSRegularExpression(pattern: pattern)
+}()

--- a/Sources/Tokenizers/PreTokenizer.swift
+++ b/Sources/Tokenizers/PreTokenizer.swift
@@ -220,6 +220,38 @@ class MetaspacePreTokenizer: PreTokenizer {
     }
 }
 
+/// Pre-compiled GPT-2 / Llama / Qwen / Gemma byte-level pre-tokenization regex.
+///
+/// The same pattern is used by ``BPETokenizer/byteEncode(text:)``,
+/// ``BPETokenizer/hexaEncode(text:)`` and ``ByteLevelPreTokenizer/preTokenize(text:options:)``.
+/// Foundation's `String.range(of:options:.regularExpression)` re-parses the pattern on every
+/// call, so caching a single `NSRegularExpression` removes the dominant cost of
+/// short-input `encode` and lets us iterate matches via `enumerateMatches` without
+/// allocating an intermediate range array.
+let byteLevelPreTokenizeRegex: NSRegularExpression = {
+    let pattern = #"'s|'t|'re|'ve|'m|'ll|'d| ?\p{L}+| ?\p{N}+| ?[^\s\p{L}\p{N}]+|\s+(?!\S)|\s+"#
+    // The pattern is a compile-time constant and has been used in production for
+    // years; treating compilation failure as a programmer error matches every
+    // other in-tree regex.
+    return try! NSRegularExpression(pattern: pattern)
+}()
+
+/// Apply `regex` to `text` and call `body` once per match with the matched
+/// substring. Wraps the boilerplate of bridging through `NSString` /
+/// `NSRange` / `enumerateMatches` so call sites only express the per-token
+/// logic. Used by the byte-level pre-tokenizer and by `BPETokenizer`'s
+/// byte / hex encode helpers.
+func enumerateRegexTokens(
+    in text: String, with regex: NSRegularExpression, _ body: (String) -> Void
+) {
+    let nsText = text as NSString
+    let fullRange = NSRange(location: 0, length: nsText.length)
+    regex.enumerateMatches(in: text, range: fullRange) { match, _, _ in
+        guard let match else { return }
+        body(nsText.substring(with: match.range))
+    }
+}
+
 class ByteLevelPreTokenizer: PreTokenizer {
     let addPrefixSpace: Bool
     let trimOffsets: Bool
@@ -231,9 +263,7 @@ class ByteLevelPreTokenizer: PreTokenizer {
         useRegex = config.useRegex.boolean(or: true)
     }
 
-    /// Byte-level encode a single token (no pre-tokenization split). Hot inner
-    /// loop: indexes the cached 256-entry table once per UTF-8 byte and appends
-    /// directly into a single output string.
+    /// Byte-level encode a single token (no pre-tokenization split).
     private func byteEncodeToken(_ token: String) -> String {
         var encoded = ""
         encoded.reserveCapacity(token.utf8.count)
@@ -249,16 +279,11 @@ class ByteLevelPreTokenizer: PreTokenizer {
             return [byteEncodeToken(token)]
         }
 
-        let nsText = text as NSString
-        let fullRange = NSRange(location: 0, length: nsText.length)
         var result: [String] = []
-        byteLevelPreTokenizeRegex.enumerateMatches(in: text, range: fullRange) { match, _, _ in
-            guard let match else { return }
-            var token = nsText.substring(with: match.range)
-            if self.addPrefixSpace, !token.hasPrefix(" ") {
-                token = " " + token
-            }
-            result.append(self.byteEncodeToken(token))
+        enumerateRegexTokens(in: text, with: byteLevelPreTokenizeRegex) { token in
+            let prefixed =
+                (self.addPrefixSpace && !token.hasPrefix(" ")) ? " " + token : token
+            result.append(self.byteEncodeToken(prefixed))
         }
         return result
     }

--- a/Sources/Tokenizers/PreTokenizer.swift
+++ b/Sources/Tokenizers/PreTokenizer.swift
@@ -224,7 +224,6 @@ class ByteLevelPreTokenizer: PreTokenizer {
     let addPrefixSpace: Bool
     let trimOffsets: Bool
     let useRegex: Bool
-    let RE = #"'s|'t|'re|'ve|'m|'ll|'d| ?\p{L}+| ?\p{N}+| ?[^\s\p{L}\p{N}]+|\s+(?!\S)|\s+"#
 
     required init(config: Config) {
         addPrefixSpace = config.addPrefixSpace.boolean(or: false)
@@ -232,17 +231,36 @@ class ByteLevelPreTokenizer: PreTokenizer {
         useRegex = config.useRegex.boolean(or: true)
     }
 
-    func preTokenize(text: String, options: PreTokenizerOptions = [.firstSection]) -> [String] {
-        // Split on whitespace and punctuation
-        let tokens = useRegex ? text.ranges(of: RE).map { String(text[$0]) } : [text]
-        return tokens.map { token in
-            if addPrefixSpace, !token.hasPrefix(" ") {
-                return " " + token
-            }
-            return token
-        }.map { token in
-            Array(token.utf8).map { byteEncoder[$0]! }.joined()
+    /// Byte-level encode a single token (no pre-tokenization split). Hot inner
+    /// loop: indexes the cached 256-entry table once per UTF-8 byte and appends
+    /// directly into a single output string.
+    private func byteEncodeToken(_ token: String) -> String {
+        var encoded = ""
+        encoded.reserveCapacity(token.utf8.count)
+        for byte in token.utf8 {
+            encoded.append(byteEncoderTable[Int(byte)])
         }
+        return encoded
+    }
+
+    func preTokenize(text: String, options: PreTokenizerOptions = [.firstSection]) -> [String] {
+        guard useRegex else {
+            let token = (addPrefixSpace && !text.hasPrefix(" ")) ? " " + text : text
+            return [byteEncodeToken(token)]
+        }
+
+        let nsText = text as NSString
+        let fullRange = NSRange(location: 0, length: nsText.length)
+        var result: [String] = []
+        byteLevelPreTokenizeRegex.enumerateMatches(in: text, range: fullRange) { match, _, _ in
+            guard let match else { return }
+            var token = nsText.substring(with: match.range)
+            if self.addPrefixSpace, !token.hasPrefix(" ") {
+                token = " " + token
+            }
+            result.append(self.byteEncodeToken(token))
+        }
+        return result
     }
 }
 

--- a/Sources/Tokenizers/PreTokenizer.swift
+++ b/Sources/Tokenizers/PreTokenizer.swift
@@ -246,9 +246,11 @@ func enumerateRegexTokens(
 ) {
     let nsText = text as NSString
     let fullRange = NSRange(location: 0, length: nsText.length)
-    regex.enumerateMatches(in: text, range: fullRange) { match, _, _ in
-        guard let match else { return }
-        body(nsText.substring(with: match.range))
+    withoutActuallyEscaping(body) { escapableBody in
+        regex.enumerateMatches(in: text, range: fullRange) { match, _, _ in
+            guard let match else { return }
+            escapableBody(nsText.substring(with: match.range))
+        }
     }
 }
 

--- a/Tests/Benchmarks/BPEPreTokenizeBenchmarkTests.swift
+++ b/Tests/Benchmarks/BPEPreTokenizeBenchmarkTests.swift
@@ -38,27 +38,27 @@ struct BPEPreTokenizeBenchmarkTests {
         shortText = "Explain the BPE tokenization algorithm in three short bullet points."
 
         let para = """
-        Byte-pair encoding (BPE) is a tokenization algorithm originally proposed for data \
-        compression by Philip Gage in 1994. It was later adapted for use in neural machine \
-        translation by Sennrich, Haddow, and Birch in 2015, and is now the dominant \
-        sub-word tokenization scheme for modern large language models including the GPT, \
-        Llama, Qwen, and Mistral families. The algorithm operates by iteratively replacing \
-        the most frequent adjacent pair of bytes in a corpus with a new symbol, building up \
-        a vocabulary of merges that compactly represents both common words and rare strings.
-        """
+            Byte-pair encoding (BPE) is a tokenization algorithm originally proposed for data \
+            compression by Philip Gage in 1994. It was later adapted for use in neural machine \
+            translation by Sennrich, Haddow, and Birch in 2015, and is now the dominant \
+            sub-word tokenization scheme for modern large language models including the GPT, \
+            Llama, Qwen, and Mistral families. The algorithm operates by iteratively replacing \
+            the most frequent adjacent pair of bytes in a corpus with a new symbol, building up \
+            a vocabulary of merges that compactly represents both common words and rare strings.
+            """
         mediumText = String(repeating: para + "\n\n", count: 2)
         longText = String(repeating: para + "\n\n", count: 20)
 
         codeText = """
-        public final class GPT2BytePairEncoderConfiguration: Codable, Sendable {
-            public let vocabularyIdentifierToTokenStringMap: [Int: String]
-            public let bytePairMergeRanksByPairOfStrings: [BytePair: Int]
-            public let unknownTokenIdentifierForOutOfVocabularyByteSequences: Int?
-            public let beginningOfSequenceSpecialTokenIdentifier: Int?
-            public let endOfSequenceSpecialTokenIdentifier: Int?
-            public let shouldFuseConsecutiveUnknownTokenSequencesIntoASingleUnknownToken: Bool
-        }
-        """
+            public final class GPT2BytePairEncoderConfiguration: Codable, Sendable {
+                public let vocabularyIdentifierToTokenStringMap: [Int: String]
+                public let bytePairMergeRanksByPairOfStrings: [BytePair: Int]
+                public let unknownTokenIdentifierForOutOfVocabularyByteSequences: Int?
+                public let beginningOfSequenceSpecialTokenIdentifier: Int?
+                public let endOfSequenceSpecialTokenIdentifier: Int?
+                public let shouldFuseConsecutiveUnknownTokenSequencesIntoASingleUnknownToken: Bool
+            }
+            """
     }
 
     // MARK: - Measurement helpers

--- a/Tests/Benchmarks/BPEPreTokenizeBenchmarkTests.swift
+++ b/Tests/Benchmarks/BPEPreTokenizeBenchmarkTests.swift
@@ -1,0 +1,195 @@
+//
+//  BPEPreTokenizeBenchmarkTests.swift
+//  swift-transformers
+//
+//  Benchmarks for the byte-level pre-tokenization hot path
+//  (`ByteLevelPreTokenizer.preTokenize`, `BPETokenizer.byteEncode` /
+//  `hexaEncode`). Run with `RUN_BENCHMARKS=1`.
+//
+
+import Dispatch
+import Foundation
+import Hub
+import Testing
+
+@testable import Tokenizers
+
+@Suite(.serialized, .enabled(if: ProcessInfo.processInfo.environment["RUN_BENCHMARKS"] == "1"))
+struct BPEPreTokenizeBenchmarkTests {
+    /// Realistic Qwen3 BPE (~152K merges); same model used by the BPE merge
+    /// inner-loop benchmark, so `encode` numbers are directly comparable.
+    static let modelId = "mlx-community/Qwen3-0.6B-Base-DQ5"
+
+    let tokenizer: Tokenizer
+    let shortText: String
+    let mediumText: String
+    let longText: String
+    let codeText: String
+
+    init() async throws {
+        let hubApi = HubApi()
+        let repo = Hub.Repo(id: Self.modelId)
+        let modelFolder = try await hubApi.snapshot(from: repo, matching: ["tokenizer.json", "tokenizer_config.json"])
+        let offlineHubApi = HubApi(useOfflineMode: true)
+        tokenizer = try await AutoTokenizer.from(modelFolder: modelFolder, hubApi: offlineHubApi)
+
+        // Short prompt — typical chat turn (~70 chars). This is the regime
+        // where regex re-compilation dominates encode time.
+        shortText = "Explain the BPE tokenization algorithm in three short bullet points."
+
+        let para = """
+        Byte-pair encoding (BPE) is a tokenization algorithm originally proposed for data \
+        compression by Philip Gage in 1994. It was later adapted for use in neural machine \
+        translation by Sennrich, Haddow, and Birch in 2015, and is now the dominant \
+        sub-word tokenization scheme for modern large language models including the GPT, \
+        Llama, Qwen, and Mistral families. The algorithm operates by iteratively replacing \
+        the most frequent adjacent pair of bytes in a corpus with a new symbol, building up \
+        a vocabulary of merges that compactly represents both common words and rare strings.
+        """
+        mediumText = String(repeating: para + "\n\n", count: 2)
+        longText = String(repeating: para + "\n\n", count: 20)
+
+        codeText = """
+        public final class GPT2BytePairEncoderConfiguration: Codable, Sendable {
+            public let vocabularyIdentifierToTokenStringMap: [Int: String]
+            public let bytePairMergeRanksByPairOfStrings: [BytePair: Int]
+            public let unknownTokenIdentifierForOutOfVocabularyByteSequences: Int?
+            public let beginningOfSequenceSpecialTokenIdentifier: Int?
+            public let endOfSequenceSpecialTokenIdentifier: Int?
+            public let shouldFuseConsecutiveUnknownTokenSequencesIntoASingleUnknownToken: Bool
+        }
+        """
+    }
+
+    // MARK: - Measurement helpers
+
+    struct Stats {
+        let mean: Double
+        let stdDev: Double
+        let p50: Double
+        let p95: Double
+        let min: Double
+        let max: Double
+
+        var formatted: String {
+            String(format: "%7.3f ms (± %5.3f, p50 %6.3f, p95 %6.3f)", mean, stdDev, p50, p95)
+        }
+    }
+
+    private static func stats(_ times: [Double]) -> Stats {
+        let sorted = times.sorted()
+        let mean = sorted.reduce(0, +) / Double(sorted.count)
+        let variance = sorted.map { ($0 - mean) * ($0 - mean) }.reduce(0, +) / Double(sorted.count)
+        let stdDev = sqrt(variance)
+        let p50 = sorted[sorted.count / 2]
+        let p95 = sorted[min(sorted.count - 1, Int(Double(sorted.count) * 0.95))]
+        return Stats(mean: mean, stdDev: stdDev, p50: p50, p95: p95, min: sorted.first ?? 0, max: sorted.last ?? 0)
+    }
+
+    private static func measure(label: String, iterations: Int, warmup: Int = 3, _ block: () -> Void) -> Stats {
+        for _ in 0..<warmup { block() }
+        var times: [Double] = []
+        times.reserveCapacity(iterations)
+        for _ in 0..<iterations {
+            let start = DispatchTime.now()
+            block()
+            let end = DispatchTime.now()
+            times.append(Double(end.uptimeNanoseconds - start.uptimeNanoseconds) / 1_000_000)
+        }
+        let s = stats(times)
+        print("  \(label.padding(toLength: 26, withPad: " ", startingAt: 0)) \(s.formatted)")
+        return s
+    }
+
+    // MARK: - Benchmarks
+
+    /// Direct micro-benchmark of `ByteLevelPreTokenizer.preTokenize`. This
+    /// isolates the regex + byte-encoder cost from BPE merging and from
+    /// tokenizer-config loading, so before/after numbers are stable across
+    /// models that share the GPT-2 byte-level pre-tokenizer.
+    @Test("ByteLevelPreTokenizer micro-benchmark")
+    func byteLevelPreTokenizerMicro() {
+        let preTokenizer = ByteLevelPreTokenizer(config: Config([String: Config]()))
+        let preTokenizerWithPrefix = ByteLevelPreTokenizer(config: Config(["addPrefixSpace": true]))
+        let preTokenizerNoRegex = ByteLevelPreTokenizer(config: Config(["useRegex": false]))
+
+        print("\n=== ByteLevelPreTokenizer.preTokenize micro-benchmark ===")
+        let cases: [(String, String, Int)] = [
+            ("short (~70 B)", shortText, 5_000),
+            ("code (~600 B)", codeText, 1_000),
+            ("medium (~3 KB)", mediumText, 200),
+            ("long (~30 KB)", longText, 20),
+        ]
+        for (label, text, iterations) in cases {
+            _ = Self.measure(label: "default \(label)", iterations: iterations) {
+                _ = preTokenizer.preTokenize(text: text)
+            }
+        }
+        _ = Self.measure(label: "addPrefixSpace short", iterations: 5_000) {
+            _ = preTokenizerWithPrefix.preTokenize(text: shortText)
+        }
+        _ = Self.measure(label: "useRegex=false short", iterations: 5_000) {
+            _ = preTokenizerNoRegex.preTokenize(text: shortText)
+        }
+    }
+
+    /// Direct micro-benchmark of `BPETokenizer.byteEncode` / `hexaEncode`. These
+    /// two helpers share the byte-level regex + byte encoder lookups; this test
+    /// covers them on the same model used by the BPE merge benchmark so the
+    /// numbers can be added together to reason about end-to-end encode cost.
+    @Test("BPETokenizer.byteEncode / hexaEncode micro-benchmark")
+    func bpeTokenizerHelperMicro() throws {
+        guard let bpe = tokenizer as? PreTrainedTokenizer else {
+            Issue.record("Expected PreTrainedTokenizer")
+            return
+        }
+        guard let model = Mirror(reflecting: bpe).descendant("model") as? BPETokenizer else {
+            Issue.record("Expected BPETokenizer model")
+            return
+        }
+
+        print("\n=== BPETokenizer.byteEncode micro-benchmark ===")
+        _ = Self.measure(label: "byteEncode short", iterations: 5_000) {
+            _ = model.byteEncode(text: shortText)
+        }
+        _ = Self.measure(label: "byteEncode code", iterations: 1_000) {
+            _ = model.byteEncode(text: codeText)
+        }
+        _ = Self.measure(label: "byteEncode medium", iterations: 200) {
+            _ = model.byteEncode(text: mediumText)
+        }
+
+        print("\n=== BPETokenizer.hexaEncode micro-benchmark ===")
+        // hexaEncode is called once per unknown BPE chunk; benchmark per-call
+        // cost on a short identifier-style input.
+        let identifier = "supercalifragilisticexpialidocious"
+        _ = Self.measure(label: "hexaEncode word", iterations: 10_000) {
+            _ = model.hexaEncode(text: identifier)
+        }
+        _ = Self.measure(label: "hexaEncode short", iterations: 5_000) {
+            _ = model.hexaEncode(text: shortText)
+        }
+    }
+
+    /// End-to-end encode throughput. The pre-tokenize fast path benefits
+    /// short-input encoding the most (where regex compilation is the dominant
+    /// term), so short cases are weighted heavier.
+    @Test("BPE encode end-to-end throughput")
+    func encodeThroughput() {
+        print("\n=== BPE encode end-to-end (\(Self.modelId)) ===")
+        let cases: [(String, String, Int)] = [
+            ("short (~70 B)", shortText, 1_000),
+            ("code (~600 B)", codeText, 200),
+            ("medium (~3 KB)", mediumText, 50),
+            ("long (~30 KB)", longText, 10),
+        ]
+        for (label, text, iterations) in cases {
+            let bytes = text.utf8.count
+            let stats = Self.measure(label: label, iterations: iterations) {
+                _ = tokenizer.encode(text: text, addSpecialTokens: false)
+            }
+            let mbPerSec = (Double(bytes) / 1_048_576.0) / (stats.mean / 1_000.0)
+            print(String(format: "    → %.2f MB/s", mbPerSec))
+        }
+    }
+}

--- a/Tests/Benchmarks/BPEPreTokenizeBenchmarkTests.swift
+++ b/Tests/Benchmarks/BPEPreTokenizeBenchmarkTests.swift
@@ -7,7 +7,6 @@
 //  `hexaEncode`). Run with `RUN_BENCHMARKS=1`.
 //
 
-import Dispatch
 import Foundation
 import Hub
 import Testing
@@ -61,46 +60,6 @@ struct BPEPreTokenizeBenchmarkTests {
             """
     }
 
-    // MARK: - Measurement helpers
-
-    struct Stats {
-        let mean: Double
-        let stdDev: Double
-        let p50: Double
-        let p95: Double
-        let min: Double
-        let max: Double
-
-        var formatted: String {
-            String(format: "%7.3f ms (± %5.3f, p50 %6.3f, p95 %6.3f)", mean, stdDev, p50, p95)
-        }
-    }
-
-    private static func stats(_ times: [Double]) -> Stats {
-        let sorted = times.sorted()
-        let mean = sorted.reduce(0, +) / Double(sorted.count)
-        let variance = sorted.map { ($0 - mean) * ($0 - mean) }.reduce(0, +) / Double(sorted.count)
-        let stdDev = sqrt(variance)
-        let p50 = sorted[sorted.count / 2]
-        let p95 = sorted[min(sorted.count - 1, Int(Double(sorted.count) * 0.95))]
-        return Stats(mean: mean, stdDev: stdDev, p50: p50, p95: p95, min: sorted.first ?? 0, max: sorted.last ?? 0)
-    }
-
-    private static func measure(label: String, iterations: Int, warmup: Int = 3, _ block: () -> Void) -> Stats {
-        for _ in 0..<warmup { block() }
-        var times: [Double] = []
-        times.reserveCapacity(iterations)
-        for _ in 0..<iterations {
-            let start = DispatchTime.now()
-            block()
-            let end = DispatchTime.now()
-            times.append(Double(end.uptimeNanoseconds - start.uptimeNanoseconds) / 1_000_000)
-        }
-        let s = stats(times)
-        print("  \(label.padding(toLength: 26, withPad: " ", startingAt: 0)) \(s.formatted)")
-        return s
-    }
-
     // MARK: - Benchmarks
 
     /// Direct micro-benchmark of `ByteLevelPreTokenizer.preTokenize`. This
@@ -121,14 +80,14 @@ struct BPEPreTokenizeBenchmarkTests {
             ("long (~30 KB)", longText, 20),
         ]
         for (label, text, iterations) in cases {
-            _ = Self.measure(label: "default \(label)", iterations: iterations) {
+            _ = benchmarkMeasure(label: "default \(label)", iterations: iterations) {
                 _ = preTokenizer.preTokenize(text: text)
             }
         }
-        _ = Self.measure(label: "addPrefixSpace short", iterations: 5_000) {
+        _ = benchmarkMeasure(label: "addPrefixSpace short", iterations: 5_000) {
             _ = preTokenizerWithPrefix.preTokenize(text: shortText)
         }
-        _ = Self.measure(label: "useRegex=false short", iterations: 5_000) {
+        _ = benchmarkMeasure(label: "useRegex=false short", iterations: 5_000) {
             _ = preTokenizerNoRegex.preTokenize(text: shortText)
         }
     }
@@ -149,13 +108,13 @@ struct BPEPreTokenizeBenchmarkTests {
         }
 
         print("\n=== BPETokenizer.byteEncode micro-benchmark ===")
-        _ = Self.measure(label: "byteEncode short", iterations: 5_000) {
+        _ = benchmarkMeasure(label: "byteEncode short", iterations: 5_000) {
             _ = model.byteEncode(text: shortText)
         }
-        _ = Self.measure(label: "byteEncode code", iterations: 1_000) {
+        _ = benchmarkMeasure(label: "byteEncode code", iterations: 1_000) {
             _ = model.byteEncode(text: codeText)
         }
-        _ = Self.measure(label: "byteEncode medium", iterations: 200) {
+        _ = benchmarkMeasure(label: "byteEncode medium", iterations: 200) {
             _ = model.byteEncode(text: mediumText)
         }
 
@@ -163,10 +122,10 @@ struct BPEPreTokenizeBenchmarkTests {
         // hexaEncode is called once per unknown BPE chunk; benchmark per-call
         // cost on a short identifier-style input.
         let identifier = "supercalifragilisticexpialidocious"
-        _ = Self.measure(label: "hexaEncode word", iterations: 10_000) {
+        _ = benchmarkMeasure(label: "hexaEncode word", iterations: 10_000) {
             _ = model.hexaEncode(text: identifier)
         }
-        _ = Self.measure(label: "hexaEncode short", iterations: 5_000) {
+        _ = benchmarkMeasure(label: "hexaEncode short", iterations: 5_000) {
             _ = model.hexaEncode(text: shortText)
         }
     }
@@ -185,7 +144,7 @@ struct BPEPreTokenizeBenchmarkTests {
         ]
         for (label, text, iterations) in cases {
             let bytes = text.utf8.count
-            let stats = Self.measure(label: label, iterations: iterations) {
+            let stats = benchmarkMeasure(label: label, iterations: iterations) {
                 _ = tokenizer.encode(text: text, addSpecialTokens: false)
             }
             let mbPerSec = (Double(bytes) / 1_048_576.0) / (stats.mean / 1_000.0)

--- a/Tests/Benchmarks/BenchmarkSupport.swift
+++ b/Tests/Benchmarks/BenchmarkSupport.swift
@@ -1,0 +1,61 @@
+//
+//  BenchmarkSupport.swift
+//  swift-transformers
+//
+//  Shared benchmark helpers for the `Tests/Benchmarks` suite. Each benchmark
+//  file gates its `@Suite` on `RUN_BENCHMARKS=1`, so these helpers are only
+//  exercised when explicitly opted in.
+//
+
+import Dispatch
+import Foundation
+
+/// Summary statistics for a sequence of per-iteration benchmark times (ms).
+struct BenchmarkStats {
+    let mean: Double
+    let stdDev: Double
+    let p50: Double
+    let p95: Double
+    let min: Double
+    let max: Double
+
+    var formatted: String {
+        String(format: "%7.3f ms (± %5.3f, p50 %6.3f, p95 %6.3f)", mean, stdDev, p50, p95)
+    }
+}
+
+/// Compute mean / stddev / p50 / p95 from a list of per-iteration times.
+func benchmarkStats(_ times: [Double]) -> BenchmarkStats {
+    let sorted = times.sorted()
+    let mean = sorted.reduce(0, +) / Double(sorted.count)
+    let variance = sorted.map { ($0 - mean) * ($0 - mean) }.reduce(0, +) / Double(sorted.count)
+    let stdDev = variance.squareRoot()
+    let p50 = sorted[sorted.count / 2]
+    let p95 = sorted[Swift.min(sorted.count - 1, Int(Double(sorted.count) * 0.95))]
+    return BenchmarkStats(
+        mean: mean, stdDev: stdDev, p50: p50, p95: p95,
+        min: sorted.first ?? 0, max: sorted.last ?? 0
+    )
+}
+
+/// Run `block` `iterations` times after `warmup` warm-up runs and return the
+/// aggregated stats. Each iteration's wall-clock time is captured via
+/// `DispatchTime.now()`. The label is printed alongside the stats so a single
+/// benchmark suite can group multiple measurements in its output.
+@discardableResult
+func benchmarkMeasure(
+    label: String, iterations: Int, warmup: Int = 3, _ block: () -> Void
+) -> BenchmarkStats {
+    for _ in 0..<warmup { block() }
+    var times: [Double] = []
+    times.reserveCapacity(iterations)
+    for _ in 0..<iterations {
+        let start = DispatchTime.now()
+        block()
+        let end = DispatchTime.now()
+        times.append(Double(end.uptimeNanoseconds - start.uptimeNanoseconds) / 1_000_000)
+    }
+    let s = benchmarkStats(times)
+    print("  \(label.padding(toLength: 26, withPad: " ", startingAt: 0)) \(s.formatted)")
+    return s
+}

--- a/Tests/TokenizersTests/ByteEncoderTests.swift
+++ b/Tests/TokenizersTests/ByteEncoderTests.swift
@@ -1,0 +1,56 @@
+//
+//  ByteEncoderTests.swift
+//
+//  Defensive coverage for the byte-level encoder data tables that the BPE
+//  hot path indexes into. The lookup is array-indexed (no fallback), so a
+//  silently dropped entry would surface as an empty string in tokenizer
+//  output rather than a crash; these tests pin the invariants.
+//
+
+import Foundation
+import Testing
+
+@testable import Tokenizers
+
+@Suite("Byte encoder tables")
+struct ByteEncoderTests {
+    /// `byteEncoderTable` is indexed directly by every input byte on the BPE
+    /// pre-tokenize hot path, so the array must be exactly 256 long and every
+    /// entry must be a non-empty mapping. Anything missing would silently emit
+    /// `""` for that byte during encode.
+    @Test("byteEncoderTable is dense over 0..<256")
+    func byteEncoderTableIsDense() {
+        #expect(byteEncoderTable.count == 256)
+        for byte in 0..<256 {
+            #expect(
+                !byteEncoderTable[byte].isEmpty,
+                "byteEncoderTable[\(byte)] is empty — the canonical GPT-2 byte-level alphabet covers the full 0..<256 range"
+            )
+        }
+    }
+
+    /// The fast-path `byteEncoderTable` must agree with the canonical
+    /// `byteEncoder` dictionary for every byte. This guards against drift if
+    /// either definition is edited in isolation.
+    @Test("byteEncoderTable agrees with byteEncoder dictionary")
+    func byteEncoderTableMatchesDictionary() {
+        #expect(byteEncoder.count == 256)
+        for (byte, expected) in byteEncoder {
+            #expect(byteEncoderTable[Int(byte)] == expected)
+        }
+    }
+
+    /// `byteEncoder` and `byteDecoder` must be exact inverses; a regression on
+    /// either side breaks BPE round-trips. The asserts below would already
+    /// surface as decode errors in real-world tokenization, but the explicit
+    /// check makes the failure mode obvious.
+    @Test("byteEncoder and byteDecoder are inverse mappings")
+    func byteEncoderDecoderRoundTrip() {
+        for (byte, str) in byteEncoder {
+            #expect(byteDecoder[str] == byte)
+        }
+        for (str, byte) in byteDecoder {
+            #expect(byteEncoder[byte] == str)
+        }
+    }
+}


### PR DESCRIPTION
## Summary

`ByteLevelPreTokenizer.preTokenize` is the byte-level pre-tokenization hot path
for every BPE-based tokenizer (GPT-2, Llama, Qwen, Gemma, Mistral, Whisper, ...).
On every encode call it pays three avoidable costs that this PR removes.

`BPETokenizer.byteEncode` and `BPETokenizer.hexaEncode` carry the same pattern
and are migrated to the same shared infrastructure, so the speedup applies
uniformly across the byte-level helpers.

## What changes

1. **Pre-compile the GPT-2 byte-level pre-tokenize regex once.** The pattern
   was previously passed by string to `String.range(of:options:.regularExpression)`,
   which re-parses the pattern on every match step. A single
   `NSRegularExpression` is now created at file scope in `ByteEncoder.swift`
   and shared by `ByteLevelPreTokenizer` and `BPETokenizer`. Iteration uses
   `enumerateMatches`, so we also avoid allocating an intermediate
   `[Range<Index>]`. `NSRegularExpression` is documented as thread-safe for
   `enumerateMatches` / `matches`, so no locking is required.
2. **Replace the byte → unicode-character dictionary with a fixed-size array.**
   `byteEncoder` is a `[UTF8.CodeUnit: String]`; every input byte costs a
   hash lookup. The alphabet covers the full `0..<256` range, so a 256-entry
   `[String]` (`byteEncoderTable`) is dense and lets the inner loop replace
   the dictionary lookup with an array index.
3. **Drop intermediate allocations in the inner loop.** The previous form
   materialised an `Array(token.utf8)` and a `compactMap` before `joined()`.
   Appending the table entries directly into a single output `String` (with
   reserved capacity) drops both intermediates.
4. **Cache `<0x%02X>` strings in `hexaEncode`.** The byte fallback formatter
   was called once per byte; a 256-entry `hexaEncoderTable` removes the
   per-call `String(format:)` overhead.

## Verification

`swift test --filter TokenizersTests` — all **107 existing tokenizer tests**
pass, including the 18 ``Pre-Tokenizer Tests`` (3 ``ByteLevelPreTokenizer``
configurations covering the default / ``addPrefixSpace`` / ``useRegex=false``
code paths).

A new benchmark suite ``Tests/Benchmarks/BPEPreTokenizeBenchmarkTests.swift``
is gated on ``RUN_BENCHMARKS=1`` and reuses the same Qwen3-0.6B-Base BPE model
used by the existing JSON parser benchmark, so the two suites can be reasoned
about together.

### Numbers (Apple M-series, Swift release, mean of `iterations` runs after 3 warmup runs)

`ByteLevelPreTokenizer.preTokenize` micro-benchmark — the direct hot path:

| input | iters | before (mean / p50) | after (mean / p50) | p50 speedup |
|---|---:|---:|---:|---:|
| short (~70 B) | 5,000 | 0.034 / 0.026 ms | 0.004 / 0.004 ms | **6.5x** |
| code (~600 B) | 1,000 | 0.234 / 0.165 ms | 0.025 / 0.025 ms | **6.6x** |
| medium (~3 KB) | 200 | 0.549 / 0.456 ms | 0.062 / 0.062 ms | **7.4x** |
| long (~30 KB) | 20 | 6.488 / 4.750 ms | 0.606 / 0.607 ms | **7.8x** |
| addPrefixSpace short | 5,000 | 0.033 / 0.025 ms | 0.004 / 0.004 ms | **6.3x** |
| useRegex=false short | 5,000 | 0.002 / 0.002 ms | 0.001 / 0.001 ms | 2.0x |

`BPETokenizer.byteEncode` / `hexaEncode` micro-benchmark — the same shared
infrastructure benefits both helpers:

| function / input | iters | before (mean / p50) | after (mean / p50) | p50 speedup |
|---|---:|---:|---:|---:|
| `byteEncode` short (~70 B) | 5,000 | 0.029 / 0.027 ms | 0.005 / 0.004 ms | **6.8x** |
| `byteEncode` code (~600 B) | 1,000 | 0.189 / 0.169 ms | 0.024 / 0.024 ms | **7.0x** |
| `byteEncode` medium (~3 KB) | 200 | 0.519 / 0.479 ms | 0.060 / 0.060 ms | **8.0x** |
| `hexaEncode` long word | 10,000 | 0.030 / 0.029 ms | 0.001 / 0.001 ms | **29x** |
| `hexaEncode` short (~70 B) | 5,000 | 0.082 / 0.069 ms | 0.004 / 0.004 ms | **17x** |

(`hexaEncode` benefits more because the cached `<0x%02X>` table replaces a
``String(format:)`` call on every byte.)

End-to-end `tokenizer.encode(text:)` on Qwen3-0.6B-Base (152K-merge BPE):

| input | iters | before (p50) | after (p50) |
|---|---:|---:|---:|
| short (~70 B) | 1,000 | 0.149 ms | 0.149 ms |
| code (~600 B) | 200 | 2.461 ms | 2.420 ms |
| medium (~3 KB) | 50 | 2.560 ms | 2.661 ms |
| long (~30 KB) | 10 | 28.123 ms | 27.545 ms |

End-to-end is dominated by the `BPETokenizer.bpe(token:)` merge inner loop on
this model (152K merges), which is what PR #346 targets. The two PRs are
complementary: this one cuts the pre-tokenize phase, that one cuts the merge
phase. End-to-end gains compose if both land.

### Reproduction

```
git fetch origin
git checkout main
git checkout -b before
swift test -c release --filter TokenizersTests          # 107 tests pass
RUN_BENCHMARKS=1 swift test -c release \
  --filter BPEPreTokenizeBenchmarkTests                 # before numbers

git checkout perf/bpe-pretokenize-fast-path
swift test -c release --filter TokenizersTests          # 107 tests still pass
RUN_BENCHMARKS=1 swift test -c release \
  --filter BPEPreTokenizeBenchmarkTests                 # after numbers
```

The benchmark suite is opt-in (gated on `RUN_BENCHMARKS=1`), matching the
existing convention in ``Tests/Benchmarks/JSONParserBenchmarkTests.swift``.