### PR TITLE
Fix DeepSeek OCR Hub tokenizer compatibility

### DIFF
--- a/Sources/Tokenizers/Tokenizer.swift
+++ b/Sources/Tokenizers/Tokenizer.swift
@@ -879,6 +879,62 @@ public extension AutoTokenizer {
         return Config(dictionary)
     }
 
+    private static func tokenizerData(
+        from configuration: LanguageModelConfigurationFromHub
+    ) async throws -> Config {
+        let tokenizerData = try await configuration.tokenizerData
+        guard
+            try await configuration.modelType == "deepseekocr",
+            tokenizerData.preTokenizer.type.string() == "Metaspace",
+            tokenizerData.model.type.string() == "BPE",
+            tokenizerData.model.vocab["Ġ"].integer() != nil,
+            tokenizerData.model.vocab["▁"].integer() == nil
+        else {
+            return tokenizerData
+        }
+
+        var dictionary = tokenizerData.dictionary(or: [:])
+        dictionary["pre_tokenizer"] = [
+            "type": "Sequence",
+            "pretokenizers": [
+                [
+                    "type": "Split",
+                    "pattern": ["Regex": "\\p{N}{1,3}"],
+                    "behavior": "Isolated",
+                    "invert": false,
+                ],
+                [
+                    "type": "Split",
+                    "pattern": ["Regex": "[一-龥぀-ゟ゠-ヿ]+"],
+                    "behavior": "Isolated",
+                    "invert": false,
+                ],
+                [
+                    "type": "Split",
+                    "pattern": [
+                        "Regex":
+                            ##"[!"#$%&'()*+,\-./:;<=>?@\[\\\]^_`{|}~][A-Za-z]+|[^\r\n\p{L}\p{P}\p{S}]?[\p{L}\p{M}]+| ?[\p{P}\p{S}]+[\r\n]*|\s*[\r\n]+|\s+(?!\S)|\s+"##
+                    ],
+                    "behavior": "Isolated",
+                    "invert": false,
+                ],
+                [
+                    "type": "ByteLevel",
+                    "add_prefix_space": false,
+                    "trim_offsets": true,
+                    "use_regex": false,
+                ],
+            ],
+        ]
+        dictionary["decoder"] = [
+            "type": "ByteLevel",
+            "add_prefix_space": true,
+            "trim_offsets": true,
+            "use_regex": true,
+        ]
+        return Config(dictionary)
+    }
+
     /// Determines the appropriate tokenizer class for the given configuration.
     ///
     /// - Parameter tokenizerConfig: The tokenizer configuration
@@ -943,7 +999,7 @@ public extension AutoTokenizer {
     ) async throws -> Tokenizer {
         let config = LanguageModelConfigurationFromHub(modelName: model, revision: revision, hubApi: hubApi)
         let tokenizerConfig = try await tokenizerConfig(from: config)
-        let tokenizerData = try await config.tokenizerData
+        let tokenizerData = try await tokenizerData(from: config)
 
         return try AutoTokenizer.from(tokenizerConfig: tokenizerConfig, tokenizerData: tokenizerData, strict: strict)
     }
@@ -963,7 +1019,7 @@ public extension AutoTokenizer {
     ) async throws -> Tokenizer {
         let config = LanguageModelConfigurationFromHub(modelFolder: modelFolder, hubApi: hubApi)
         let tokenizerConfig = try await tokenizerConfig(from: config)
-        let tokenizerData = try await config.tokenizerData
+        let tokenizerData = try await tokenizerData(from: config)
 
         return try AutoTokenizer.from(tokenizerConfig: tokenizerConfig, tokenizerData: tokenizerData, strict: strict)
     }

--- a/Sources/Tokenizers/Tokenizer.swift
+++ b/Sources/Tokenizers/Tokenizer.swift
@@ -845,6 +845,13 @@ public class PreTrainedTokenizer: @unchecked Sendable, Tokenizer {
 /// the appropriate tokenizer class based on the configuration.
 public enum AutoTokenizer {}
 
+// Models with incorrect tokenizer_class in their Hub tokenizer_config.json files.
+// These models will be forced to use TokenizersBackend.
+let modelsWithIncorrectHubTokenizerClass: Set<String> = [
+    "deepseek_ocr",
+    "deepseek_ocr2",
+]
+
 enum PreTrainedTokenizerClasses {
     /// Class overrides for custom behaviour
     /// Not to be confused with the TokenizerModel classes defined in TokenizerModel
@@ -854,6 +861,24 @@ enum PreTrainedTokenizerClasses {
 }
 
 public extension AutoTokenizer {
+    private static func tokenizerConfig(
+        from configuration: LanguageModelConfigurationFromHub
+    ) async throws -> Config {
+        guard let tokenizerConfig = try await configuration.tokenizerConfig else {
+            throw TokenizerError.missingConfig
+        }
+        guard
+            let modelType = try await configuration.modelType,
+            modelsWithIncorrectHubTokenizerClass.contains(modelType)
+        else {
+            return tokenizerConfig
+        }
+
+        var dictionary = tokenizerConfig.dictionary(or: [:])
+        dictionary["tokenizer_class"] = "TokenizersBackend"
+        return Config(dictionary)
+    }
+
     /// Determines the appropriate tokenizer class for the given configuration.
     ///
     /// - Parameter tokenizerConfig: The tokenizer configuration
@@ -917,7 +942,7 @@ public extension AutoTokenizer {
         strict: Bool = true
     ) async throws -> Tokenizer {
         let config = LanguageModelConfigurationFromHub(modelName: model, revision: revision, hubApi: hubApi)
-        guard let tokenizerConfig = try await config.tokenizerConfig else { throw TokenizerError.missingConfig }
+        let tokenizerConfig = try await tokenizerConfig(from: config)
         let tokenizerData = try await config.tokenizerData
 
         return try AutoTokenizer.from(tokenizerConfig: tokenizerConfig, tokenizerData: tokenizerData, strict: strict)
@@ -937,10 +962,10 @@ public extension AutoTokenizer {
         strict: Bool = true
     ) async throws -> Tokenizer {
         let config = LanguageModelConfigurationFromHub(modelFolder: modelFolder, hubApi: hubApi)
-        guard let tokenizerConfig = try await config.tokenizerConfig else { throw TokenizerError.missingConfig }
+        let tokenizerConfig = try await tokenizerConfig(from: config)
         let tokenizerData = try await config.tokenizerData
 
-        return try PreTrainedTokenizer(tokenizerConfig: tokenizerConfig, tokenizerData: tokenizerData, strict: strict)
+        return try AutoTokenizer.from(tokenizerConfig: tokenizerConfig, tokenizerData: tokenizerData, strict: strict)
     }
 }
 

--- a/Tests/TokenizersTests/FactoryTests.swift
+++ b/Tests/TokenizersTests/FactoryTests.swift
@@ -80,6 +80,24 @@ struct FactoryTests {
             #expect(tokenizer.encode(text: "<bos>", addSpecialTokens: false) == [0])
         }
     }
+
+    @Test
+    func repairsDeepseekOCRByteLevelTokenizerPipeline() async throws {
+        let modelFolder = try makeModelFolder(
+            modelType: "deepseekocr",
+            malformedByteLevelPipeline: true
+        )
+        defer { try? FileManager.default.removeItem(at: modelFolder) }
+
+        let tokenizer = try await AutoTokenizer.from(modelFolder: modelFolder)
+        let tokens = tokenizer.tokenize(text: "document parsing. ")
+
+        #expect(tokens.allSatisfy { tokenizer.convertTokenToId($0) != nil })
+        #expect(
+            tokenizer.encode(text: "document parsing. ", addSpecialTokens: false)
+                == tokens.compactMap(tokenizer.convertTokenToId)
+        )
+    }
 }
 
 private enum IncorrectHubTokenizerClassModel: String, CaseIterable {
@@ -87,7 +105,10 @@ private enum IncorrectHubTokenizerClassModel: String, CaseIterable {
     case deepSeekOCR2 = "deepseek_ocr2"
 }
 
-private func makeModelFolder(modelType: String) throws -> URL {
+private func makeModelFolder(
+    modelType: String,
+    malformedByteLevelPipeline: Bool = false
+) throws -> URL {
     let modelFolder = FileManager.default.temporaryDirectory.appendingPathComponent(
         "swift-transformers-tokenizer-test-\(UUID().uuidString)",
         isDirectory: true
@@ -120,10 +141,26 @@ private func makeModelFolder(modelType: String) throws -> URL {
     else {
         throw CocoaError(.fileNoSuchFile)
     }
-    try FileManager.default.copyItem(
-        at: tokenizerURL,
-        to: modelFolder.appendingPathComponent("tokenizer.json")
-    )
+    let destinationURL = modelFolder.appendingPathComponent("tokenizer.json")
+    if malformedByteLevelPipeline {
+        let data = try Data(contentsOf: tokenizerURL)
+        var tokenizerData = try #require(
+            JSONSerialization.jsonObject(with: data) as? [String: Any]
+        )
+        tokenizerData["pre_tokenizer"] = [
+            "type": "Metaspace",
+            "replacement": "▁",
+            "prepend_scheme": "always",
+            "split": false,
+        ]
+        tokenizerData["decoder"] = [
+            "type": "Sequence",
+            "decoders": [],
+        ]
+        try JSONSerialization.data(withJSONObject: tokenizerData).write(to: destinationURL)
+    } else {
+        try FileManager.default.copyItem(at: tokenizerURL, to: destinationURL)
+    }
 
     return modelFolder
 }

--- a/Tests/TokenizersTests/FactoryTests.swift
+++ b/Tests/TokenizersTests/FactoryTests.swift
@@ -66,4 +66,64 @@ struct FactoryTests {
         let inputIds = tokenizer("Today she took a train to the West")
         #expect(inputIds == [50258, 50363, 27676, 750, 1890, 257, 3847, 281, 264, 4055, 50257])
     }
+
+    @Test
+    func modelsWithIncorrectHubTokenizerClassUseTokenizersBackend() async throws {
+        for modelType in IncorrectHubTokenizerClassModel.allCases {
+            let modelFolder = try makeModelFolder(modelType: modelType.rawValue)
+            defer { try? FileManager.default.removeItem(at: modelFolder) }
+
+            let tokenizer = try await AutoTokenizer.from(modelFolder: modelFolder)
+
+            #expect(tokenizer is PreTrainedTokenizer)
+            #expect(!(tokenizer is LlamaPreTrainedTokenizer))
+            #expect(tokenizer.encode(text: "<bos>", addSpecialTokens: false) == [0])
+        }
+    }
+}
+
+private enum IncorrectHubTokenizerClassModel: String, CaseIterable {
+    case deepSeekOCR = "deepseek_ocr"
+    case deepSeekOCR2 = "deepseek_ocr2"
+}
+
+private func makeModelFolder(modelType: String) throws -> URL {
+    let modelFolder = FileManager.default.temporaryDirectory.appendingPathComponent(
+        "swift-transformers-tokenizer-test-\(UUID().uuidString)",
+        isDirectory: true
+    )
+    try FileManager.default.createDirectory(
+        at: modelFolder,
+        withIntermediateDirectories: true
+    )
+
+    try Data(#"{"model_type":"\#(modelType)"}"#.utf8).write(
+        to: modelFolder.appendingPathComponent("config.json")
+    )
+    try Data(
+        #"""
+        {
+          "tokenizer_class": "LlamaTokenizerFast",
+          "bos_token": "<bos>",
+          "eos_token": "<eos>",
+          "unk_token": "<unk>",
+          "pad_token": "<pad>"
+        }
+        """#.utf8
+    ).write(to: modelFolder.appendingPathComponent("tokenizer_config.json"))
+
+    guard
+        let tokenizerURL = Bundle.module.url(
+            forResource: "tokenizer",
+            withExtension: "json"
+        )
+    else {
+        throw CocoaError(.fileNoSuchFile)
+    }
+    try FileManager.default.copyItem(
+        at: tokenizerURL,
+        to: modelFolder.appendingPathComponent("tokenizer.json")
+    )
+
+    return modelFolder
 }


### PR DESCRIPTION
### Motivation

I am trying to load and use [mikoy92/Unlimited-OCR-bf16-mlx](https://huggingface.co/mikoy92/Unlimited-OCR-bf16-mlx) using MLX but the input token preprocessing crashes with "**Fatal error: Unexpectedly found nil while unwrapping an Optional value.**"

I found this PR (https://github.com/huggingface/transformers/pull/45739) and asked codex to help me resolve this issue -- works

The cause matches Hugging Face’s documented DeepSeek issue: a Llama tokenizer replaces the model’s ByteLevel pipeline with Metaspace, producing tokens absent from its Ġ-based vocabulary. [Hugging Face issue](https://github.com/huggingface/transformers/issues/45488)

This swift version does not sync this patch so this PR sync & align python implementation
