### PR TITLE
Adopt Jinja ObjectKey in Config.jinjaValue()

### DIFF
--- a/Sources/Hub/Config.swift
+++ b/Sources/Hub/Config.swift
@@ -449,9 +449,9 @@ public struct Config: Hashable, Sendable,
         case let .array(val):
             return .array(val.map { $0.jinjaValue() })
         case let .dictionary(val):
-            var result: [String: Jinja.Value] = [:]
+            var result: [Jinja.ObjectKey: Jinja.Value] = [:]
             for (key, config) in val {
-                result[key.string] = config.jinjaValue()
+                result[.string(key.string)] = config.jinjaValue()
             }
             return .object(.init(uniqueKeysWithValues: result))
         case let .boolean(val):
@@ -463,7 +463,7 @@ public struct Config: Hashable, Sendable,
         case let .string(val):
             return .string(val.string)
         case let .token(val):
-            return [String(val.0): .string(val.1.string)]
+            return [.string(String(val.0)): .string(val.1.string)]
         case .null:
             return .null
         }


### PR DESCRIPTION
swift-jinja 2.4.0 changed `Value.object`'s key type from `String` to `ObjectKey` (the integer-object-key fix, huggingface/swift-jinja#62) — a source-breaking change. Since swift-transformers pins Jinja `from: "2.0.0"`, a fresh resolve now picks up 2.4.0, and `Config.jinjaValue()` no longer compiles because it still builds `String`-keyed objects:

```
Sources/Hub/Config.swift:456:29: error: initializer 'init(uniqueKeysWithValues:)' requires the types 'Dictionary<String, Value>.Element' and '(ObjectKey, Value)' be equivalent
Sources/Hub/Config.swift:466:21: error: cannot convert value of type 'String' to expected dictionary key type 'ObjectKey'
```

This wraps the keys at the two construction sites (the `.dictionary` case and the `.token` case) with `ObjectKey.string(...)`. These were the only two sites — `swift build` completes clean with Jinja resolved at 2.4.0.

Resolves #377.