### PR TITLE
Cache pre-tokenize regex for Bert/whitespace/punctuation/digits

### DIFF
--- a/Sources/Tokenizers/PreTokenizer.swift
+++ b/Sources/Tokenizers/PreTokenizer.swift
@@ -333,7 +333,6 @@ class PunctuationPreTokenizer: PreTokenizer {
     required init(config: Config) {}
 
     func preTokenize(text: String, options: PreTokenizerOptions = [.firstSection]) -> [String] {
-        // Ref: https://github.com/xenova/transformers.js/blob/27920d84831e323275b38f0b5186644b7936e1a2/src/tokenizers.js#L1138
         splitMatches(in: text, with: punctuationPreTokenizeRegex)
     }
 }

--- a/Sources/Tokenizers/PreTokenizer.swift
+++ b/Sources/Tokenizers/PreTokenizer.swift
@@ -11,6 +11,58 @@ import Hub
 /// Character class used by punctuation-based pre-tokenizers.
 private let punctuationRegex = #"\p{P}\u0021-\u002F\u003A-\u0040\u005B-\u0060\u007B-\u007E"#
 
+/// Pre-compiled regex shared by ``BertPreTokenizer``.
+///
+/// Foundation's `String.range(of:options:.regularExpression)` re-parses the
+/// pattern on every call. Compiling once removes the dominant cost of
+/// per-call pre-tokenization for short inputs.
+private let bertPreTokenizeRegex: NSRegularExpression = {
+    let pattern = "[^\\s\(punctuationRegex)]+|[\(punctuationRegex)]"
+    return try! NSRegularExpression(pattern: pattern)
+}()
+
+/// Pre-compiled regex shared by ``WhitespacePreTokenizer`` (also used for
+/// ``PreTokenizerType/WhitespaceSplit``).
+private let whitespacePreTokenizeRegex: NSRegularExpression = {
+    try! NSRegularExpression(pattern: #"\S+"#)
+}()
+
+/// Pre-compiled regex shared by ``PunctuationPreTokenizer``.
+private let punctuationPreTokenizeRegex: NSRegularExpression = {
+    let pattern = "[^\(punctuationRegex)]+|[\(punctuationRegex)]+"
+    return try! NSRegularExpression(pattern: pattern)
+}()
+
+/// Pre-compiled regex used by ``DigitsPreTokenizer`` when each digit should be
+/// emitted as its own token (`individualDigits == true`).
+private let digitsPreTokenizeIndividualRegex: NSRegularExpression = {
+    try! NSRegularExpression(pattern: "[^\\d]+|\\d")
+}()
+
+/// Pre-compiled regex used by ``DigitsPreTokenizer`` when consecutive digits
+/// should be grouped into a single token (`individualDigits == false`).
+private let digitsPreTokenizeGroupedRegex: NSRegularExpression = {
+    try! NSRegularExpression(pattern: "[^\\d]+|\\d+")
+}()
+
+/// Apply `regex` to `text` and return the substring of every match.
+///
+/// Equivalent to `text.ranges(of: pattern).map { String(text[$0]) }`, but
+/// uses `enumerateMatches` against an already-compiled regex and avoids the
+/// intermediate `[Range<String.Index>]` allocation. The bridge to `NSString`
+/// is cheap on `String` instances and lets `substring(with:)` slice on the
+/// UTF-16 ranges that `NSRegularExpression` returns.
+private func splitMatches(in text: String, with regex: NSRegularExpression) -> [String] {
+    let nsText = text as NSString
+    let fullRange = NSRange(location: 0, length: nsText.length)
+    var result: [String] = []
+    regex.enumerateMatches(in: text, range: fullRange) { match, _, _ in
+        guard let match else { return }
+        result.append(nsText.substring(with: match.range))
+    }
+    return result
+}
+
 /// Options that can be passed to pre-tokenization operations.
 public enum PreTokenizerOption: String {
     /// Indicates this is the first section of text being processed.
@@ -112,15 +164,11 @@ struct PreTokenizerFactory {
 }
 
 class BertPreTokenizer: PreTokenizer {
-    let re: String
-
-    required init(config: Config) {
-        // Ref: https://github.com/huggingface/transformers.js/blob/27920d84831e323275b38f0b5186644b7936e1a2/src/tokenizers.js#L1002
-        re = "[^\\s\(punctuationRegex)]+|[\(punctuationRegex)]"
-    }
+    // Ref: https://github.com/huggingface/transformers.js/blob/27920d84831e323275b38f0b5186644b7936e1a2/src/tokenizers.js#L1002
+    required init(config: Config) {}
 
     func preTokenize(text: String, options: PreTokenizerOptions = [.firstSection]) -> [String] {
-        text.ranges(of: re).map { String(text[$0]) }
+        splitMatches(in: text, with: bertPreTokenizeRegex)
     }
 }
 
@@ -140,14 +188,10 @@ class PreTokenizerSequence: PreTokenizer {
 }
 
 class WhitespacePreTokenizer: PreTokenizer {
-    let re: String
-
-    required init(config: Config) {
-        re = #"\S+"#
-    }
+    required init(config: Config) {}
 
     func preTokenize(text: String, options: PreTokenizerOptions = [.firstSection]) -> [String] {
-        text.ranges(of: re).map { String(text[$0]) }
+        splitMatches(in: text, with: whitespacePreTokenizeRegex)
     }
 }
 
@@ -292,28 +336,24 @@ class ByteLevelPreTokenizer: PreTokenizer {
 }
 
 class PunctuationPreTokenizer: PreTokenizer {
-    let re: String
-
-    required init(config: Config) {
-        re = "[^\(punctuationRegex)]+|[\(punctuationRegex)]+"
-    }
+    required init(config: Config) {}
 
     func preTokenize(text: String, options: PreTokenizerOptions = [.firstSection]) -> [String] {
         // Ref: https://github.com/xenova/transformers.js/blob/27920d84831e323275b38f0b5186644b7936e1a2/src/tokenizers.js#L1138
-        text.ranges(of: re).map { String(text[$0]) }
+        splitMatches(in: text, with: punctuationPreTokenizeRegex)
     }
 }
 
 class DigitsPreTokenizer: PreTokenizer {
-    let re: String
+    let regex: NSRegularExpression
 
     required init(config: Config) {
         let individualDigits = config.individualDigits.boolean(or: false)
-        re = "[^\\d]+|\\d\(individualDigits ? "" : "+")"
+        regex = individualDigits ? digitsPreTokenizeIndividualRegex : digitsPreTokenizeGroupedRegex
     }
 
     func preTokenize(text: String, options: PreTokenizerOptions = [.firstSection]) -> [String] {
-        text.ranges(of: re).map { String(text[$0]) }
+        splitMatches(in: text, with: regex)
     }
 }
 

--- a/Sources/Tokenizers/PreTokenizer.swift
+++ b/Sources/Tokenizers/PreTokenizer.swift
@@ -12,17 +12,12 @@ import Hub
 private let punctuationRegex = #"\p{P}\u0021-\u002F\u003A-\u0040\u005B-\u0060\u007B-\u007E"#
 
 /// Pre-compiled regex shared by ``BertPreTokenizer``.
-///
-/// Foundation's `String.range(of:options:.regularExpression)` re-parses the
-/// pattern on every call. Compiling once removes the dominant cost of
-/// per-call pre-tokenization for short inputs.
 private let bertPreTokenizeRegex: NSRegularExpression = {
     let pattern = "[^\\s\(punctuationRegex)]+|[\(punctuationRegex)]"
     return try! NSRegularExpression(pattern: pattern)
 }()
 
-/// Pre-compiled regex shared by ``WhitespacePreTokenizer`` (also used for
-/// ``PreTokenizerType/WhitespaceSplit``).
+/// Pre-compiled regex shared by ``WhitespacePreTokenizer``, ``PreTokenizerType/WhitespaceSplit``.
 private let whitespacePreTokenizeRegex: NSRegularExpression = {
     try! NSRegularExpression(pattern: #"\S+"#)
 }()
@@ -164,7 +159,6 @@ struct PreTokenizerFactory {
 }
 
 class BertPreTokenizer: PreTokenizer {
-    // Ref: https://github.com/huggingface/transformers.js/blob/27920d84831e323275b38f0b5186644b7936e1a2/src/tokenizers.js#L1002
     required init(config: Config) {}
 
     func preTokenize(text: String, options: PreTokenizerOptions = [.firstSection]) -> [String] {

--- a/Tests/Benchmarks/PreTokenizeBenchmarkTests.swift
+++ b/Tests/Benchmarks/PreTokenizeBenchmarkTests.swift
@@ -1,0 +1,181 @@
+//
+//  PreTokenizeBenchmarkTests.swift
+//  swift-transformers
+//
+//  Benchmarks for the punctuation/whitespace/digits/Bert pre-tokenizers,
+//  which all sit on the same `text.ranges(of: re)` pattern as
+//  `ByteLevelPreTokenizer` did before the byte-level fast path landed.
+//  Run with `RUN_BENCHMARKS=1`.
+//
+
+import Dispatch
+import Foundation
+import Hub
+import Testing
+
+@testable import Tokenizers
+
+@Suite(.serialized, .enabled(if: ProcessInfo.processInfo.environment["RUN_BENCHMARKS"] == "1"))
+struct PreTokenizeBenchmarkTests {
+    let shortText: String
+    let codeText: String
+    let mediumText: String
+    let longText: String
+    let numericText: String
+
+    init() {
+        // Short prompt — typical chat turn (~70 B). Regex re-compilation
+        // dominates per-call cost in this regime.
+        shortText = "Explain the BPE tokenization algorithm in three short bullet points."
+
+        let para = """
+        Byte-pair encoding (BPE) is a tokenization algorithm originally proposed for data \
+        compression by Philip Gage in 1994. It was later adapted for use in neural machine \
+        translation by Sennrich, Haddow, and Birch in 2015, and is now the dominant \
+        sub-word tokenization scheme for modern large language models including the GPT, \
+        Llama, Qwen, and Mistral families. The algorithm operates by iteratively replacing \
+        the most frequent adjacent pair of bytes in a corpus with a new symbol, building up \
+        a vocabulary of merges that compactly represents both common words and rare strings.
+        """
+        mediumText = String(repeating: para + "\n\n", count: 2)
+        longText = String(repeating: para + "\n\n", count: 20)
+
+        codeText = """
+        public final class GPT2BytePairEncoderConfiguration: Codable, Sendable {
+            public let vocabularyIdentifierToTokenStringMap: [Int: String]
+            public let bytePairMergeRanksByPairOfStrings: [BytePair: Int]
+            public let unknownTokenIdentifierForOutOfVocabularyByteSequences: Int?
+            public let beginningOfSequenceSpecialTokenIdentifier: Int?
+            public let endOfSequenceSpecialTokenIdentifier: Int?
+            public let shouldFuseConsecutiveUnknownTokenSequencesIntoASingleUnknownToken: Bool
+        }
+        """
+
+        // Numeric-heavy text exercises the digit-splitting branch.
+        numericText = """
+        Order #2024-001234 totals $1,299.99 plus 8.875% tax for a final amount of \
+        $1,415.36, paid 2026-04-30 at 14:32:07 UTC. Reference codes: A1B2-C3D4-E5F6, \
+        SKU 9876543210, account 4111-1111-1111-1111, phone +1-555-867-5309.
+        """
+    }
+
+    // MARK: - Measurement helpers
+
+    struct Stats {
+        let mean: Double
+        let stdDev: Double
+        let p50: Double
+        let p95: Double
+        let min: Double
+        let max: Double
+
+        var formatted: String {
+            String(format: "%7.3f ms (± %5.3f, p50 %6.3f, p95 %6.3f)", mean, stdDev, p50, p95)
+        }
+    }
+
+    private static func stats(_ times: [Double]) -> Stats {
+        let sorted = times.sorted()
+        let mean = sorted.reduce(0, +) / Double(sorted.count)
+        let variance = sorted.map { ($0 - mean) * ($0 - mean) }.reduce(0, +) / Double(sorted.count)
+        let stdDev = sqrt(variance)
+        let p50 = sorted[sorted.count / 2]
+        let p95 = sorted[min(sorted.count - 1, Int(Double(sorted.count) * 0.95))]
+        return Stats(mean: mean, stdDev: stdDev, p50: p50, p95: p95, min: sorted.first ?? 0, max: sorted.last ?? 0)
+    }
+
+    private static func measure(label: String, iterations: Int, warmup: Int = 3, _ block: () -> Void) -> Stats {
+        for _ in 0..<warmup { block() }
+        var times: [Double] = []
+        times.reserveCapacity(iterations)
+        for _ in 0..<iterations {
+            let start = DispatchTime.now()
+            block()
+            let end = DispatchTime.now()
+            times.append(Double(end.uptimeNanoseconds - start.uptimeNanoseconds) / 1_000_000)
+        }
+        let s = stats(times)
+        print("  \(label.padding(toLength: 26, withPad: " ", startingAt: 0)) \(s.formatted)")
+        return s
+    }
+
+    // MARK: - Benchmarks
+
+    @Test("BertPreTokenizer micro-benchmark")
+    func bertPreTokenizer() {
+        let preTokenizer = BertPreTokenizer(config: Config([String: Config]()))
+        print("\n=== BertPreTokenizer.preTokenize ===")
+        let cases: [(String, String, Int)] = [
+            ("short (~70 B)", shortText, 5_000),
+            ("code (~600 B)", codeText, 1_000),
+            ("medium (~3 KB)", mediumText, 200),
+            ("long (~30 KB)", longText, 20),
+        ]
+        for (label, text, iterations) in cases {
+            _ = Self.measure(label: label, iterations: iterations) {
+                _ = preTokenizer.preTokenize(text: text)
+            }
+        }
+    }
+
+    @Test("WhitespacePreTokenizer micro-benchmark")
+    func whitespacePreTokenizer() {
+        let preTokenizer = WhitespacePreTokenizer(config: Config([String: Config]()))
+        print("\n=== WhitespacePreTokenizer.preTokenize ===")
+        let cases: [(String, String, Int)] = [
+            ("short (~70 B)", shortText, 5_000),
+            ("code (~600 B)", codeText, 1_000),
+            ("medium (~3 KB)", mediumText, 200),
+            ("long (~30 KB)", longText, 20),
+        ]
+        for (label, text, iterations) in cases {
+            _ = Self.measure(label: label, iterations: iterations) {
+                _ = preTokenizer.preTokenize(text: text)
+            }
+        }
+    }
+
+    @Test("PunctuationPreTokenizer micro-benchmark")
+    func punctuationPreTokenizer() {
+        let preTokenizer = PunctuationPreTokenizer(config: Config([String: Config]()))
+        print("\n=== PunctuationPreTokenizer.preTokenize ===")
+        let cases: [(String, String, Int)] = [
+            ("short (~70 B)", shortText, 5_000),
+            ("code (~600 B)", codeText, 1_000),
+            ("medium (~3 KB)", mediumText, 200),
+            ("long (~30 KB)", longText, 20),
+        ]
+        for (label, text, iterations) in cases {
+            _ = Self.measure(label: label, iterations: iterations) {
+                _ = preTokenizer.preTokenize(text: text)
+            }
+        }
+    }
+
+    @Test("DigitsPreTokenizer micro-benchmark")
+    func digitsPreTokenizer() {
+        let groupedTokenizer = DigitsPreTokenizer(config: Config([String: Config]()))
+        let individualTokenizer = DigitsPreTokenizer(config: Config(["individualDigits": true]))
+
+        print("\n=== DigitsPreTokenizer.preTokenize (grouped) ===")
+        let cases: [(String, String, Int)] = [
+            ("numeric (~250 B)", numericText, 5_000),
+            ("short (~70 B)", shortText, 5_000),
+            ("code (~600 B)", codeText, 1_000),
+            ("medium (~3 KB)", mediumText, 200),
+            ("long (~30 KB)", longText, 20),
+        ]
+        for (label, text, iterations) in cases {
+            _ = Self.measure(label: label, iterations: iterations) {
+                _ = groupedTokenizer.preTokenize(text: text)
+            }
+        }
+
+        print("\n=== DigitsPreTokenizer.preTokenize (individual) ===")
+        for (label, text, iterations) in cases {
+            _ = Self.measure(label: label, iterations: iterations) {
+                _ = individualTokenizer.preTokenize(text: text)
+            }
+        }
+    }
+}

--- a/Tests/Benchmarks/PreTokenizeBenchmarkTests.swift
+++ b/Tests/Benchmarks/PreTokenizeBenchmarkTests.swift
@@ -29,34 +29,34 @@ struct PreTokenizeBenchmarkTests {
         shortText = "Explain the BPE tokenization algorithm in three short bullet points."
 
         let para = """
-        Byte-pair encoding (BPE) is a tokenization algorithm originally proposed for data \
-        compression by Philip Gage in 1994. It was later adapted for use in neural machine \
-        translation by Sennrich, Haddow, and Birch in 2015, and is now the dominant \
-        sub-word tokenization scheme for modern large language models including the GPT, \
-        Llama, Qwen, and Mistral families. The algorithm operates by iteratively replacing \
-        the most frequent adjacent pair of bytes in a corpus with a new symbol, building up \
-        a vocabulary of merges that compactly represents both common words and rare strings.
-        """
+            Byte-pair encoding (BPE) is a tokenization algorithm originally proposed for data \
+            compression by Philip Gage in 1994. It was later adapted for use in neural machine \
+            translation by Sennrich, Haddow, and Birch in 2015, and is now the dominant \
+            sub-word tokenization scheme for modern large language models including the GPT, \
+            Llama, Qwen, and Mistral families. The algorithm operates by iteratively replacing \
+            the most frequent adjacent pair of bytes in a corpus with a new symbol, building up \
+            a vocabulary of merges that compactly represents both common words and rare strings.
+            """
         mediumText = String(repeating: para + "\n\n", count: 2)
         longText = String(repeating: para + "\n\n", count: 20)
 
         codeText = """
-        public final class GPT2BytePairEncoderConfiguration: Codable, Sendable {
-            public let vocabularyIdentifierToTokenStringMap: [Int: String]
-            public let bytePairMergeRanksByPairOfStrings: [BytePair: Int]
-            public let unknownTokenIdentifierForOutOfVocabularyByteSequences: Int?
-            public let beginningOfSequenceSpecialTokenIdentifier: Int?
-            public let endOfSequenceSpecialTokenIdentifier: Int?
-            public let shouldFuseConsecutiveUnknownTokenSequencesIntoASingleUnknownToken: Bool
-        }
-        """
+            public final class GPT2BytePairEncoderConfiguration: Codable, Sendable {
+                public let vocabularyIdentifierToTokenStringMap: [Int: String]
+                public let bytePairMergeRanksByPairOfStrings: [BytePair: Int]
+                public let unknownTokenIdentifierForOutOfVocabularyByteSequences: Int?
+                public let beginningOfSequenceSpecialTokenIdentifier: Int?
+                public let endOfSequenceSpecialTokenIdentifier: Int?
+                public let shouldFuseConsecutiveUnknownTokenSequencesIntoASingleUnknownToken: Bool
+            }
+            """
 
         // Numeric-heavy text exercises the digit-splitting branch.
         numericText = """
-        Order #2024-001234 totals $1,299.99 plus 8.875% tax for a final amount of \
-        $1,415.36, paid 2026-04-30 at 14:32:07 UTC. Reference codes: A1B2-C3D4-E5F6, \
-        SKU 9876543210, account 4111-1111-1111-1111, phone +1-555-867-5309.
-        """
+            Order #2024-001234 totals $1,299.99 plus 8.875% tax for a final amount of \
+            $1,415.36, paid 2026-04-30 at 14:32:07 UTC. Reference codes: A1B2-C3D4-E5F6, \
+            SKU 9876543210, account 4111-1111-1111-1111, phone +1-555-867-5309.
+            """
     }
 
     // MARK: - Measurement helpers

--- a/Tests/Benchmarks/PreTokenizeBenchmarkTests.swift
+++ b/Tests/Benchmarks/PreTokenizeBenchmarkTests.swift
@@ -8,7 +8,6 @@
 //  Run with `RUN_BENCHMARKS=1`.
 //
 
-import Dispatch
 import Foundation
 import Hub
 import Testing
@@ -59,46 +58,6 @@ struct PreTokenizeBenchmarkTests {
             """
     }
 
-    // MARK: - Measurement helpers
-
-    struct Stats {
-        let mean: Double
-        let stdDev: Double
-        let p50: Double
-        let p95: Double
-        let min: Double
-        let max: Double
-
-        var formatted: String {
-            String(format: "%7.3f ms (± %5.3f, p50 %6.3f, p95 %6.3f)", mean, stdDev, p50, p95)
-        }
-    }
-
-    private static func stats(_ times: [Double]) -> Stats {
-        let sorted = times.sorted()
-        let mean = sorted.reduce(0, +) / Double(sorted.count)
-        let variance = sorted.map { ($0 - mean) * ($0 - mean) }.reduce(0, +) / Double(sorted.count)
-        let stdDev = sqrt(variance)
-        let p50 = sorted[sorted.count / 2]
-        let p95 = sorted[min(sorted.count - 1, Int(Double(sorted.count) * 0.95))]
-        return Stats(mean: mean, stdDev: stdDev, p50: p50, p95: p95, min: sorted.first ?? 0, max: sorted.last ?? 0)
-    }
-
-    private static func measure(label: String, iterations: Int, warmup: Int = 3, _ block: () -> Void) -> Stats {
-        for _ in 0..<warmup { block() }
-        var times: [Double] = []
-        times.reserveCapacity(iterations)
-        for _ in 0..<iterations {
-            let start = DispatchTime.now()
-            block()
-            let end = DispatchTime.now()
-            times.append(Double(end.uptimeNanoseconds - start.uptimeNanoseconds) / 1_000_000)
-        }
-        let s = stats(times)
-        print("  \(label.padding(toLength: 26, withPad: " ", startingAt: 0)) \(s.formatted)")
-        return s
-    }
-
     // MARK: - Benchmarks
 
     @Test("BertPreTokenizer micro-benchmark")
@@ -112,7 +71,7 @@ struct PreTokenizeBenchmarkTests {
             ("long (~30 KB)", longText, 20),
         ]
         for (label, text, iterations) in cases {
-            _ = Self.measure(label: label, iterations: iterations) {
+            _ = benchmarkMeasure(label: label, iterations: iterations) {
                 _ = preTokenizer.preTokenize(text: text)
             }
         }
@@ -129,7 +88,7 @@ struct PreTokenizeBenchmarkTests {
             ("long (~30 KB)", longText, 20),
         ]
         for (label, text, iterations) in cases {
-            _ = Self.measure(label: label, iterations: iterations) {
+            _ = benchmarkMeasure(label: label, iterations: iterations) {
                 _ = preTokenizer.preTokenize(text: text)
             }
         }
@@ -146,7 +105,7 @@ struct PreTokenizeBenchmarkTests {
             ("long (~30 KB)", longText, 20),
         ]
         for (label, text, iterations) in cases {
-            _ = Self.measure(label: label, iterations: iterations) {
+            _ = benchmarkMeasure(label: label, iterations: iterations) {
                 _ = preTokenizer.preTokenize(text: text)
             }
         }
@@ -166,14 +125,14 @@ struct PreTokenizeBenchmarkTests {
             ("long (~30 KB)", longText, 20),
         ]
         for (label, text, iterations) in cases {
-            _ = Self.measure(label: label, iterations: iterations) {
+            _ = benchmarkMeasure(label: label, iterations: iterations) {
                 _ = groupedTokenizer.preTokenize(text: text)
             }
         }
 
         print("\n=== DigitsPreTokenizer.preTokenize (individual) ===")
         for (label, text, iterations) in cases {
-            _ = Self.measure(label: label, iterations: iterations) {
+            _ = benchmarkMeasure(label: label, iterations: iterations) {
                 _ = individualTokenizer.preTokenize(text: text)
             }
         }


### PR DESCRIPTION
## What

`BertPreTokenizer`, `WhitespacePreTokenizer`, `PunctuationPreTokenizer`, and `DigitsPreTokenizer` all sit on the same pattern that the byte-level pre-tokenizer carried before #347 landed:

```swift
text.ranges(of: re).map { String(text[$0]) }
```

`String.range(of:options:.regularExpression)` re-parses the pattern on every match step, and the surrounding `ranges(of:)` helper allocates an intermediate `[Range<String.Index>]`. This change moves each pattern into a file-scope `NSRegularExpression` and replaces the per-call recompilation + allocation with a single `enumerateMatches` pass, mirroring exactly what #347 did for `ByteLevelPreTokenizer`.

## Why

These four pre-tokenizers cover Bert / DistilBert / Electra / multilingual-e5 (BertPreTokenizer), the WhitespaceSplit step that several pipelines layer in front of Metaspace, the Punctuation pre-tokenizer used in many WordPiece-style tokenizers, and Digits which is on the Llama / Mistral SentencePiece path. They are quietly hot paths.

The change is a mechanical follow-up to #347 — same infrastructure, same justification, applied to the four types that were left behind.

## Performance

Apple M-series, release build, `RUN_BENCHMARKS=1`, 5 000 / 1 000 / 200 / 20 iterations per case (warmup 3). Numbers are p50 in milliseconds; mean is similar but slightly noisier on long inputs.

### `BertPreTokenizer.preTokenize`

| input | before | after | speedup |
|---|---|---|---|
| short (~70 B) | 0.026 | 0.002 | **13.0×** |
| code (~600 B) | 0.153 | 0.008 | **19.1×** |
| medium (~3 KB) | 0.447 | 0.032 | **14.0×** |
| long (~30 KB) | 4.747 | 0.334 | **14.2×** |

### `WhitespacePreTokenizer.preTokenize`

| input | before | after | speedup |
|---|---|---|---|
| short (~70 B) | 0.008 | 0.002 | **4.0×** |
| code (~600 B) | 0.025 | 0.008 | **3.1×** |
| medium (~3 KB) | 0.155 | 0.029 | **5.3×** |
| long (~30 KB) | 1.308 | 0.275 | **4.8×** |

### `PunctuationPreTokenizer.preTokenize`

| input | before | after | speedup |
|---|---|---|---|
| short (~70 B) | 0.017 | 0.001 | **17.0×** |
| code (~600 B) | 0.134 | 0.007 | **19.1×** |
| medium (~3 KB) | 0.266 | 0.010 | **26.6×** |
| long (~30 KB) | 2.831 | 0.097 | **29.2×** |

### `DigitsPreTokenizer.preTokenize` (grouped, default)

| input | before | after | speedup |
|---|---|---|---|
| numeric (~250 B) | 0.053 | 0.010 | **5.3×** |
| short (~70 B) | 0.005 | 0.001 | **5.0×** |
| code (~600 B) | 0.029 | 0.002 | **14.5×** |
| medium (~3 KB) | 0.066 | 0.005 | **13.2×** |
| long (~30 KB) | 0.736 | 0.041 | **17.9×** |

### `DigitsPreTokenizer.preTokenize` (`individualDigits = true`)

| input | before | after | speedup |
|---|---|---|---|
| numeric (~250 B) | 0.087 | 0.014 | **6.2×** |
| short (~70 B) | 0.005 | 0.001 | **5.0×** |
| code (~600 B) | 0.029 | 0.002 | **14.5×** |
| medium (~3 KB) | 0.075 | 0.006 | **12.5×** |
| long (~30 KB) | 0.809 | 0.054 | **15.0×** |

## Implementation notes

- Five `NSRegularExpression`s live at file scope in `PreTokenizer.swift` next to `punctuationRegex`. They are lazily initialised once per process. `NSRegularExpression` is documented as thread-safe for `enumerateMatches` / `matches`, so no additional locking is required (same property #347 relies on for the byte-level regex).
- `DigitsPreTokenizer` keeps an `NSRegularExpression` instance member that is bound in `init` to either the grouped or individual variant based on `individualDigits`. The selection is one branch at construction instead of one branch per `preTokenize` call.
- A small file-scope `splitMatches(in:with:)` factors out the `enumerateMatches` -> `[String]` loop so the four `preTokenize` bodies stay one line each.
- The `re: String` instance properties on `Bert` / `Whitespace` / `Punctuation` were internal-only and are removed (mirroring how #347 dropped `RE` on `ByteLevelPreTokenizer`).

## Tests

All **107 existing TokenizersTests pass**, including the BERT / Whitespace / Punctuation / Digits cases in `PreTokenizerTests` and the higher-level `BertTokenizerTests` / SentencePiece / Llama suites that exercise these tokenizers indirectly.

```
swift test --filter "TokenizersTests"
…
✔ Test run with 107 tests in 12 suites passed after 17.603 seconds.
```

A new benchmark suite `Tests/Benchmarks/PreTokenizeBenchmarkTests.swift` is gated on `RUN_BENCHMARKS=1` and mirrors the `BPEPreTokenizeBenchmarkTests` layout from #347:

```bash
RUN_BENCHMARKS=1 swift test -c release --filter "PreTokenizeBenchmarkTests"
```

## Risk

Low. The behavioural contract is "match the same regex over the same text and return the substrings", which both before and after rely on `NSRegularExpression` semantics under the hood. Tests cover exact-match parity for all four pre-tokenizers; no fuzz cases regressed.

## Related

Sibling perf work landing in this push:
- #346 — BPE merge priority queue (5–12× inner loop)
- #347 — Byte-level pre-tokenize regex cache (6–8× p50 on `ByteLevelPreTokenizer.preTokenize`, 17–29× on `hexaEncode`)
- #348 — Unigram tokenize O(N²) → O(N) (15–25× on long inputs)

This PR completes the regex-cache half of #347 for the remaining four pre-tokenizers.