### PR TITLE
Make ParsedValue and ParsedMessage codable

### DIFF
--- a/Sources/Tokenizers/ResponseTemplate.swift
+++ b/Sources/Tokenizers/ResponseTemplate.swift
@@ -23,7 +23,7 @@ public enum ResponseParserError: Error, Sendable, Equatable {
 }
 
 /// A JSON-shaped value tree — the type a parsed field collapses into.
-public enum ParsedValue: Sendable, Hashable {
+public enum ParsedValue: Sendable, Hashable, Codable {
     case null
     case bool(Bool)
     case int(Int64)


### PR DESCRIPTION
Small addition: you probably want to ParsedValue and ParsedMessage to be codablefor callers