### PR TITLE
fix(Hub): canonicalize downloadBase before offline-mode loop to fix '..' path mismatch

### DIFF
--- a/Sources/Hub/HubApi.swift
+++ b/Sources/Hub/HubApi.swift
@@ -911,11 +911,17 @@ public extension HubApi {
                 throw EnvironmentError.offlineModeError(("No files available locally for this repository"))
             }
 
+            // Canonicalize once outside the loop so the string replacement matches
+            // the canonical paths that FileManager.enumerator returns even when
+            // the caller constructed downloadBase with ".." components. (Fix for #366)
+            let canonicalDestination = repoDestination.standardizedFileURL
+            let canonicalMetadataDestination = repoMetadataDestination.standardizedFileURL
+
             for fileUrl in fileUrls {
                 let metadataPath = URL(
                     fileURLWithPath: fileUrl.path.replacingOccurrences(
-                        of: repoDestination.path,
-                        with: repoMetadataDestination.path
+                        of: canonicalDestination.path,
+                        with: canonicalMetadataDestination.path
                     ) + ".metadata"
                 )
 


### PR DESCRIPTION
Fixes #366

## Problem

When a caller constructs `HubApi` with a `downloadBase` that contains `..` components (e.g. `URL(fileURLWithPath: "../cache")`), `FileManager.enumerator` returns **canonical** (resolved) paths, while `repoDestination.path` still contains the raw `..`. This causes the `replacingOccurrences` string replacement to silently fail — the metadata path lookup produces no match — so `snapshot()` throws even though all files are present locally.

```swift
// repoDestination.path  → "/Users/foo/../cache/models/bert"
// fileUrl.path          → "/Users/cache/models/bert/config.json"  (canonical)
// replacingOccurrences silently returns the original string — no match
```

## Fix

Canonicalize both destination URLs **once, outside the loop** using `.standardizedFileURL` before the string replacement:

```swift
let canonicalDestination = repoDestination.standardizedFileURL
let canonicalMetadataDestination = repoMetadataDestination.standardizedFileURL

for fileUrl in fileUrls {
    let metadataPath = URL(
        fileURLWithPath: fileUrl.path.replacingOccurrences(
            of: canonicalDestination.path,
            with: canonicalMetadataDestination.path
        ) + ".metadata"
    )
```

`URL.standardizedFileURL` resolves `..` components without touching the filesystem, so it is safe even when paths do not yet exist on disk.

## Checklist
- [x] Bug fix (no API change)
- [ ] - [x] Zero-dependency — uses `URL.standardizedFileURL` from Foundation
- [ ] - [x] Only the offline-mode branch is affected; normal download path is unchanged