### PR TITLE
Add Sendable conformance to Hub.Repo and Hub.RepoType

### DIFF
--- a/Sources/Hub/Hub.swift
+++ b/Sources/Hub/Hub.swift
@@ -77,7 +77,7 @@ public extension Hub {
     }
 
     /// The type of repository on the Hugging Face Hub.
-    enum RepoType: String, Codable {
+    enum RepoType: String, Codable, Sendable {
         /// Model repositories containing machine learning models.
         case models
         /// Dataset repositories containing training and evaluation data.
@@ -90,7 +90,7 @@ public extension Hub {
     ///
     /// A repository is identified by its unique ID and type, allowing access to
     /// different kinds of resources hosted on the Hub platform.
-    struct Repo: Codable {
+    struct Repo: Codable, Sendable {
         /// The unique identifier for the repository (e.g., "microsoft/DialoGPT-medium").
         public let id: String
         /// The type of repository (models, datasets, or spaces).


### PR DESCRIPTION
## Summary

`Hub.RepoType` and `Hub.Repo` are immutable `Codable` value types but don't conform to
`Sendable`. Under Swift 6 / strict concurrency that prevents passing them across actor or task
boundaries (e.g. a `Repo` captured in a `Task`, or stored in an actor-isolated cache) without
warnings or errors.

Both are trivially sendable:
- `RepoType` is a `String`-raw `enum`.
- `Repo` has only `let` properties of `Sendable` types (`String`, `RepoType`).

This adds the conformance. Additive (no API break), no behavior change.
