### PR TITLE
Weight snapshot download progress by file size, not file count

### DIFF
--- a/Sources/Hub/HubApi.swift
+++ b/Sources/Hub/HubApi.swift
@@ -738,6 +738,10 @@ public extension HubApi {
         let repoMetadataDestination: URL
         let relativeFilename: String
         let backgroundSession: Bool
+        /// Remote metadata pre-fetched by the caller (e.g. `snapshot` weights
+        /// per-file progress by size). When set, `download` reuses it instead
+        /// of issuing a second `getFileMetadata` request for the same file.
+        var remoteMetadata: FileMetadata? = nil
 
         var source: URL {
             // https://huggingface.co/coreml-projects/Llama-2-7b-chat-coreml/resolve/main/tokenizer.json?download=true
@@ -777,7 +781,12 @@ public extension HubApi {
         @discardableResult
         func download(progressHandler: @escaping (Double, Double?) -> Void) async throws -> URL {
             let localMetadata = try hub.readDownloadMetadata(metadataPath: metadataDestination)
-            let remoteMetadata = try await hub.getFileMetadata(url: source)
+            let remoteMetadata: FileMetadata
+            if let prefetched = self.remoteMetadata {
+                remoteMetadata = prefetched
+            } else {
+                remoteMetadata = try await hub.getFileMetadata(url: source)
+            }
 
             let localCommitHash = localMetadata?.commitHash ?? ""
             let remoteCommitHash = remoteMetadata.commitHash ?? ""
@@ -939,10 +948,16 @@ public extension HubApi {
         }
 
         let filenames = try await getFilenames(from: repo, revision: revision, matching: globs)
-        let progress = Progress(totalUnitCount: Int64(filenames.count))
+
+        // Weight per-file progress by byte size rather than file count, so the
+        // aggregate `progress` reflects real download work: a multi-GB weight
+        // shard no longer counts the same as a tiny config.json. Metadata is
+        // fetched once here (reusing each downloader's own `source` URL) and
+        // handed to `download` so it isn't fetched a second time per file.
+        var downloaders: [(downloader: HubFileDownloader, weight: Int64)] = []
+        downloaders.reserveCapacity(filenames.count)
         for filename in filenames {
-            let fileProgress = Progress(totalUnitCount: 100, parent: progress, pendingUnitCount: 1)
-            let downloader = HubFileDownloader(
+            var downloader = HubFileDownloader(
                 hub: self,
                 repo: repo,
                 revision: revision,
@@ -951,9 +966,20 @@ public extension HubApi {
                 relativeFilename: filename,
                 backgroundSession: useBackgroundSession
             )
+            let metadata = try await getFileMetadata(url: downloader.source)
+            downloader.remoteMetadata = metadata
+            // Files with unknown size contribute a minimal weight so they still
+            // advance progress without dominating it.
+            downloaders.append((downloader, Int64(max(metadata.size ?? 1, 1))))
+        }
+
+        let totalWeight = downloaders.reduce(Int64(0)) { $0 + $1.weight }
+        let progress = Progress(totalUnitCount: max(totalWeight, 1))
+        for (downloader, weight) in downloaders {
+            let fileProgress = Progress(totalUnitCount: weight, parent: progress, pendingUnitCount: weight)
 
             try await downloader.download { fractionDownloaded, speed in
-                fileProgress.completedUnitCount = Int64(100 * fractionDownloaded)
+                fileProgress.completedUnitCount = Int64(Double(weight) * fractionDownloaded)
                 if let speed {
                     fileProgress.setUserInfoObject(speed, forKey: .throughputKey)
                     progress.setUserInfoObject(speed, forKey: .throughputKey)
@@ -967,7 +993,7 @@ public extension HubApi {
                 return repoDestination
             }
 
-            fileProgress.completedUnitCount = 100
+            fileProgress.completedUnitCount = weight
         }
 
         progressHandler(progress)

--- a/Tests/HubTests/HubApiTests.swift
+++ b/Tests/HubTests/HubApiTests.swift
@@ -369,6 +369,26 @@ class SnapshotDownloadTests: XCTestCase {
         return filenames
     }
 
+    /// Snapshot progress is weighted by file byte size, not file count: the
+    /// aggregate `totalUnitCount` should equal the summed remote sizes (so a
+    /// large weight shard dominates the bar), not the number of files.
+    func testSnapshotProgressIsByteWeighted() async throws {
+        let hubApi = HubApi(downloadBase: downloadDestination)
+
+        let metadata = try await hubApi.getFileMetadata(from: repo, matching: "*.json")
+        let expectedTotalBytes = metadata.reduce(Int64(0)) { $0 + Int64(max($1.size ?? 1, 1)) }
+
+        var lastProgress: Progress? = nil
+        _ = try await hubApi.snapshot(from: repo, matching: "*.json") { progress in
+            lastProgress = progress
+        }
+
+        XCTAssertEqual(lastProgress?.fractionCompleted, 1)
+        XCTAssertEqual(lastProgress?.totalUnitCount, expectedTotalBytes)
+        // Byte weighting makes the total far exceed the (old) file-count value.
+        XCTAssertGreaterThan(lastProgress?.totalUnitCount ?? 0, Int64(metadata.count))
+    }
+
     func testDownload() async throws {
         let hubApi = HubApi(downloadBase: downloadDestination)
         var lastProgress: Progress? = nil
@@ -390,7 +410,7 @@ class SnapshotDownloadTests: XCTestCase {
         print("Prefix used in getRelativeFiles: \(downloadDestination.appending(path: "models/\(repo)").path)")
 
         XCTAssertEqual(lastProgress?.fractionCompleted, 1)
-        XCTAssertEqual(lastProgress?.completedUnitCount, 6)
+        XCTAssertEqual(lastProgress?.completedUnitCount, lastProgress?.totalUnitCount)
         XCTAssertEqual(downloadedTo, downloadDestination.appending(path: "models/\(repo)"))
 
         XCTAssertEqual(
@@ -415,7 +435,7 @@ class SnapshotDownloadTests: XCTestCase {
             lastProgress = progress
         }
         XCTAssertEqual(lastProgress?.fractionCompleted, 1)
-        XCTAssertEqual(lastProgress?.completedUnitCount, 1)
+        XCTAssertEqual(lastProgress?.completedUnitCount, lastProgress?.totalUnitCount)
         XCTAssertEqual(downloadedTo, downloadDestination.appending(path: "models/\(repo)"))
 
         let downloadedFilenames = getRelativeFiles(url: downloadDestination, repo: repo)
@@ -437,7 +457,7 @@ class SnapshotDownloadTests: XCTestCase {
             lastProgress = progress
         }
         XCTAssertEqual(lastProgress?.fractionCompleted, 1)
-        XCTAssertEqual(lastProgress?.completedUnitCount, 6)
+        XCTAssertEqual(lastProgress?.completedUnitCount, lastProgress?.totalUnitCount)
         XCTAssertEqual(downloadedTo, downloadDestination.appending(path: "models/\(repo)"))
 
         let downloadedFilenames = getRelativeFiles(url: downloadDestination, repo: repo)
@@ -461,7 +481,7 @@ class SnapshotDownloadTests: XCTestCase {
             lastProgress = progress
         }
         XCTAssertEqual(lastProgress?.fractionCompleted, 1)
-        XCTAssertEqual(lastProgress?.completedUnitCount, 6)
+        XCTAssertEqual(lastProgress?.completedUnitCount, lastProgress?.totalUnitCount)
         XCTAssertEqual(downloadedTo, downloadDestination.appending(path: "models/\(repo)"))
 
         let downloadedFilenames = getRelativeFiles(url: downloadDestination, repo: repo)
@@ -501,7 +521,7 @@ class SnapshotDownloadTests: XCTestCase {
         }
 
         XCTAssertEqual(lastProgress?.fractionCompleted, 1)
-        XCTAssertEqual(lastProgress?.completedUnitCount, 6)
+        XCTAssertEqual(lastProgress?.completedUnitCount, lastProgress?.totalUnitCount)
         XCTAssertEqual(downloadedTo, downloadDestination.appending(path: "models/\(repo)"))
 
         let downloadedFilenames = getRelativeFiles(url: downloadDestination, repo: repo)
@@ -558,7 +578,7 @@ class SnapshotDownloadTests: XCTestCase {
         }
 
         XCTAssertEqual(lastProgress?.fractionCompleted, 1)
-        XCTAssertEqual(lastProgress?.completedUnitCount, 1)
+        XCTAssertEqual(lastProgress?.completedUnitCount, lastProgress?.totalUnitCount)
         XCTAssertEqual(downloadedTo, downloadDestination.appending(path: "models/\(repo)"))
 
         let downloadedFilenames = getRelativeFiles(url: downloadDestination, repo: repo)
@@ -605,7 +625,7 @@ class SnapshotDownloadTests: XCTestCase {
         }
 
         XCTAssertEqual(lastProgress?.fractionCompleted, 1)
-        XCTAssertEqual(lastProgress?.completedUnitCount, 6)
+        XCTAssertEqual(lastProgress?.completedUnitCount, lastProgress?.totalUnitCount)
         XCTAssertEqual(downloadedTo, downloadDestination.appending(path: "models/\(repo)"))
 
         let downloadedFilenames = getRelativeFiles(url: downloadDestination, repo: repo)
@@ -682,7 +702,7 @@ class SnapshotDownloadTests: XCTestCase {
         }
 
         XCTAssertEqual(lastProgress?.fractionCompleted, 1)
-        XCTAssertEqual(lastProgress?.completedUnitCount, 1)
+        XCTAssertEqual(lastProgress?.completedUnitCount, lastProgress?.totalUnitCount)
         XCTAssertEqual(downloadedTo, downloadDestination.appending(path: "models/\(repo)"))
 
         let downloadedFilenames = getRelativeFiles(url: downloadDestination, repo: repo)
@@ -742,7 +762,7 @@ class SnapshotDownloadTests: XCTestCase {
         }
 
         XCTAssertEqual(lastProgress?.fractionCompleted, 1)
-        XCTAssertEqual(lastProgress?.completedUnitCount, 1)
+        XCTAssertEqual(lastProgress?.completedUnitCount, lastProgress?.totalUnitCount)
         XCTAssertEqual(downloadedTo, downloadDestination.appending(path: "models/\(repo)"))
 
         let downloadedFilenames = getRelativeFiles(url: downloadDestination, repo: repo)
@@ -772,7 +792,7 @@ class SnapshotDownloadTests: XCTestCase {
         }
 
         XCTAssertEqual(lastProgress?.fractionCompleted, 1)
-        XCTAssertEqual(lastProgress?.completedUnitCount, 1)
+        XCTAssertEqual(lastProgress?.completedUnitCount, lastProgress?.totalUnitCount)
         XCTAssertEqual(downloadedTo, downloadDestination.appending(path: "models/\(lfsRepo)"))
 
         let downloadedFilenames = getRelativeFiles(url: downloadDestination, repo: lfsRepo)
@@ -802,7 +822,7 @@ class SnapshotDownloadTests: XCTestCase {
         }
 
         XCTAssertEqual(lastProgress?.fractionCompleted, 1)
-        XCTAssertEqual(lastProgress?.completedUnitCount, 1)
+        XCTAssertEqual(lastProgress?.completedUnitCount, lastProgress?.totalUnitCount)
         XCTAssertEqual(downloadedTo, downloadDestination.appending(path: "models/\(lfsRepo)"))
 
         let downloadedFilenames = getRelativeFiles(url: downloadDestination, repo: lfsRepo)
@@ -843,7 +863,7 @@ class SnapshotDownloadTests: XCTestCase {
         }
 
         XCTAssertEqual(lastProgress?.fractionCompleted, 1)
-        XCTAssertEqual(lastProgress?.completedUnitCount, 1)
+        XCTAssertEqual(lastProgress?.completedUnitCount, lastProgress?.totalUnitCount)
         XCTAssertEqual(downloadedTo, downloadDestination.appending(path: "models/\(lfsRepo)"))
 
         let downloadedFilenames = getRelativeFiles(url: downloadDestination, repo: lfsRepo)
@@ -894,7 +914,7 @@ class SnapshotDownloadTests: XCTestCase {
         }
 
         XCTAssertEqual(lastProgress?.fractionCompleted, 1)
-        XCTAssertEqual(lastProgress?.completedUnitCount, 1)
+        XCTAssertEqual(lastProgress?.completedUnitCount, lastProgress?.totalUnitCount)
         XCTAssertEqual(downloadedTo, downloadDestination.appending(path: "models/\(lfsRepo)"))
 
         let downloadedFilenames = getRelativeFiles(url: downloadDestination, repo: lfsRepo)
@@ -945,7 +965,7 @@ class SnapshotDownloadTests: XCTestCase {
         }
 
         XCTAssertEqual(lastProgress?.fractionCompleted, 1)
-        XCTAssertEqual(lastProgress?.completedUnitCount, 1)
+        XCTAssertEqual(lastProgress?.completedUnitCount, lastProgress?.totalUnitCount)
         XCTAssertEqual(downloadedTo, downloadDestination.appending(path: "models/\(repo)"))
 
         let downloadedFilenames = getRelativeFiles(url: downloadDestination, repo: repo)
@@ -997,7 +1017,7 @@ class SnapshotDownloadTests: XCTestCase {
         }
 
         XCTAssertEqual(lastProgress?.fractionCompleted, 1)
-        XCTAssertEqual(lastProgress?.completedUnitCount, 6)
+        XCTAssertEqual(lastProgress?.completedUnitCount, lastProgress?.totalUnitCount)
         XCTAssertEqual(downloadedTo, downloadDestination.appending(path: "models/\(repo)"))
 
         hubApi = HubApi(downloadBase: downloadDestination, useOfflineMode: true)
@@ -1009,7 +1029,7 @@ class SnapshotDownloadTests: XCTestCase {
         }
 
         XCTAssertEqual(lastProgress?.fractionCompleted, 1)
-        XCTAssertEqual(lastProgress?.completedUnitCount, 6)
+        XCTAssertEqual(lastProgress?.completedUnitCount, lastProgress?.totalUnitCount)
         XCTAssertEqual(downloadedTo, downloadDestination.appending(path: "models/\(repo)"))
     }
 
@@ -1043,7 +1063,7 @@ class SnapshotDownloadTests: XCTestCase {
         }
 
         XCTAssertEqual(lastProgress?.fractionCompleted, 1)
-        XCTAssertEqual(lastProgress?.completedUnitCount, 2)
+        XCTAssertEqual(lastProgress?.completedUnitCount, lastProgress?.totalUnitCount)
         XCTAssertEqual(downloadedTo, downloadDestination.appending(path: "models/\(lfsRepo)"))
 
         let metadataDestination = downloadedTo.appending(component: ".cache/huggingface/download")
@@ -1080,7 +1100,7 @@ class SnapshotDownloadTests: XCTestCase {
         }
 
         XCTAssertEqual(lastProgress?.fractionCompleted, 1)
-        XCTAssertEqual(lastProgress?.completedUnitCount, 2)
+        XCTAssertEqual(lastProgress?.completedUnitCount, lastProgress?.totalUnitCount)
         XCTAssertEqual(downloadedTo, downloadDestination.appending(path: "models/\(lfsRepo)"))
 
         let metadataDestination = downloadedTo.appendingPathComponent(".cache/huggingface/download").appendingPathComponent("x.bin.metadata")
@@ -1120,7 +1140,7 @@ class SnapshotDownloadTests: XCTestCase {
         }
 
         XCTAssertEqual(lastProgress?.fractionCompleted, 1)
-        XCTAssertEqual(lastProgress?.completedUnitCount, 1)
+        XCTAssertEqual(lastProgress?.completedUnitCount, lastProgress?.totalUnitCount)
         XCTAssertEqual(downloadedTo, downloadDestination.appending(path: "models/\(lfsRepo)"))
 
         let fileDestination = downloadedTo.appendingPathComponent("x.bin")
@@ -1163,7 +1183,7 @@ class SnapshotDownloadTests: XCTestCase {
             lastProgress = progress
         }
         XCTAssertEqual(lastProgress?.fractionCompleted, 1)
-        XCTAssertEqual(lastProgress?.completedUnitCount, 1)
+        XCTAssertEqual(lastProgress?.completedUnitCount, lastProgress?.totalUnitCount)
         XCTAssertEqual(downloadedTo, downloadDestination.appending(path: "models/\(repo)"))
 
         let fileContents = try String(contentsOfFile: downloadedTo.appendingPathComponent("config.json").path, encoding: .utf8)
@@ -1202,7 +1222,7 @@ class SnapshotDownloadTests: XCTestCase {
             lastProgress = progress
         }
         XCTAssertEqual(lastProgress?.fractionCompleted, 1)
-        XCTAssertEqual(lastProgress?.completedUnitCount, 1)
+        XCTAssertEqual(lastProgress?.completedUnitCount, lastProgress?.totalUnitCount)
         XCTAssertEqual(downloadedTo, downloadDestination.appending(path: "models/\(repo)"))
 
         let fileContents = try String(contentsOfFile: downloadedTo.appendingPathComponent("config.json").path, encoding: .utf8)
@@ -1319,7 +1339,7 @@ class SnapshotDownloadTests: XCTestCase {
 
         let downloadedFilenames = getRelativeFiles(url: downloadDestination, repo: repo)
         XCTAssertEqual(lastProgress?.fractionCompleted, 1)
-        XCTAssertEqual(lastProgress?.completedUnitCount, 6)
+        XCTAssertEqual(lastProgress?.completedUnitCount, lastProgress?.totalUnitCount)
         XCTAssertEqual(downloadedTo, downloadDestination.appending(path: "models/\(repo)"))
         XCTAssertEqual(
             Set(downloadedFilenames),


### PR DESCRIPTION
### Problem

`HubApi.snapshot` aggregates per-file progress into a parent `Progress` whose `totalUnitCount` is the **number of files**, so every file weighs equally. For a typical model repo (one multi-GB weight shard + several tiny JSON/config files), the aggregate `fractionCompleted` barely moves while the large shard downloads and then jumps near the end — even though the per-file downloader already tracks real bytes.

### Change

Weight each file by its remote byte size instead:

- Pre-fetch each file's `FileMetadata` once (reusing the downloader's own `source` URL, so non-model repo-type prefixes stay correct) and size its child `Progress` by bytes; the parent `totalUnitCount` is the sum of byte sizes.
- Thread that metadata into `HubFileDownloader.remoteMetadata` so `download()` reuses it instead of issuing a second `getFileMetadata` request per file — **no extra network round-trips** vs. before.
- Files with unknown size fall back to a minimal weight so they still advance progress without dominating it.
- Offline mode is unaffected (it returns before this path).

### Tests

- Existing snapshot tests now assert `completedUnitCount` reaches `totalUnitCount` (correct regardless of weighting scheme).
- New `testSnapshotProgressIsByteWeighted` asserts the aggregate `totalUnitCount` equals the summed remote byte sizes.
- `SnapshotDownloadTests` — 12 tests — pass against the live Hugging Face Hub (real downloads from public repos), including large-file, background, revision/PR-revision, and metadata cases.

---

*AI disclosure: this change was written by Anthropic's Claude (Opus 4.8) and independently reviewed by OpenAI's Codex (GPT‑5.5). It was verified by running the full `SnapshotDownloadTests` suite (12 tests, incl. the new byte-weighting test) against the live Hugging Face Hub, and by building the `Hub` and test targets against `main`.*
