### PR TITLE
BPE merge by Unicode scalar, not grapheme cluster (#352, Bug 4)

### DIFF
--- a/Sources/Tokenizers/BPETokenizer.swift
+++ b/Sources/Tokenizers/BPETokenizer.swift
@@ -231,23 +231,33 @@ class BPETokenizer: PreTrainedTokenizerModel, @unchecked Sendable {
         return result
     }
 
-    /// Applies the BPE merge sequence to `token` and returns the merged pieces
-    /// joined by a single space.
+    /// Applies the BPE merge sequence to `token` and returns the resulting pieces.
     ///
     /// Equivalent to the canonical greedy "lowest-rank merge first" BPE algorithm
-    /// (e.g. `tiktoken`, `huggingface/tokenizers`). The previous implementation
-    /// rebuilt the entire pair set and scanned the full word on every iteration,
-    /// which is O(N² · M). This version maintains the symbols as an in-place
-    /// linked list and tracks candidate merges in a min-heap keyed by rank, so
-    /// the work per merge step is O(log N) heap ops + O(1) list surgery.
-    func bpe(token: String) -> String {
-        if token.count <= 1 {
-            return token
+    /// (e.g. `tiktoken`, `huggingface/tokenizers`). Maintains the symbols as an
+    /// in-place linked list and tracks candidate merges in a min-heap keyed by
+    /// rank, so the work per merge step is O(log N) heap ops + O(1) list surgery.
+    ///
+    /// Returns an array of pieces rather than a space-joined string: a downstream
+    /// `split(separator: " ")` would be unsafe when a piece begins with a Unicode
+    /// non-spacing mark, because the mark forms a single grapheme cluster with the
+    /// preceding space and the split silently swallows the boundary.
+    func bpe(token: String) -> [String] {
+        // Iterate Unicode scalars rather than grapheme clusters. Combining marks
+        // (e.g. Thai vowel U+0E31, Devanagari halant U+094D, the variation selector
+        // and combining keycap U+FE0F + U+20E3) form a single Swift `Character`
+        // with their base, but the BPE vocab and merge table are scalar-indexed —
+        // grouping them prevents merges and forces spurious byte-fallback even
+        // when both scalars are direct vocab entries.
+        // Reference: https://github.com/huggingface/swift-transformers/issues/352
+        let initialSymbols = token.unicodeScalars.map { String($0) }
+        if initialSymbols.count <= 1 {
+            return [token]
         }
 
-        // Initial symbols: one entry per Character of `token`. We keep these as
-        // a doubly linked list embedded in parallel arrays of indices.
-        var symbols = Array(token).map { String($0) }
+        // Initial symbols: one entry per Unicode scalar of `token`. We keep these
+        // as a doubly linked list embedded in parallel arrays of indices.
+        var symbols = initialSymbols
         let initialCount = symbols.count
         var prevIndex = Array(repeating: -1, count: initialCount)
         var nextIndex = Array(repeating: -1, count: initialCount)
@@ -316,7 +326,7 @@ class BPETokenizer: PreTrainedTokenizerModel, @unchecked Sendable {
             pieces.append(symbols[cursor])
             cursor = nextIndex[cursor]
         }
-        return pieces.joined(separator: " ")
+        return pieces
     }
 
     /// Tokenizes input text using the BPE algorithm.
@@ -325,7 +335,7 @@ class BPETokenizer: PreTrainedTokenizerModel, @unchecked Sendable {
     /// - Returns: An array of BPE token strings
     func tokenize(text: String) -> [String] {
         var tokens: [String] = []
-        let bpeTokens = bpe(token: text).split(separator: " ").map { String($0) }
+        let bpeTokens = bpe(token: text)
         for token in bpeTokens {
             if convertTokenToId(token) != unknownTokenId {
                 tokens.append(token)

--- a/Sources/Tokenizers/BPETokenizer.swift
+++ b/Sources/Tokenizers/BPETokenizer.swift
@@ -243,13 +243,6 @@ class BPETokenizer: PreTrainedTokenizerModel, @unchecked Sendable {
     /// non-spacing mark, because the mark forms a single grapheme cluster with the
     /// preceding space and the split silently swallows the boundary.
     func bpe(token: String) -> [String] {
-        // Iterate Unicode scalars rather than grapheme clusters. Combining marks
-        // (e.g. Thai vowel U+0E31, Devanagari halant U+094D, the variation selector
-        // and combining keycap U+FE0F + U+20E3) form a single Swift `Character`
-        // with their base, but the BPE vocab and merge table are scalar-indexed —
-        // grouping them prevents merges and forces spurious byte-fallback even
-        // when both scalars are direct vocab entries.
-        // Reference: https://github.com/huggingface/swift-transformers/issues/352
         var symbols = token.unicodeScalars.map { String($0) }
         if symbols.count <= 1 {
             return symbols.isEmpty ? [] : [token]

--- a/Sources/Tokenizers/BPETokenizer.swift
+++ b/Sources/Tokenizers/BPETokenizer.swift
@@ -250,14 +250,11 @@ class BPETokenizer: PreTrainedTokenizerModel, @unchecked Sendable {
         // grouping them prevents merges and forces spurious byte-fallback even
         // when both scalars are direct vocab entries.
         // Reference: https://github.com/huggingface/swift-transformers/issues/352
-        let initialSymbols = token.unicodeScalars.map { String($0) }
-        if initialSymbols.count <= 1 {
-            return [token]
+        var symbols = token.unicodeScalars.map { String($0) }
+        if symbols.count <= 1 {
+            return symbols.isEmpty ? [] : [token]
         }
 
-        // Initial symbols: one entry per Unicode scalar of `token`. We keep these
-        // as a doubly linked list embedded in parallel arrays of indices.
-        var symbols = initialSymbols
         let initialCount = symbols.count
         var prevIndex = Array(repeating: -1, count: initialCount)
         var nextIndex = Array(repeating: -1, count: initialCount)

--- a/Tests/TokenizersTests/TokenizerTests.swift
+++ b/Tests/TokenizersTests/TokenizerTests.swift
@@ -224,6 +224,23 @@ struct TokenizerTests {
         #expect(inputIds == [1, 29871, 6324])
     }
 
+    /// https://github.com/huggingface/swift-transformers/issues/352 (Bug 4)
+    @Test
+    func llama7bCombiningMarks() async throws {
+        // Thai "สวัส" (sa-wo-han-sa) is U+0E2A U+0E27 U+0E31 U+0E2A. The Thai vowel
+        // U+0E31 is non-spacing and forms a single Swift `Character` with the
+        // preceding `ว`. BPE's initial symbol decomposition `Array(token)` therefore
+        // saw three symbols ["ส", "ว ั", "ส"] instead of four — the merged "ว ั"
+        // wasn't in the merges table, so byte-fallback fired on it even though both
+        // U+0E27 (`ว`, id 30492) and U+0E31 (`ั`, id 30510) are direct vocab entries.
+        // Switching to `unicodeScalars` iteration restores byte-identity to HF Python.
+        let tokenizerOpt = try await AutoTokenizer.from(pretrained: "huggyllama/llama-7b") as? PreTrainedTokenizer
+        #expect(tokenizerOpt != nil)
+        let tokenizer = tokenizerOpt!
+
+        #expect(tokenizer.encode(text: "สวัส") == [1, 29871, 30547, 30492, 30510, 30547])
+    }
+
     /// https://github.com/huggingface/swift-transformers/issues/99
     @Test
     func robertaXLMTokenizer() async throws {

--- a/Tests/TokenizersTests/TokenizerTests.swift
+++ b/Tests/TokenizersTests/TokenizerTests.swift
@@ -227,13 +227,6 @@ struct TokenizerTests {
     /// https://github.com/huggingface/swift-transformers/issues/352 (Bug 4)
     @Test
     func llama7bCombiningMarks() async throws {
-        // Thai "สวัส" (sa-wo-han-sa) is U+0E2A U+0E27 U+0E31 U+0E2A. The Thai vowel
-        // U+0E31 is non-spacing and forms a single Swift `Character` with the
-        // preceding `ว`. BPE's initial symbol decomposition `Array(token)` therefore
-        // saw three symbols ["ส", "ว ั", "ส"] instead of four — the merged "ว ั"
-        // wasn't in the merges table, so byte-fallback fired on it even though both
-        // U+0E27 (`ว`, id 30492) and U+0E31 (`ั`, id 30510) are direct vocab entries.
-        // Switching to `unicodeScalars` iteration restores byte-identity to HF Python.
         let tokenizerOpt = try await AutoTokenizer.from(pretrained: "huggyllama/llama-7b") as? PreTrainedTokenizer
         #expect(tokenizerOpt != nil)
         let tokenizer = tokenizerOpt!


### PR DESCRIPTION
Addresses Bug 4 of #352.

`BPETokenizer.bpe(token:)` decomposed the input into initial BPE symbols via `Array(token).map { String(\$0) }`, which iterates Swift `Character` (extended grapheme clusters). Non-spacing combining marks that the BPE vocab and merge table treat as standalone scalars — e.g. Thai vowel mark U+0E31, Devanagari halant U+094D, the variation selector + combining keycap behind emoji keycaps — therefore fused with their base character into a single symbol, preventing the merge loop from ever considering the combining-mark scalar as its own atom. Llama-7B's `byte_fallback: true` then byte-encoded the unmatched fused symbol, even though both halves were direct vocab entries.

There were actually **two** grapheme-cluster traps in the BPE path:

1. The initial symbol decomposition at the top of `bpe(token:)` — switched to `token.unicodeScalars.map { String(\$0) }`, plus the early-return guard for trivial inputs counts scalars rather than `Character`s.

2. The downstream re-split of the BPE result. `bpe(token:)` returned its pieces joined by ASCII space, and the caller re-split with `bpe(token: text).split(separator: " ").map { String(\$0) }`. But Swift's `split` operates on grapheme clusters: **if a piece begins with a non-spacing mark, the preceding ASCII space fuses with the mark into a single grapheme and `split` silently swallows the boundary**. The merged substring (including the literal space) then byte-fallbacks. To remove the round-trip entirely, `bpe(token:)` now returns `[String]` directly.

The benchmark test in `Tests/Benchmarks/BPETokenizerBenchmarkTests.swift` calls `bpe(token:)` via `_ = model.bpe(token: encoded)`, so the return-type change does not affect it.

## Test plan

- [x] `swift test --filter TokenizerTests` — all 46 tests pass (no regressions).
- [x] New test `llama7bCombiningMarks()` uses `huggyllama/llama-7b` over Thai `"สวัส"`. Pre-fix: byte-fallback on `ว` and `ั`; post-fix: 4 direct vocab matches plus the leading `▁`, matching HF Python `transformers==4.57.1` byte-for-byte.

🤖 Generated with [Claude Code](https://claude.com/claude-code)