### PR TITLE
Fix WordPieceDecoder crash on empty input and ByteFallbackDecoder trailing byte drop

### DIFF
--- a/Sources/Tokenizers/Decoder.swift
+++ b/Sources/Tokenizers/Decoder.swift
@@ -84,7 +84,14 @@ class WordPieceDecoder: Decoder {
     }
 
     func decode(tokens: [String]) -> [String] {
-        let firstToken = cleanup ? cleanUpTokenization(tokens.first!) : tokens.first!
+        // An empty token list can reach this decoder when the calling chain has
+        // filtered out every input — e.g. `decode(tokens:, skipSpecialTokens: true)`
+        // on an id sequence that consisted entirely of special tokens, or after a
+        // `compactMap { convertIdToToken($0) }` drops every entry as out-of-vocab.
+        // The reference Rust implementation no-ops in that case rather than
+        // unwrapping `tokens.first!` (which previously crashed).
+        guard let first = tokens.first else { return [] }
+        let firstToken = cleanup ? cleanUpTokenization(first) : first
         return [firstToken]
             + tokens.dropFirst().map { token in
                 let token = token.hasPrefix(prefix) ? token.replacingCharacters(in: token.range(of: prefix)!, with: "") : " \(token)"
@@ -186,19 +193,26 @@ class ByteFallbackDecoder: Decoder {
             return Int(token[startIndex..<endIndex], radix: 16)
         }
 
+        func flushPendingBytes() {
+            guard !byteTokens.isEmpty else { return }
+            let codeUnits = byteTokens.map { UTF8.CodeUnit($0) }
+            newTokens.append(String(decoding: codeUnits, as: UTF8.self))
+            byteTokens.removeAll()
+        }
+
         for token in tokens {
             if let byte = parseByte(token) {
                 byteTokens.append(byte)
             } else {
-                if !byteTokens.isEmpty {
-                    // decode as utf8 and append
-                    let codeUnits = byteTokens.map { UTF8.CodeUnit($0) }
-                    newTokens.append(String(decoding: codeUnits, as: UTF8.self))
-                    byteTokens.removeAll()
-                }
+                flushPendingBytes()
                 newTokens.append(token)
             }
         }
+        // Flush trailing byte tokens — when the input ends with a run of
+        // `<0xHH>` (e.g. multi-byte UTF-8 for a final emoji or CJK character),
+        // the previous implementation dropped them on the floor instead of
+        // appending the decoded UTF-8 string.
+        flushPendingBytes()
         return newTokens
     }
 }

--- a/Tests/TokenizersTests/ChatTemplateTests.swift
+++ b/Tests/TokenizersTests/ChatTemplateTests.swift
@@ -181,10 +181,13 @@ struct ChatTemplateTests {
             messages: messages, chatTemplate: whitespaceSensitiveTemplate
         )
         let decoded = tokenizer.decode(tokens: encoded)
-        let expected = """
-            Describe the Swift programming language.
-            assistant
-            """
+        // The template ends with a `{% endif %}` block on its own line, so the
+        // rendered text legitimately ends with "\n". Phi's tokenizer encodes that
+        // trailing newline as a `<0x0A>` byte-fallback token; before
+        // `ByteFallbackDecoder` was fixed to flush its pending byte buffer at
+        // end-of-input, the trailing newline was silently dropped and this test
+        // appeared to pass on the truncated string.
+        let expected = "Describe the Swift programming language.\nassistant\n"
         #expect(decoded == expected)
         #expect(!decoded.hasPrefix("\n"))
         #expect(!decoded.contains("\n\n"))

--- a/Tests/TokenizersTests/DecoderTests.swift
+++ b/Tests/TokenizersTests/DecoderTests.swift
@@ -114,6 +114,43 @@ struct DecoderTests {
         #expect(decoded.joined() == "How are you?")
     }
 
+    /// Regression coverage: `WordPieceDecoder.decode(tokens: [])` previously crashed
+    /// with `Fatal error: Unexpectedly found nil while unwrapping an Optional value`
+    /// because of `tokens.first!`. An empty token list can legitimately reach the
+    /// decoder when `Tokenizer.decode(tokens:, skipSpecialTokens: true)` is called
+    /// on an id sequence whose non-special-token ids all fail vocab lookup (the
+    /// `compactMap` upstream drops them silently), so the decoder has to no-op
+    /// instead of asserting.
+    @Test("WordPiece decoder no-ops on empty input")
+    func wordPieceDecoderEmptyInput() {
+        let decoder = WordPieceDecoder(config: Config(["prefix": "##", "cleanup": true]))
+        #expect(decoder.decode(tokens: []) == [])
+        let decoderNoCleanup = WordPieceDecoder(config: Config(["prefix": "##", "cleanup": false]))
+        #expect(decoderNoCleanup.decode(tokens: []) == [])
+    }
+
+    /// Regression coverage: `ByteFallbackDecoder.decode` accumulated runs of
+    /// `<0xHH>` byte tokens and flushed them only when a non-byte token followed.
+    /// Inputs that ended with a multi-byte UTF-8 run (e.g. a trailing emoji or
+    /// CJK character whose final code point fell back to bytes) had those bytes
+    /// silently dropped from the output.
+    @Test("ByteFallback decoder flushes trailing byte tokens")
+    func byteFallbackDecoderTrailingBytes() {
+        let decoder = ByteFallbackDecoder(config: Config(["type": "ByteFallback"]))
+        // © is U+00A9 → UTF-8 0xC2 0xA9.
+        #expect(decoder.decode(tokens: ["<0xC2>", "<0xA9>"]) == ["©"])
+        // Trailing bytes after a real token must still flush.
+        #expect(decoder.decode(tokens: ["abc", "<0xC2>", "<0xA9>"]) == ["abc", "©"])
+        // 🚀 is U+1F680 → UTF-8 0xF0 0x9F 0x9A 0x80 (four-byte fallback at end).
+        #expect(decoder.decode(tokens: ["hi", "<0xF0>", "<0x9F>", "<0x9A>", "<0x80>"]) == ["hi", "🚀"])
+        // Existing in-loop flush behavior is preserved.
+        #expect(decoder.decode(tokens: ["<0xC2>", "<0xA9>", "xyz"]) == ["©", "xyz"])
+        // Empty input still returns empty.
+        #expect(decoder.decode(tokens: []) == [])
+        // Non-byte-only inputs unchanged.
+        #expect(decoder.decode(tokens: ["abc", "def"]) == ["abc", "def"])
+    }
+
     @Test("WordPiece decoder with prefix and cleanup")
     func wordPieceDecoder() {
         let config = Config(["prefix": "##", "cleanup": true])


### PR DESCRIPTION
## What

Fixes two independent bugs in `Sources/Tokenizers/Decoder.swift`:

1. **`WordPieceDecoder.decode(tokens:)` crashes on empty input.** The first line force-unwrapped `tokens.first!`, so the decoder asserted with *"Fatal error: Unexpectedly found nil while unwrapping an Optional value"* whenever the calling chain handed it an empty token list. An empty list can legitimately arrive there — for example `Tokenizer.decode(tokens:, skipSpecialTokens: true)` on an id sequence whose non-special-token ids all fail vocab lookup (the `compactMap` upstream drops every entry), or `decode(tokens: [<just special tokens>], skipSpecialTokens: true)` after the special-token filter empties the list.

2. **`ByteFallbackDecoder.decode(tokens:)` silently drops trailing `<0xHH>` byte runs.** The decoder accumulated `<0xHH>` byte tokens and flushed them to a UTF-8 string only when it encountered a non-byte token, but the post-loop flush was missing. When the input ended on a multi-byte UTF-8 run (e.g. a trailing emoji, CJK character, or a Llama-style `<0x0A>` newline at end-of-text), those bytes never reached `newTokens` and the output was truncated.

## Fixes

### `WordPieceDecoder`

Early-returns `[]` when called with an empty list, matching the no-op behavior of the reference Rust implementation.

### `ByteFallbackDecoder`

Factored the byte-flush into a small `flushPendingBytes()` closure and called it both at the start of every non-byte token (preserved behavior) and once after the loop (new). The intra-loop behavior is otherwise unchanged.

## Test coverage

Two new regression tests in `Tests/TokenizersTests/DecoderTests.swift`:

- `WordPiece decoder no-ops on empty input` — verifies `WordPieceDecoder.decode(tokens: [])` returns `[]` for both `cleanup: true` and `cleanup: false`. This is the direct regression for the crash.
- `ByteFallback decoder flushes trailing byte tokens` — exercises six cases including `["<0xC2>", "<0xA9>"] → ["©"]` (trailing 2-byte UTF-8), `["hi", "<0xF0>", "<0x9F>", "<0x9A>", "<0x80>"] → ["hi", "🚀"]` (trailing 4-byte UTF-8 emoji), the pre-existing in-loop flush (`["<0xC2>", "<0xA9>", "xyz"] → ["©", "xyz"]`), empty input, and the all-non-byte case.

One updated test:

- `Jinja block whitespace control` (`Tests/TokenizersTests/ChatTemplateTests.swift`) — the expected string was previously `"Describe the Swift programming language.\nassistant"` (no trailing newline). The rendered Jinja template actually ends with a newline (the trailing `{% endif %}` block sits on its own line), which Phi's tokenizer encodes as a `<0x0A>` byte-fallback token. The pre-fix `ByteFallbackDecoder` dropped that trailing token on the floor, so the bug-masked decoder output happened to equal the assertion. With the trailing-flush fix the test now compares against the un-truncated `"…assistant\n"` and the two adjacent assertions (`!hasPrefix("\n")`, `!contains("\n\n")`) still hold. A short comment in the test body explains why.

## Verification

Local on macOS 26 / Swift 6.2.1 / M-series, from `main`:

```
$ swift test
✔ Test run with 157 tests in 20 suites passed after ~13s.

$ swift test --parallel
✔ Test run with 157 tests in 20 suites passed after ~13s.

$ xcrun swift-format lint Sources/Tokenizers/Decoder.swift Tests/TokenizersTests/{DecoderTests,ChatTemplateTests}.swift
(clean)
```

Without the fixes:
- The new `WordPiece decoder no-ops on empty input` test crashes the process with the fatal-error message quoted above (verified by reverting the `guard let first` line locally).
- The new `ByteFallback decoder flushes trailing byte tokens` cases that end on byte runs fail (`["<0xC2>", "<0xA9>"]` returns `[]` instead of `["©"]`).
